### PR TITLE
feat: add output format flexibility with auto-downgrade in non-TTY

### DIFF
--- a/cli/src/cli/commands/providers.ts
+++ b/cli/src/cli/commands/providers.ts
@@ -1,27 +1,18 @@
 import type { AuthDeps } from '../../deps.js';
-import { formatJson, formatTable } from '../formatters.js';
+import { formatTable } from '../formatters.js';
+import { detectFormat, formatOutput } from '../../utils/formatter.js';
 
 export async function runProviders(
     positionals: string[],
     flags: Record<string, string | boolean | string[]>,
     deps: AuthDeps,
 ): Promise<void> {
-    const format = (flags.format as string) ?? (process.stdout.isTTY ? 'table' : 'json');
+    const format = detectFormat(flags.format as string | undefined, 'table');
     const providers = deps.authManager.providerRegistry.list();
 
     const statuses = await Promise.all(providers.map((p) => deps.authManager.getStatus(p.id)));
 
-    if (format === 'json') {
-        const output = statuses.map((s) => ({
-            id: s.id,
-            name: s.name,
-            strategy: s.strategy,
-            configured: s.configured,
-            valid: s.valid,
-            credentialType: s.credentialType ?? null,
-        }));
-        process.stdout.write(formatJson(output) + '\n');
-    } else {
+    if (format === 'table') {
         if (statuses.length === 0) {
             process.stderr.write('No providers configured.\n');
             return;
@@ -33,5 +24,15 @@ export async function runProviders(
             status: s.valid ? 'authenticated' : 'not authenticated',
         }));
         process.stdout.write(formatTable(rows) + '\n');
+    } else {
+        const output = statuses.map((s) => ({
+            id: s.id,
+            name: s.name,
+            strategy: s.strategy,
+            configured: s.configured,
+            valid: s.valid,
+            credentialType: s.credentialType ?? null,
+        }));
+        process.stdout.write(formatOutput(output, format) + '\n');
     }
 }

--- a/cli/src/cli/commands/status.ts
+++ b/cli/src/cli/commands/status.ts
@@ -1,7 +1,8 @@
 import type { AuthDeps } from '../../deps.js';
-import { formatJson, formatTable, formatExpiry, formatStatusIndicator } from '../formatters.js';
+import { formatExpiry, formatStatusIndicator, formatTable } from '../formatters.js';
 import type { ProviderStatus } from '../../core/types.js';
 import { getWatchProviders, type WatchProviderEntry } from '../../watch/watch-config.js';
