### PR TITLE
feat: add shell completion for bash, zsh, and fish

### DIFF
--- a/cli/src/cli/commands/completion.ts
+++ b/cli/src/cli/commands/completion.ts
@@ -1,0 +1,184 @@
+import { ExitCode } from '../exit-codes.js';
+
+const SUBCOMMANDS =
+    'init doctor get login request status logout providers remote sync watch rename remove completion';
+
+function bashScript(): string {
+    return [
+        '_sig_completions() {',
+        '    local cur prev commands',
+        '    cur="${COMP_WORDS[COMP_CWORD]}"',
+        '    prev="${COMP_WORDS[COMP_CWORD-1]}"',
+        `    commands="${SUBCOMMANDS}"`,
+        '',
+        '    case "$prev" in',
+        '        sig)',
+        '            COMPREPLY=($(compgen -W "$commands" -- "$cur"))',
+        '            ;;',
+        '        get|login|status|logout|rename|remove)',
+        '            local providers',
+        "            providers=$(sig providers --format json 2>/dev/null | node -e \"process.stdin.resume();let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{JSON.parse(d).forEach(p=>console.log(p.id))}catch{}})\" 2>/dev/null)",
+        '            COMPREPLY=($(compgen -W "$providers" -- "$cur"))',
+        '            ;;',
+        '        remote)',
+        '            COMPREPLY=($(compgen -W "add remove list" -- "$cur"))',
+        '            ;;',
+        '        sync)',
+        '            COMPREPLY=($(compgen -W "push pull" -- "$cur"))',
+        '            ;;',
+        '        watch)',
+        '            COMPREPLY=($(compgen -W "add remove list start set-interval" -- "$cur"))',
+        '            ;;',
+        '        completion)',
+        '            COMPREPLY=($(compgen -W "bash zsh fish" -- "$cur"))',
+        '            ;;',
+        '        --format)',
+        '            COMPREPLY=($(compgen -W "json table yaml env plain" -- "$cur"))',
+        '            ;;',
+        '        --method)',
+        '            COMPREPLY=($(compgen -W "GET POST PUT PATCH DELETE HEAD OPTIONS" -- "$cur"))',
+        '            ;;',
+        '        *)',
+        '            COMPREPLY=()',
+        '            ;;',
+        '    esac',
+        '}',
+        'complete -F _sig_completions sig',
+        '',
+    ].join('\n');
+}
+
+function zshScript(): string {
+    const nodeCmd = "process.stdin.resume();let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{JSON.parse(d).forEach(p=>console.log(p.id))}catch{}})";
+    return [
+        '#compdef sig',
+        '',
+        '_sig() {',
+        '    local state',
+        '    local -a commands',
+        '    commands=(',
+        "        'init:Create ~/.sig/config.yaml'",
+        "        'doctor:Check environment and configuration'",
+        "        'get:Retrieve credential headers'",
+        "        'login:Browser SSO login'",
+        "        'request:Make an authenticated HTTP request'",
+        "        'status:Show authentication status'",
+        "        'logout:Clear credentials'",
+        "        'providers:List configured providers'",
+        "        'remote:Manage remote credential stores'",
+        "        'sync:Sync credentials with remote'",
+        "        'watch:Auto-refresh credentials'",
+        "        'rename:Rename a provider'",
+        "        'remove:Remove provider and credentials'",
+        "        'completion:Generate shell completion script'",
+        '    )',
+        '',
+        '    _arguments -C \\',
+        "        '1: :->command' \\",
+        "        '*: :->args' \\",
+        "        '--verbose[Debug output to stderr]' \\",
+        "        '--help[Show help]'",
+        '',
+        '    case $state in',
+        '        command)',
+        "            _describe 'sig commands' commands",
+        '            ;;',
+        '        args)',
+        '            case $words[2] in',
+        '                get|login|status|logout|rename|remove)',
+        '                    local providers',
+        `                    providers=($(sig providers --format json 2>/dev/null | node -e "$\{nodeCmd}" 2>/dev/null))`,
+        "                    _describe 'providers' providers",
+        '                    ;;',
+        '                remote)',
+        '                    local -a sub=(add remove list)',
+        "                    _describe 'remote subcommands' sub",
+        '                    ;;',
+        '                sync)',
+        '                    local -a sub=(push pull)',
+        "                    _describe 'sync subcommands' sub",
+        '                    ;;',
+        '                watch)',
+        '                    local -a sub=(add remove list start set-interval)',
+        "                    _describe 'watch subcommands' sub",
+        '                    ;;',
+        '                completion)',
+        '                    local -a shells=(bash zsh fish)',
+        "                    _describe 'shells' shells",
+        '                    ;;',
+        '            esac',
+        '            ;;',
+        '    esac',
+        '}',
+        '',
+        '_sig',
+        '',
+    ].join('\n');
+}
+
+function fishScript(): string {
+    return [
+        '# Fish shell completions for sig',
+        '',
+        'complete -c sig -f',
+        'complete -c sig -n "__fish_use_subcommand" -a init -d "Create ~/.sig/config.yaml"',
+        'complete -c sig -n "__fish_use_subcommand" -a doctor -d "Check environment and configuration"',
+        'complete -c sig -n "__fish_use_subcommand" -a get -d "Retrieve credential headers"',
+        'complete -c sig -n "__fish_use_subcommand" -a login -d "Browser SSO login"',
+        'complete -c sig -n "__fish_use_subcommand" -a request -d "Make an authenticated HTTP request"',
+        'complete -c sig -n "__fish_use_subcommand" -a status -d "Show authentication status"',
+        'complete -c sig -n "__fish_use_subcommand" -a logout -d "Clear credentials"',
+        'complete -c sig -n "__fish_use_subcommand" -a providers -d "List configured providers"',
+        'complete -c sig -n "__fish_use_subcommand" -a remote -d "Manage remote credential stores"',
+        'complete -c sig -n "__fish_use_subcommand" -a sync -d "Sync credentials with remote"',
+        'complete -c sig -n "__fish_use_subcommand" -a watch -d "Auto-refresh credentials"',
+        'complete -c sig -n "__fish_use_subcommand" -a rename -d "Rename a provider"',
+        'complete -c sig -n "__fish_use_subcommand" -a remove -d "Remove provider and credentials"',
+        'complete -c sig -n "__fish_use_subcommand" -a completion -d "Generate shell completion script"',
+        '',
+        'function __sig_providers',
+        '    sig providers --format json 2>/dev/null | node -e "process.stdin.resume();let d=\'\';process.stdin.on(\'data\',c=>d+=c);process.stdin.on(\'end\',()=>{try{JSON.parse(d).forEach(p=>console.log(p.id))}catch{}}" 2>/dev/null',
+        'end',
+        '',
+        'complete -c sig -n "__fish_seen_subcommand_from get login status logout rename remove" -a "(__sig_providers)"',
+        'complete -c sig -n "__fish_seen_subcommand_from remote" -a "add remove list"',
+        'complete -c sig -n "__fish_seen_subcommand_from sync" -a "push pull"',
+        'complete -c sig -n "__fish_seen_subcommand_from watch" -a "add remove list start set-interval"',
+        'complete -c sig -n "__fish_seen_subcommand_from completion" -a "bash zsh fish"',
+        'complete -c sig -l verbose -d "Debug output to stderr"',
+        'complete -c sig -l help -d "Show help"',
+        'complete -c sig -l format -d "Output format" -a "json table yaml env plain"',
+        'complete -c sig -l method -d "HTTP method" -a "GET POST PUT PATCH DELETE HEAD OPTIONS"',
+        '',
+    ].join('\n');
+}
+
+export async function runCompletion(
+    positionals: string[],
+    _flags: Record<string, string | boolean | string[]>,
+): Promise<void> {
+    const shell = positionals[0];
+
+    if (!shell) {
+        process.stderr.write('Usage: sig completion <shell>\n');
+        process.stderr.write('Supported shells: bash, zsh, fish\n');
+        process.exitCode = ExitCode.GENERAL_ERROR;
+        return;
+    }
+
+    switch (shell) {
+        case 'bash':
+            process.stdout.write(bashScript());
+            break;
+        case 'zsh':
+            process.stdout.write(zshScript());
+            break;
+        case 'fish':
+            process.stdout.write(fishScript());
+            break;
+        default:
+            process.stderr.write(`Unknown shell: ${shell}\n`);
+            process.stderr.write('Supported shells: bash, zsh, fish\n');
+            process.exitCode = ExitCode.GENERAL_ERROR;
+    }
+}

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -18,6 +18,7 @@ import { runInit } from './commands/init.js';
 import { runDoctor } from './commands/doctor.js';
 import { runRename } from './commands/rename.js';
 import { runRemove } from './commands/remove.js';
