### PR TITLE
feat: add strategy auto-cascade for automatic auth method detection

### DIFF
--- a/cli/src/cli/commands/cascade.ts
+++ b/cli/src/cli/commands/cascade.ts
@@ -1,0 +1,135 @@
+import type { AuthDeps } from '../../deps.js';
+import { isOk } from '../../core/result.js';
+import { ProviderNotFoundError } from '../../core/errors.js';
+import { BROWSER_REQUIRED_STRATEGIES } from '../../core/constants.js';
+import { ExitCode } from '../exit-codes.js';
+import { formatJson } from '../formatters.js';
+
+type StepResult =
+    | 'valid'
+    | 'refreshed'
+    | 'authenticated'
+    | 'not found'
+    | 'expired'
+    | 'failed'
+    | 'skipped';
+
+function printStep(n: number, total: number, desc: string, result: StepResult): void {
+    const icon =
+        result === 'valid' || result === 'refreshed' || result === 'authenticated'
+            ? '\u2713'
+            : '\u2717';
+    process.stderr.write(`  [${n}/${total}] ${desc} ${icon} ${result}\n`);
+}
+
+export async function runCascade(
+    positionals: string[],
+    flags: Record<string, string | boolean | string[]>,
+    deps: AuthDeps,
+): Promise<void> {
+    const target = positionals[0];
+    if (!target) {
+        process.stderr.write('Usage: sig cascade <url>\n');
+        process.exitCode = ExitCode.GENERAL_ERROR;
+        return;
+    }
+
+    let provider;
+    try {
+        provider = deps.authManager.resolveProvider(target);
+    } catch (e) {
+        if (e instanceof ProviderNotFoundError) {
+            process.stderr.write(
+                `Error: No provider found matching "${target}". Run "sig providers" to see configured providers.\n`,
+            );
+            process.exitCode = ExitCode.GENERAL_ERROR;
+            return;
+        }
+        throw e;
+    }
+
+    const total = 3;
+    process.stderr.write(`Cascade auth for "${provider.name}" (${provider.id})\n`);
+
+    // Step 1: Check stored credentials
+    const status = await deps.authManager.getStatus(provider.id);
+    if (status.valid) {
+        printStep(1, total, 'Checking stored credentials...', 'valid');
+        const result = await deps.authManager.getCredentials(provider.id);
+        if (isOk(result)) {
+            process.stderr.write(
+                `Authenticated with "${provider.name}" (using stored credential).\n`,
+            );
+            process.stdout.write(
+                formatJson({
+                    provider: provider.id,
+                    type: result.value.type,
+                    ...(status.expiresAt ? { expiresAt: status.expiresAt } : {}),
+                    source: 'stored',
+                }) + '\n',
+            );
+            return;
+        }
+    }
+
+    if (status.configured && !status.valid) {
+        printStep(1, total, 'Checking stored credentials...', 'expired');
+        process.stderr.write(`  [2/${total}] Attempting credential refresh... `);
+
+        const refreshResult = await deps.authManager.getCredentials(provider.id);
+        if (isOk(refreshResult)) {
+            process.stderr.write(`\u2713 refreshed\n`);
+            const newStatus = await deps.authManager.getStatus(provider.id);
+            process.stderr.write(`Authenticated with "${provider.name}" (credential refreshed).\n`);
+            process.stdout.write(
+                formatJson({
+                    provider: provider.id,
+                    type: refreshResult.value.type,
+                    ...(newStatus.expiresAt ? { expiresAt: newStatus.expiresAt } : {}),
+                    source: 'refreshed',
+                }) + '\n',
+            );
+            return;
+        }
+        process.stderr.write(`\u2717 failed\n`);
+    } else {
+        printStep(1, total, 'Checking stored credentials...', 'not found');
+        printStep(2, total, 'Attempting credential refresh...', 'skipped');
+    }
+
+    // Step 3: Fall back to browser login
+    if (!deps.browserAvailable && BROWSER_REQUIRED_STRATEGIES.has(provider.strategy)) {
+        printStep(3, total, 'Falling back to browser login...', 'failed');
+        process.stderr.write(
+            `Browser is not available on this machine.\n` +
+                `Provider "${provider.name}" uses "${provider.strategy}" strategy which requires a browser.\n\n` +
+                `Alternatives:\n` +
+                `  sig login <url> --cookie <string>  Provide cookies manually\n` +
+                `  sig login <url> --token <token>    Provide a token directly\n` +
+                `  sig sync pull                       Pull credentials from a machine with a browser\n`,
+        );
+        process.exitCode = ExitCode.GENERAL_ERROR;
+        return;
+    }
+
+    process.stderr.write(`  [3/${total}] Falling back to browser login... `);
+    const authResult = await deps.authManager.forceReauth(provider.id);
+    if (!isOk(authResult)) {
+        process.stderr.write(`\u2717 failed\n`);
+        process.stderr.write(`Authentication failed: ${authResult.error.message}\n`);
+        process.exitCode = ExitCode.GENERAL_ERROR;
+        return;
+    }
+
+    process.stderr.write(`\u2713 authenticated\n`);
+    const finalStatus = await deps.authManager.getStatus(provider.id);
+    process.stderr.write(`Authenticated with "${provider.name}".\n`);
+    process.stdout.write(
+        formatJson({
+            provider: provider.id,
+            type: authResult.value.type,
+            ...(finalStatus.expiresAt ? { expiresAt: finalStatus.expiresAt } : {}),
+            source: 'browser',
+        }) + '\n',
+    );
+}