+import { detectFormat, formatOutput } from '../../utils/formatter.js';
 
 function buildRows(
     statuses: ProviderStatus[],
@@ -26,7 +27,7 @@ export async function runStatus(
     deps: AuthDeps,
 ): Promise<void> {
     const providerId = (flags.provider as string) ?? positionals[0];
-    const format = (flags.format as string) ?? (process.stdout.isTTY ? 'table' : 'json');
+    const format = detectFormat(flags.format as string | undefined, 'table');
     const tableOptions = { maxColumnWidths: { id: 30, sync: 20 } };
 
     const watchEntries = await getWatchProviders();
@@ -35,23 +36,27 @@ export async function runStatus(
     if (providerId) {
         const resolved = deps.authManager.providerRegistry.resolveFlexible(providerId);
         const status = await deps.authManager.getStatus(resolved?.id ?? providerId);
-        if (format === 'json') {
-            process.stdout.write(formatJson(status) + '\n');
-        } else {
+        if (format === 'table') {
             process.stdout.write(formatTable(buildRows([status], watchMap), tableOptions) + '\n');
+        } else {
+            process.stdout.write(
+                formatOutput(status as unknown as Record<string, unknown>, format) + '\n',
+            );
         }
         return;
     }
 
     const statuses = await deps.authManager.getAllStatus();
 
-    if (format === 'json') {
-        process.stdout.write(formatJson(statuses) + '\n');
-    } else {
+    if (format === 'table') {
         if (statuses.length === 0) {
             process.stderr.write('No providers configured.\n');
             return;
         }
         process.stdout.write(formatTable(buildRows(statuses, watchMap), tableOptions) + '\n');
+    } else {
+        process.stdout.write(
+            formatOutput(statuses as unknown as Record<string, unknown>[], format) + '\n',
+        );
     }
 }

--- a/cli/src/utils/formatter.ts
+++ b/cli/src/utils/formatter.ts
@@ -1,0 +1,128 @@
+import { formatTable } from '../cli/formatters.js';
+
+export type FormatType = 'json' | 'yaml' | 'env' | 'table' | 'plain';
+
+export function detectFormat(
+    flagValue: string | undefined,
+    defaultFormat: FormatType = 'table',
+): FormatType {
+    if (flagValue) return flagValue as FormatType;
+    if (!process.stdout.isTTY) return 'json';
+    return defaultFormat;
+}
+
+function toYaml(data: Record<string, unknown>[] | Record<string, unknown>): string {
+    const serializeValue = (val: unknown, indent: string): string => {
+        if (val === null || val === undefined) return 'null';
+        if (typeof val === 'boolean' || typeof val === 'number') return String(val);
+        if (typeof val === 'string') {
+            if (val.includes('\n') || val.includes(':') || val.includes('#'))
+                return `"${val.replace(/"/g, '\\"')}"`;
+            return val;
+        }
+        if (Array.isArray(val)) {
+            if (val.length === 0) return '[]';
+            return (
+                '\n' + val.map((v) => `${indent}- ${serializeValue(v, indent + '  ')}`).join('\n')
+            );
+        }
+        if (typeof val === 'object') {
+            const obj = val as Record<string, unknown>;
+            const keys = Object.keys(obj);
+            if (keys.length === 0) return '{}';
+            return (
+                '\n' +
+                keys
+                    .map((k) => `${indent}  ${k}: ${serializeValue(obj[k], indent + '  ')}`)
+                    .join('\n')
+            );
+        }
+        return String(val);
+    };
+
+    const serializeObject = (obj: Record<string, unknown>): string =>
+        Object.entries(obj)
+            .map(([k, v]) => `${k}: ${serializeValue(v, '')}`)
+            .join('\n');
+
+    if (Array.isArray(data)) {
+        return data
+            .map(
+                (item) =>
+                    `- ${Object.entries(item)
+                        .map(([k, v]) => `${k}: ${serializeValue(v, '  ')}`)
+                        .join('\n  ')}`,
+            )
+            .join('\n');
+    }
+    return serializeObject(data);
+}
+
+function toEnv(data: Record<string, unknown>[] | Record<string, unknown>): string {
+    const toEnvKey = (key: string): string => key.toUpperCase().replace(/[^A-Z0-9]/g, '_');
+
+    const serializeEnvValue = (val: unknown): string => {
+        if (val === null || val === undefined) return '';
+        if (typeof val === 'string')
+            return val.includes(' ') || val.includes('"') ? `"${val.replace(/"/g, '\\"')}"` : val;
+        return String(val);
+    };
+
+    if (Array.isArray(data)) {
+        return data
+            .map((item, i) =>
+                Object.entries(item)
+                    .map(([k, v]) => `${toEnvKey(k)}_${i}=${serializeEnvValue(v)}`)
+                    .join('\n'),
+            )
+            .join('\n');
+    }
+    return Object.entries(data)
+        .map(([k, v]) => `${toEnvKey(k)}=${serializeEnvValue(v)}`)
+        .join('\n');
+}
+
+function toPlain(data: Record<string, unknown>[] | Record<string, unknown>): string {
+    const serializePlain = (val: unknown): string => {
+        if (val === null || val === undefined) return '-';
+        if (typeof val === 'object') return JSON.stringify(val);
+        return String(val);
+    };
+
+    if (Array.isArray(data)) {
+        return data
+            .map((item) =>
+                Object.entries(item)
+                    .map(([k, v]) => `${k}: ${serializePlain(v)}`)
+                    .join('\n'),
+            )
+            .join('\n---\n');
+    }
+    return Object.entries(data)
+        .map(([k, v]) => `${k}: ${serializePlain(v)}`)
+        .join('\n');
+}
+
+export function formatOutput(
+    data: Record<string, unknown>[] | Record<string, unknown>,
+    format: FormatType,
+): string {
+    switch (format) {
+        case 'json':
+            return JSON.stringify(data, null, 2);
+        case 'yaml':
+            return toYaml(data);
+        case 'env':
+            return toEnv(data);
+        case 'table': {
+            const stringify = (v: unknown): string =>
+                v === null || v === undefined ? '-' : String(v);
+            const toStringRecord = (obj: Record<string, unknown>): Record<string, string> =>
+                Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, stringify(v)]));
+            const rows = Array.isArray(data) ? data.map(toStringRecord) : [toStringRecord(data)];
+            return formatTable(rows);
+        }
+        case 'plain':
+            return toPlain(data);
+    }
+}

--- a/cli/tests/unit/utils/formatter.test.ts
+++ b/cli/tests/unit/utils/formatter.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { detectFormat, formatOutput, type FormatType } from '../../../src/utils/formatter.js';
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('detectFormat', () => {
+    it('returns flag value when provided', () => {
+        expect(detectFormat('yaml')).toBe('yaml');
+        expect(detectFormat('env')).toBe('env');
+        expect(detectFormat('json')).toBe('json');
+    });
+
+    it('returns defaultFormat when no flag and stdout is TTY', () => {
+        Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+        expect(detectFormat(undefined, 'table')).toBe('table');
+        expect(detectFormat(undefined, 'plain')).toBe('plain');
+    });
+
+    it('auto-downgrades to json when stdout is not TTY', () => {
+        Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+        expect(detectFormat(undefined, 'table')).toBe('json');
+        expect(detectFormat(undefined, 'plain')).toBe('json');
+    });
+
+    it('flag value overrides TTY detection', () => {
+        Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+        expect(detectFormat('yaml')).toBe('yaml');
+    });
+});
+
+describe('formatOutput', () => {
+    const singleItem = { id: 'my-app', name: 'My App', valid: true };
+    const arrayItems = [
+        { id: 'app1', name: 'App 1', valid: true },
+        { id: 'app2', name: 'App 2', valid: false },
+    ];
+
+    describe('json format', () => {
+        it('serializes single object', () => {
+            const result = formatOutput(singleItem, 'json');
+            expect(JSON.parse(result)).toEqual(singleItem);
+        });
+
+        it('serializes array', () => {
+            const result = formatOutput(arrayItems, 'json');
+            expect(JSON.parse(result)).toEqual(arrayItems);
+        });
+    });
+
+    describe('yaml format', () => {
+        it('serializes single object as key: value lines', () => {
+            const result = formatOutput(singleItem, 'yaml');
+            expect(result).toContain('id: my-app');
+            expect(result).toContain('name: My App');
+            expect(result).toContain('valid: true');
+        });
+
+        it('serializes array with list prefixes', () => {
+            const result = formatOutput(arrayItems, 'yaml');
+            expect(result).toContain('- ');
+            expect(result).toContain('app1');
+            expect(result).toContain('app2');
+        });
+    });
+
+    describe('env format', () => {
+        it('outputs KEY=value lines for single object', () => {
+            const result = formatOutput(singleItem, 'env');
+            expect(result).toContain('ID=my-app');
+            expect(result).toContain('NAME=');
+            expect(result).toContain('My App');
+            expect(result).toContain('VALID=true');
+        });
+
+        it('outputs indexed keys for array', () => {
+            const result = formatOutput(arrayItems, 'env');
+            expect(result).toContain('ID_0=app1');
+            expect(result).toContain('ID_1=app2');
+        });
+    });
+
+    describe('table format', () => {
+        it('outputs aligned columns with headers for array', () => {
+            const result = formatOutput(arrayItems, 'table');
+            expect(result).toContain('ID');
+            expect(result).toContain('NAME');
+            expect(result).toContain('app1');
+            expect(result).toContain('app2');
+        });
+
+        it('outputs single row table for single object', () => {
+            const result = formatOutput(singleItem, 'table');
+            expect(result).toContain('ID');
+            expect(result).toContain('my-app');
+        });
+    });
+
+    describe('plain format', () => {
+        it('outputs key: value lines for single object', () => {
+            const result = formatOutput(singleItem, 'plain');
+            expect(result).toContain('id: my-app');
+            expect(result).toContain('name: My App');
+            expect(result).toContain('valid: true');
+        });
+
+        it('separates array items with ---', () => {
+            const result = formatOutput(arrayItems, 'plain');
+            expect(result).toContain('---');
+            expect(result).toContain('id: app1');
+            expect(result).toContain('id: app2');
+        });
+    });
+
+    describe('all formats produce non-empty output', () => {
+        const formats: FormatType[] = ['json', 'yaml', 'env', 'table', 'plain'];
+        for (const fmt of formats) {
+            it(`${fmt} produces output`, () => {
+                expect(formatOutput(singleItem, fmt).length).toBeGreaterThan(0);
+            });
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- New `cli/src/utils/formatter.ts` with `detectFormat` and `formatOutput` (json/yaml/env/table/plain)
- Auto-downgrades to JSON when stdout is not a TTY (pipe-friendly)
- Updated `sig status` and `sig providers` to use shared formatter
- 19 unit tests

## Test plan
- [ ] `sig status --format json` outputs valid JSON
- [ ] `sig providers --format yaml` outputs YAML
- [ ] Piping `sig status | cat` auto-switches to JSON
- [ ] All existing tests pass