+import { runCompletion } from './commands/completion.js';
 import { ExitCode } from './exit-codes.js';
 
 interface ParsedArgs {
@@ -123,6 +124,7 @@ Setup:
     --force                      Overwrite existing config
     --channel <name>             Browser channel (chrome|msedge|chromium)
   doctor                       Check environment and configuration
+  completion <shell>           Generate shell completion script (bash|zsh|fish)
 
 Global options:
   --verbose                    Debug output to stderr
@@ -157,6 +159,10 @@ export async function run(args: string[]): Promise<void> {
     }
     if (command === Command.DOCTOR) {
         await runDoctor(positionals, flags);
+        return;
+    }
+    if (command === Command.COMPLETION) {
+        await runCompletion(positionals, flags);
         return;
     }
 

--- a/cli/src/core/constants.ts
+++ b/cli/src/core/constants.ts
@@ -22,6 +22,7 @@ export const Command = {
     WATCH: 'watch',
     RENAME: 'rename',
     REMOVE: 'remove',
+    COMPLETION: 'completion',
     HELP: 'help',
 } as const;
 

--- a/cli/tests/unit/cli/completion.test.ts
+++ b/cli/tests/unit/cli/completion.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { runCompletion } from '../../../src/cli/commands/completion.js';
+
+describe('runCompletion', () => {
+    let stdoutData: string;
+    let stderrData: string;
+    const origStdoutWrite = process.stdout.write.bind(process.stdout);
+    const origStderrWrite = process.stderr.write.bind(process.stderr);
+    const origExitCode = process.exitCode;
+
+    beforeEach(() => {
+        stdoutData = '';
+        stderrData = '';
+        process.stdout.write = (chunk: string | Uint8Array) => {
+            stdoutData += chunk.toString();
+            return true;
+        };
+        process.stderr.write = (chunk: string | Uint8Array) => {
+            stderrData += chunk.toString();
+            return true;
+        };
+        process.exitCode = undefined;
+    });
+
+    afterEach(() => {
+        process.stdout.write = origStdoutWrite;
+        process.stderr.write = origStderrWrite;
+        process.exitCode = origExitCode;
+    });
+
+    it('outputs bash completion script containing _sig_completions', async () => {
+        await runCompletion(['bash'], {});
+        expect(stdoutData).toContain('_sig_completions');
+        expect(stdoutData).toContain('complete -F _sig_completions sig');
+        expect(process.exitCode).toBeUndefined();
+    });
+
+    it('outputs zsh completion script containing compdef', async () => {
+        await runCompletion(['zsh'], {});
+        expect(stdoutData).toContain('compdef');
+        expect(stdoutData).toContain('_describe');
+        expect(process.exitCode).toBeUndefined();
+    });
+
+    it('outputs fish completion script containing complete -c sig', async () => {
+        await runCompletion(['fish'], {});
+        expect(stdoutData).toContain('complete -c sig');
+        expect(process.exitCode).toBeUndefined();
+    });
+
+    it('writes error to stderr when no shell specified', async () => {
+        await runCompletion([], {});
+        expect(stderrData).toContain('Usage');
+        expect(process.exitCode).toBe(1);
+    });
+
+    it('writes error to stderr for unknown shell', async () => {
+        await runCompletion(['powershell'], {});
+        expect(stderrData).toContain('Unknown shell');
+        expect(process.exitCode).toBe(1);
+    });
+});


### PR DESCRIPTION
## Summary

- Adds `sig completion bash|zsh|fish` command that outputs a ready-to-source shell completion script
- Self-contained: only adds 4 files/changes, no cross-branch contamination
- Registered in `main.ts` as a no-deps command (runs before config exists, like `init`/`doctor`)
- Dynamic provider completion via `sig providers --format json` at tab-complete time

## Usage

```bash
# bash — add to ~/.bashrc:
eval "$(sig completion bash)"

# zsh — add to ~/.zshrc:
eval "$(sig completion zsh)"

# fish — save to completions dir:
sig completion fish > ~/.config/fish/completions/sig.fish
```

## Files changed

- `cli/src/cli/commands/completion.ts` — implementation
- `cli/src/core/constants.ts` — adds `COMPLETION: 'completion'`
- `cli/src/cli/main.ts` — wires import, help text, and handler
- `cli/tests/unit/cli/completion.test.ts` — 5 tests

## Test plan

- [x] `runCompletion(['bash'], {})` outputs script with `_sig_completions` and `complete -F _sig_completions sig`
- [x] `runCompletion(['zsh'], {})` outputs script with `compdef` and `_describe`
- [x] `runCompletion(['fish'], {})` outputs script with `complete -c sig`
- [x] `runCompletion([], {})` writes "Usage" to stderr, exit code 1
- [x] `runCompletion(['powershell'], {})` writes "Unknown shell" to stderr, exit code 1