--- a/cli/src/cli/commands/login.ts
+++ b/cli/src/cli/commands/login.ts
@@ -20,6 +20,7 @@ import {
     CredentialTypeName,
 } from '../../core/constants.js';
 import { ExitCode } from '../exit-codes.js';
+import { runCascade } from './cascade.js';
 
 /** Convert runtime ProviderConfig to the YAML ProviderEntry format. */
 function toProviderEntry(pc: ProviderConfig): ProviderEntry {
@@ -86,6 +87,12 @@ export async function runLogin(
 
     const hasOverrides = flags.strategy !== undefined || typeof flags.as === 'string';
     const provider = hasOverrides ? { ...baseProvider } : baseProvider;
+
+    // --cascade: delegate to cascade flow (stored -> refresh -> browser)
+    if (flags.cascade === true) {
+        await runCascade(positionals, flags, deps);
+        return;
+    }
 
     // --as <id>: override the provider ID (useful for auto-provisioned providers)
     if (typeof flags.as === 'string') {

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -5,6 +5,7 @@ import { isOk } from '../core/result.js';
 import type { AuthDeps } from '../deps.js';
 import { Command } from '../core/constants.js';
 
+import { runCascade } from './commands/cascade.js';
 import { runGet } from './commands/get.js';
 import { runLogin } from './commands/login.js';
 import { runStatus } from './commands/status.js';
@@ -72,6 +73,8 @@ Authentication:
     --cookie "k=v; k2=v2"       Cookies from DevTools (no browser)
     --username <u> --password <p>  Basic auth (no browser)
     --strategy <name>            Force strategy (cookie|oauth2|api-token|basic)
+    --cascade                    Auto-try stored → refresh → browser in order
+  cascade <url>                Auto-detect and try auth methods in order
   logout [provider]            Clear credentials (all if none specified)
 
 Credentials:
@@ -132,6 +135,7 @@ Global options:
 const DEPS_COMMANDS: ReadonlySet<string> = new Set([
     Command.GET,
     Command.LOGIN,
+    Command.CASCADE,
     Command.STATUS,
     Command.LOGOUT,
     Command.PROVIDERS,
@@ -191,6 +195,9 @@ export async function run(args: string[]): Promise<void> {
             break;
         case Command.LOGIN:
             await runLogin(positionals, flags, deps as AuthDeps);
+            break;
+        case Command.CASCADE:
+            await runCascade(positionals, flags, deps as AuthDeps);
             break;
         case Command.REQUEST:
             await runRequest(positionals, flags, deps as AuthDeps);

--- a/cli/src/core/constants.ts
+++ b/cli/src/core/constants.ts
@@ -13,6 +13,7 @@ export const Command = {
     DOCTOR: 'doctor',
     GET: 'get',
     LOGIN: 'login',
+    CASCADE: 'cascade',
     REQUEST: 'request',
     STATUS: 'status',
     LOGOUT: 'logout',

--- a/cli/tests/unit/cli/cascade.test.ts
+++ b/cli/tests/unit/cli/cascade.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AuthManager } from '../../../src/auth-manager.js';
+import { MemoryStorage } from '../../../src/storage/memory-storage.js';
+import { ProviderRegistry } from '../../../src/providers/provider-registry.js';
+import { StrategyRegistry } from '../../../src/strategies/registry.js';
+import { CookieStrategyFactory } from '../../../src/strategies/cookie.strategy.js';
+import { OAuth2StrategyFactory } from '../../../src/strategies/oauth2.strategy.js';
+import { ApiTokenStrategyFactory } from '../../../src/strategies/api-token.strategy.js';
+import { BasicAuthStrategyFactory } from '../../../src/strategies/basic-auth.strategy.js';
+import { runCascade } from '../../../src/cli/commands/cascade.js';
+import type { AuthDeps } from '../../../src/deps.js';
+import type {
+    ProviderConfig,
+    ApiKeyCredential,
+    CookieCredential,
+} from '../../../src/core/types.js';
+import type { IBrowserAdapter } from '../../../src/core/interfaces/browser-adapter.js';
+import type { BrowserConfig, SigConfig } from '../../../src/config/schema.js';
+
+const browserConfig: BrowserConfig = {
+    browserDataDir: '/tmp/test-browser-data',
+    channel: 'chrome',
+    headlessTimeout: 30_000,
+    visibleTimeout: 120_000,
+    waitUntil: 'load',
+};
+
+const cookieProvider: ProviderConfig = {
+    id: 'example',
+    name: 'Example',
+    domains: ['example.com'],
+    entryUrl: 'https://example.com/',
+    strategy: 'cookie',
+    strategyConfig: { strategy: 'cookie' },
+};
+
+const apiTokenProvider: ProviderConfig = {
+    id: 'api-app',
+    name: 'API App',
+    domains: ['api.example.com'],
+    strategy: 'api-token',
+    strategyConfig: { strategy: 'api-token', headerName: 'Authorization', headerPrefix: 'Bearer' },
+};
+
+function createDeps(overrides?: {
+    browserAvailable?: boolean;
+    providers?: ProviderConfig[];
+}): AuthDeps {
+    const storage = new MemoryStorage();
+    const strategyRegistry = new StrategyRegistry();
+    strategyRegistry.register(new CookieStrategyFactory());
+    strategyRegistry.register(new OAuth2StrategyFactory());
+    strategyRegistry.register(new ApiTokenStrategyFactory());
+    strategyRegistry.register(new BasicAuthStrategyFactory());
+
+    const providers = overrides?.providers ?? [cookieProvider, apiTokenProvider];
+    const providerRegistry = new ProviderRegistry(providers);
+
+    const authManager = new AuthManager({
+        storage,
+        strategyRegistry,
+        providerRegistry,
+        browserAdapterFactory: () => ({}) as IBrowserAdapter,
+        browserConfig,
+    });
+
+    const config: SigConfig = {
+        browser: browserConfig,
+        storage: { credentialsDir: '/tmp/test-credentials' },
+        providers: {},
+    };
+
+    return {
+        authManager,
+        storage,
+        providerRegistry,
+        strategyRegistry,
+        config,
+        browserAvailable: overrides?.browserAvailable ?? true,
+    };
+}
+
+describe('runCascade', () => {
+    let stderrChunks: string[];
+    let stdoutChunks: string[];
+    let originalExitCode: number | undefined;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        stderrChunks = [];
+        stdoutChunks = [];
+        originalExitCode = process.exitCode;
+        process.exitCode = undefined;
+
+        vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+            stderrChunks.push(String(chunk));
+            return true;
+        });
+
+        vi.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+            stdoutChunks.push(String(chunk));
+            return true;
+        });
+    });
+
+    afterEach(() => {
+        process.exitCode = originalExitCode;
+        vi.restoreAllMocks();
+    });
+
+    it('prints usage and sets exit code when no url provided', async () => {
+        const deps = createDeps();
+        await runCascade([], {}, deps);
+        expect(process.exitCode).toBe(1);
+        expect(stderrChunks.join('')).toContain('Usage: sig cascade <url>');
+    });
+
+    it('errors when provider not found for non-url input', async () => {
+        const deps = createDeps();
+        await runCascade(['unknown-provider-xyz'], {}, deps);
+        expect(process.exitCode).toBe(1);
+        expect(stderrChunks.join('')).toContain('No provider found');
+    });
+
+    it('uses stored credential when valid — no browser triggered', async () => {
+        const deps = createDeps({ providers: [apiTokenProvider] });
+        const apiKeyCredential: ApiKeyCredential = {
+            type: 'api-key',
+            key: 'secret-token',
+            headerName: 'Authorization',
+            headerPrefix: 'Bearer',
+        };
+        await deps.authManager.setCredential('api-app', apiKeyCredential);
+
+        const forceReauthSpy = vi.spyOn(deps.authManager, 'forceReauth');
+
+        await runCascade(['https://api.example.com/'], {}, deps);
+
+        expect(forceReauthSpy).not.toHaveBeenCalled();
+        expect(process.exitCode).toBeUndefined();
+        const stderr = stderrChunks.join('');
+        expect(stderr).toContain('valid');
+        expect(stderr).toContain('stored credential');
+        const stdout = stdoutChunks.join('');
+        const json = JSON.parse(stdout);
+        expect(json.source).toBe('stored');
+        expect(json.provider).toBe('api-app');
+    });
+
+    it('shows step-by-step progress output', async () => {
+        const deps = createDeps({ providers: [apiTokenProvider] });
+        const apiKeyCredential: ApiKeyCredential = {
+            type: 'api-key',
+            key: 'test-token',
+            headerName: 'Authorization',
+            headerPrefix: 'Bearer',
+        };
+        await deps.authManager.setCredential('api-app', apiKeyCredential);
+
+        await runCascade(['https://api.example.com/'], {}, deps);
+
+        const stderr = stderrChunks.join('');
+        expect(stderr).toMatch(/\[1\/3\]/);
+        expect(stderr).toContain('Checking stored credentials');
+    });
+
+    it('falls through to browser when no credential exists', async () => {
+        const deps = createDeps({ providers: [cookieProvider] });
+        const forceReauthSpy = vi.spyOn(deps.authManager, 'forceReauth').mockResolvedValue({
+            ok: true,
+            value: {
+                type: 'cookie',
+                cookies: [
+                    {
+                        name: 'session',
+                        value: 'abc',
+                        domain: 'example.com',
+                        path: '/',
+                        expires: -1,
+                        httpOnly: false,
+                        secure: true,
+                    },
+                ],
+                obtainedAt: new Date().toISOString(),
+            },
+        } as { ok: true; value: CookieCredential });
+
+        await runCascade(['https://example.com/'], {}, deps);
+
+        expect(forceReauthSpy).toHaveBeenCalledWith('example');
+        expect(process.exitCode).toBeUndefined();
+        const stdout = stdoutChunks.join('');
+        const json = JSON.parse(stdout);
+        expect(json.source).toBe('browser');
+    });
+
+    it('fails gracefully when browser unavailable and no stored credential', async () => {
+        const deps = createDeps({ providers: [cookieProvider], browserAvailable: false });
+
+        await runCascade(['https://example.com/'], {}, deps);
+
+        expect(process.exitCode).toBe(1);
+        const stderr = stderrChunks.join('');
+        expect(stderr).toContain('Browser is not available');
+        expect(stderr).toContain('--cookie');
+        expect(stderr).toContain('--token');
+    });
+
+    it('reports failure when browser auth fails', async () => {
+        const deps = createDeps({ providers: [cookieProvider] });
+        vi.spyOn(deps.authManager, 'forceReauth').mockResolvedValue({
+            ok: false,
+            error: { message: 'Browser timeout', code: 'BROWSER_TIMEOUT' } as never,
+        });
+
+        await runCascade(['https://example.com/'], {}, deps);
+
+        expect(process.exitCode).toBe(1);
+        const stderr = stderrChunks.join('');
+        expect(stderr).toContain('Authentication failed');
+        expect(stderr).toContain('Browser timeout');
+    });
+});

--- a/cli/tests/unit/core/constants.test.ts
+++ b/cli/tests/unit/core/constants.test.ts
@@ -25,6 +25,7 @@ describe('constants', () => {
             expect(Command.DOCTOR).toBe('doctor');
             expect(Command.GET).toBe('get');
             expect(Command.LOGIN).toBe('login');
+            expect(Command.CASCADE).toBe('cascade');
             expect(Command.REQUEST).toBe('request');
             expect(Command.STATUS).toBe('status');
             expect(Command.LOGOUT).toBe('logout');
@@ -38,7 +39,7 @@ describe('constants', () => {
         });
 
         it('has exactly the expected number of commands', () => {
-            expect(Object.keys(Command)).toHaveLength(14);
+            expect(Object.keys(Command)).toHaveLength(15);
         });
 
         it('values are all lowercase strings', () => {


### PR DESCRIPTION
## Summary
- New `sig cascade <url>` command — probes stored creds → refresh → browser login with step-by-step progress
- `--cascade` flag on `sig login` delegates to the same flow
- 7 unit tests covering all paths

## Test plan
- [ ] `sig cascade <url>` with valid stored credential skips browser
- [ ] `sig cascade <url>` with expired credential attempts refresh
- [ ] `sig cascade <url>` with no credential falls back to browser
- [ ] All existing tests pass