### PR TITLE
feat: add sig run command for credential-injected process execution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ sig remote add|remove|list # Manage remote credential stores
 sig sync push|pull [remote]# Sync credentials with remote
 sig watch add|remove|list|start  # Auto-refresh credentials
 sig completion <shell>     # Generate shell completion (bash|zsh|fish)
+sig run --provider <id> -- <cmd>  # Run command with SIG_* credentials injected
 ```
 
 ## Extension Points

--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ sig request https://jira.example.com/rest/api/2/myself   # Authenticated request
 | `sig watch start --interval 1m`                 | Override check interval                   |
 | `sig watch set-interval <duration>`             | Set default check interval                |
 
+### Process Execution
+
+| Command                                                                   | Description                                           |
+| ------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `sig run --provider <id> -- <cmd>`                                        | Run command with `SIG_*` credentials in env           |
+| `sig run --provider <id> --expand-cookies -- <cmd>`                       | Also expand cookies as `SIG_COOKIE_<NAME>=value`      |
+| `sig run --provider <id> --no-redaction -- <cmd>`                         | Disable credential redaction from child output        |
+| `sig run --provider <id> --mount .env -- <cmd>`                           | Write credentials to `.env` file (deleted after exit) |
+| `sig run --provider <id> --mount creds.json --mount-format json -- <cmd>` | Write credentials as JSON file                        |
+
 ### Global Flags
 
 | Flag        | Description             |

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -85,6 +85,7 @@ sig remote add|remove|list # Manage remote credential stores
 sig sync push|pull [remote]# Sync credentials with remote
 sig watch add|remove|list|start  # Auto-refresh credentials
 sig completion <shell>     # Generate shell completion (bash|zsh|fish)
+sig run --provider <id> -- <cmd>  # Run command with SIG_* credentials injected
 ```
 
 ## Extension Points

--- a/cli/src/cli/commands/run.ts
+++ b/cli/src/cli/commands/run.ts
@@ -1,0 +1,132 @@
+import { spawn } from 'node:child_process';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import type { AuthDeps } from '../../deps.js';
+import { isOk } from '../../core/result.js';
+import { ExitCode } from '../exit-codes.js';
+import { credentialToEnvVars } from '../../utils/credential-env.js';
+import { extractSensitiveValues, redactOutput } from '../../utils/redact.js';
+
+export async function runRun(
+    positionals: string[],
+    flags: Record<string, string | boolean | string[]>,
+    deps: AuthDeps,
+): Promise<void> {
+    const provider = flags['provider'];
+    if (!provider || typeof provider !== 'string') {
+        process.stderr.write(
+            'Error: --provider <id> is required\nUsage: sig run --provider <id> -- <command> [args]\n',
+        );
+        process.exitCode = ExitCode.GENERAL_ERROR;
+        return;
+    }
+
+    // Validate provider exists
+    if (!deps.providerRegistry.get(provider)) {
+        process.stderr.write(
+            `Error: No provider "${provider}" found. Run "sig providers" to list configured providers.\n`,
+        );
+        process.exitCode = ExitCode.GENERAL_ERROR;
+        return;
+    }
+
+    if (positionals.length === 0) {
+        process.stderr.write(
+            'Error: No command specified\nUsage: sig run --provider <id> -- <command> [args]\n',
+        );
+        process.exitCode = ExitCode.GENERAL_ERROR;
+        return;
+    }
+
+    const credResult = await deps.authManager.getCredentials(provider);
+    if (!isOk(credResult)) {
+        process.stderr.write(`Error: ${credResult.error.message}\n`);
+        if (credResult.error.code === 'PROVIDER_NOT_FOUND') {
+            process.stderr.write(
+                `No provider "${provider}" found. Run "sig providers" to list configured providers.\n`,
+            );
+        } else {
+            process.stderr.write(`Run "sig login <url>" first to authenticate.\n`);
+        }
+        process.exitCode = ExitCode.GENERAL_ERROR;
+        return;
+    }
+
+    const credential = credResult.value;
+    const expandCookies = flags['expand-cookies'] === true;
+    const noRedaction = flags['no-redaction'] === true;
+    const mount = typeof flags['mount'] === 'string' ? flags['mount'] : undefined;
+    const mountFormat = typeof flags['mount-format'] === 'string' ? flags['mount-format'] : 'env';
+
+    const sigEnv = credentialToEnvVars(credential, provider, { expandCookies });
+    const childEnv = { ...process.env, ...sigEnv };
+
+    // Mount mode: write credentials to file
+    if (mount) {
+        let content: string;
+        if (mountFormat === 'json') {
+            content = JSON.stringify(sigEnv, null, 2) + '\n';
+        } else {
+            content =
+                Object.entries(sigEnv)
+                    .map(([k, v]) => `${k}=${v}`)
+                    .join('\n') + '\n';
+        }
+        writeFileSync(mount, content, { encoding: 'utf8', mode: 0o600 });
+    }
+
+    const [cmd, ...args] = positionals;
+    const secrets = noRedaction ? [] : extractSensitiveValues(credential);
+    let redactionNoticeShown = false;
+
+    const child = spawn(cmd, args, {
+        env: childEnv,
+        stdio: ['inherit', 'pipe', 'pipe'],
+    });
+
+    const cleanup = () => {
+        if (mount) {
+            try {
+                unlinkSync(mount);
+            } catch {
+                /* ignore */
+            }
+        }
+    };
+
+    const forwardSignal = (signal: NodeJS.Signals) => {
+        cleanup();
+        child.kill(signal);
+    };
+
+    process.on('SIGINT', () => forwardSignal('SIGINT'));
+    process.on('SIGTERM', () => forwardSignal('SIGTERM'));
+
+    const writeRedacted = (chunk: Buffer, dest: NodeJS.WriteStream) => {
+        if (noRedaction) {
+            dest.write(chunk);
+            return;
+        }
+        const text = chunk.toString();
+        const redacted = redactOutput(text, secrets);
+        if (!redactionNoticeShown && redacted !== text) {
+            redactionNoticeShown = true;
+            process.stderr.write(
+                '[sig] Credential values redacted. Use --no-redaction to disable.\n',
+            );
+        }
+        dest.write(redacted);
+    };
+
+    child.stdout.on('data', (chunk: Buffer) => writeRedacted(chunk, process.stdout));
+    child.stderr.on('data', (chunk: Buffer) => writeRedacted(chunk, process.stderr));
+
+    await new Promise<void>((resolve) => {
+        child.on('close', (code) => {
+            cleanup();
+            if (code !== null && code !== 0) {
+                process.exitCode = code;
+            }
+            resolve();
+        });
+    });
+}

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -19,6 +19,7 @@ import { runDoctor } from './commands/doctor.js';
 import { runRename } from './commands/rename.js';
 import { runRemove } from './commands/remove.js';
 import { runCompletion } from './commands/completion.js';
+import { runRun } from './commands/run.js';
 import { ExitCode } from './exit-codes.js';
 
 interface ParsedArgs {
@@ -36,7 +37,13 @@ export function parseArgs(args: string[]): ParsedArgs {
     let i = firstIsFlag ? 0 : 1;
     while (i < args.length) {
         const arg = args[i];
-        if (arg.startsWith('--')) {
+        if (arg === '--') {
+            // Everything after -- is positional (for sig run)
+            for (let j = i + 1; j < args.length; j++) {
+                positionals.push(args[j]);
+            }
+            break;
+        } else if (arg.startsWith('--')) {
             const key = arg.slice(2);
             const next = args[i + 1];
             if (next !== undefined && !next.startsWith('--')) {
@@ -127,6 +134,13 @@ Setup:
   doctor                       Check environment and configuration
   completion <shell>           Generate shell completion script (bash|zsh|fish)
 
+Process:
+  run --provider <id> -- <cmd>  Run command with credentials injected as SIG_* env vars
+    --expand-cookies             Expand individual cookies as SIG_COOKIE_<NAME>=value
+    --no-redaction               Disable credential redaction from child output
+    --mount <path>               Write credentials to file instead of env vars
+    --mount-format env|json      File format for --mount (default: env)
+
 Global options:
   --verbose                    Debug output to stderr
   --help                       Show this help
@@ -143,6 +157,7 @@ const DEPS_COMMANDS: ReadonlySet<string> = new Set([
     Command.WATCH,
     Command.RENAME,
     Command.REMOVE,
+    Command.RUN,
 ]);
 
 export async function run(args: string[]): Promise<void> {
@@ -225,6 +240,9 @@ export async function run(args: string[]): Promise<void> {
             break;
         case Command.REMOVE:
             await runRemove(positionals, flags, deps as AuthDeps);
+            break;
+        case Command.RUN:
+            await runRun(positionals, flags, deps as AuthDeps);
             break;
         default:
             process.stderr.write(`Unknown command: ${command}\n\n`);

--- a/cli/src/core/constants.ts
+++ b/cli/src/core/constants.ts
@@ -23,6 +23,7 @@ export const Command = {
     RENAME: 'rename',
     REMOVE: 'remove',
     COMPLETION: 'completion',
+    RUN: 'run',
     HELP: 'help',
 } as const;
 

--- a/cli/src/utils/credential-env.ts
+++ b/cli/src/utils/credential-env.ts
@@ -1,0 +1,76 @@
+import type { Credential } from '../core/types.js';
+
+export interface CredentialEnvOptions {
+    expandCookies?: boolean;
+}
+
+function normalizeKey(key: string): string {
+    return key.toUpperCase().replace(/-/g, '_');
+}
+
+export function credentialToEnvVars(
+    credential: Credential,
+    providerId: string,
+    options: CredentialEnvOptions,
+): Record<string, string> {
+    const env: Record<string, string> = {
+        SIG_PROVIDER: providerId,
+        SIG_CREDENTIAL_TYPE: credential.type,
+    };
+
+    switch (credential.type) {
+        case 'bearer': {
+            env['SIG_TOKEN'] = credential.accessToken;
+            env['SIG_AUTH_HEADER'] = `Bearer ${credential.accessToken}`;
+            if (credential.xHeaders) {
+                for (const [k, v] of Object.entries(credential.xHeaders)) {
+                    env[`SIG_HEADER_${normalizeKey(k)}`] = v;
+                }
+            }
+            if (credential.localStorage) {
+                for (const [k, v] of Object.entries(credential.localStorage)) {
+                    env[`SIG_LOCAL_${normalizeKey(k)}`] = v;
+                }
+            }
+            break;
+        }
+        case 'cookie': {
+            env['SIG_COOKIE'] = credential.cookies.map((c) => `${c.name}=${c.value}`).join('; ');
+            if (options.expandCookies) {
+                for (const c of credential.cookies) {
+                    env[`SIG_COOKIE_${normalizeKey(c.name)}`] = c.value;
+                }
+            }
+            if (credential.xHeaders) {
+                for (const [k, v] of Object.entries(credential.xHeaders)) {
+                    env[`SIG_HEADER_${normalizeKey(k)}`] = v;
+                }
+            }
+            if (credential.localStorage) {
+                for (const [k, v] of Object.entries(credential.localStorage)) {
+                    env[`SIG_LOCAL_${normalizeKey(k)}`] = v;
+                }
+            }
+            break;
+        }
+        case 'api-key': {
+            env['SIG_API_KEY'] = credential.key;
+            const header = credential.headerPrefix
+                ? `${credential.headerPrefix} ${credential.key}`
+                : credential.key;
+            env['SIG_AUTH_HEADER'] = header;
+            break;
+        }
+        case 'basic': {
+            env['SIG_USERNAME'] = credential.username;
+            env['SIG_PASSWORD'] = credential.password;
+            const encoded = Buffer.from(`${credential.username}:${credential.password}`).toString(
+                'base64',
+            );
+            env['SIG_AUTH_HEADER'] = `Basic ${encoded}`;
+            break;
+        }
+    }
+
+    return env;
+}

--- a/cli/src/utils/redact.ts
+++ b/cli/src/utils/redact.ts
@@ -1,0 +1,70 @@
+import type { Credential } from '../core/types.js';
+import { Transform } from 'node:stream';
+
+const MIN_SECRET_LENGTH = 8;
+
+export function extractSensitiveValues(credential: Credential): string[] {
+    const values: string[] = [];
+
+    const add = (v: string) => {
+        if (v.length >= MIN_SECRET_LENGTH) values.push(v);
+    };
+
+    switch (credential.type) {
+        case 'bearer':
+            add(credential.accessToken);
+            if (credential.refreshToken) add(credential.refreshToken);
+            for (const v of Object.values(credential.xHeaders ?? {})) add(v);
+            for (const v of Object.values(credential.localStorage ?? {})) add(v);
+            break;
+        case 'cookie':
+            for (const c of credential.cookies) add(c.value);
+            for (const v of Object.values(credential.xHeaders ?? {})) add(v);
+            for (const v of Object.values(credential.localStorage ?? {})) add(v);
+            break;
+        case 'api-key':
+            add(credential.key);
+            break;
+        case 'basic':
+            add(credential.password);
+            break;
+    }
+
+    return [...new Set(values)];
+}
+
+export function redactOutput(text: string, secrets: string[]): string {
+    const active = secrets.filter((s) => s.length >= MIN_SECRET_LENGTH);
+    if (active.length === 0) return text;
+    let result = text;
+    for (const secret of active) {
+        result = result.split(secret).join('****');
+    }
+    return result;
+}
+
+export function createRedactTransform(secrets: string[]): Transform {
+    const active = secrets.filter((s) => s.length >= MIN_SECRET_LENGTH);
+    const maxLen = active.length > 0 ? Math.max(...active.map((s) => s.length)) : 0;
+
+    let buffer = '';
+
+    return new Transform({
+        transform(chunk: Buffer, _encoding: string, callback: () => void) {
+            buffer += chunk.toString();
+            if (buffer.length > maxLen * 2) {
+                const safe = buffer.slice(0, buffer.length - maxLen);
+                this.push(redactOutput(safe, active));
+                buffer = buffer.slice(buffer.length - maxLen);
+            }
+            callback();
+        },
+        flush(callback: () => void) {
+            if (buffer.length > 0) {
+                this.push(redactOutput(buffer, active));
+                buffer = '';
+            }
+            callback();
+        },
+    });
+}

--- a/cli/tests/unit/cli/run.test.ts
+++ b/cli/tests/unit/cli/run.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { AuthManager } from '../../../src/auth-manager.js';
+import { MemoryStorage } from '../../../src/storage/memory-storage.js';
+import { ProviderRegistry } from '../../../src/providers/provider-registry.js';
+import { StrategyRegistry } from '../../../src/strategies/registry.js';
+import { CookieStrategyFactory } from '../../../src/strategies/cookie.strategy.js';
+import { OAuth2StrategyFactory } from '../../../src/strategies/oauth2.strategy.js';
+import { ApiTokenStrategyFactory } from '../../../src/strategies/api-token.strategy.js';
+import { BasicAuthStrategyFactory } from '../../../src/strategies/basic-auth.strategy.js';
+import { runRun } from '../../../src/cli/commands/run.js';
+import type { AuthDeps } from '../../../src/deps.js';
+import type { ProviderConfig } from '../../../src/core/types.js';
+import type { IBrowserAdapter } from '../../../src/core/interfaces/browser-adapter.js';
+import type { BrowserConfig, SigConfig } from '../../../src/config/schema.js';
+
+const browserConfig: BrowserConfig = {
+    browserDataDir: '/tmp/test-browser-data',
+    channel: 'chrome',
+    headlessTimeout: 30_000,
+    visibleTimeout: 120_000,
+    waitUntil: 'load',
+};
+
+const nullBrowserFactory = (): IBrowserAdapter => ({
+    name: 'null',
+    launch: () => {
+        throw new Error('Browser not available in test');
+    },
+});
+
+const apiTokenProvider: ProviderConfig = {
+    id: 'test-api',
+    name: 'Test API',
+    domains: ['api.test.com'],
+    entryUrl: 'https://api.test.com/',
+    strategy: 'api-token',
+    strategyConfig: { strategy: 'api-token' },
+};
+
+function createDeps(overrides: Partial<AuthDeps> = {}): AuthDeps {
+    const storage = new MemoryStorage();
+    const providerRegistry = new ProviderRegistry();
+    providerRegistry.register(apiTokenProvider);
+    const strategyRegistry = new StrategyRegistry();
+    strategyRegistry.register(new CookieStrategyFactory());
+    strategyRegistry.register(new OAuth2StrategyFactory());
+    strategyRegistry.register(new ApiTokenStrategyFactory());
+    strategyRegistry.register(new BasicAuthStrategyFactory());
+    const config: SigConfig = {
+        mode: 'browser',
+        browser: browserConfig,
+        storage: { credentialsDir: '/tmp/test-creds' },
+        providers: {},
+    };
+    const authManager = new AuthManager({
+        storage,
+        strategyRegistry,
+        providerRegistry,
+        browserAdapterFactory: nullBrowserFactory,
+        browserConfig,
+    });
+    return {
+        authManager,
+        storage,
+        providerRegistry,
+        strategyRegistry,
+        config,
+        browserAvailable: true,
+        ...overrides,
+    };
+}
+
+describe('runRun', () => {
+    let stderrData: string;
+    const origStderrWrite = process.stderr.write.bind(process.stderr);
+    const origExitCode = process.exitCode;
+
+    beforeEach(() => {
+        stderrData = '';
+        process.stderr.write = (chunk: string | Uint8Array) => {
+            stderrData += chunk.toString();
+            return true;
+        };
+        process.exitCode = undefined;
+    });
+
+    afterEach(() => {
+        process.stderr.write = origStderrWrite;
+        process.exitCode = origExitCode;
+    });
+
+    it('fails with usage error when --provider is missing', async () => {
+        const deps = createDeps();
+        await runRun([], {}, deps);
+        expect(stderrData).toContain('--provider');
+        expect(process.exitCode).toBe(1);
+    });
+
+    it('fails with usage error when no command after --', async () => {
+        const deps = createDeps();
+        await runRun([], { provider: 'test-api' }, deps);
+        expect(stderrData).toMatch(/command|Usage/i);
+        expect(process.exitCode).toBe(1);
+    });
+
+    it('fails with error message when provider not found', async () => {
+        const deps = createDeps();
+        await runRun([], { provider: 'nonexistent' }, deps);
+        expect(stderrData).toMatch(/not found|nonexistent/i);
+        expect(process.exitCode).toBe(1);
+    });
+
+    it('suggests sig login when no credential stored', async () => {
+        const deps = createDeps();
+        // provider exists but no credential stored
+        await runRun(['echo', 'hello'], { provider: 'test-api' }, deps);
+        expect(stderrData).toMatch(/sig login/i);
+        expect(process.exitCode).toBe(1);
+    });
+
+    it('spawns child and passes exit code 0', async () => {
+        const deps = createDeps();
+        await deps.authManager.setCredential('test-api', {
+            type: 'api-key',
+            key: 'test-key-12345',
+            headerName: 'Authorization',
+            headerPrefix: 'Bearer',
+        });
+        await runRun(['true'], { provider: 'test-api' }, deps);
+        expect(process.exitCode).toBeUndefined();
+    });
+
+    it('passes through non-zero exit code from child', async () => {
+        const deps = createDeps();
+        await deps.authManager.setCredential('test-api', {
+            type: 'api-key',
+            key: 'test-key-12345',
+            headerName: 'Authorization',
+            headerPrefix: 'Bearer',
+        });
+        await runRun(['sh', '-c', 'exit 42'], { provider: 'test-api' }, deps);
+        expect(process.exitCode).toBe(42);
+    });
+
+    it('injects SIG_* env vars into child environment', async () => {
+        const deps = createDeps();
+        await deps.authManager.setCredential('test-api', {
+            type: 'api-key',
+            key: 'test-key-12345',
+            headerName: 'Authorization',
+            headerPrefix: 'Bearer',
+        });
+
+        let capturedOutput = '';
+        const origWrite = process.stdout.write.bind(process.stdout);
+        process.stdout.write = (chunk: string | Uint8Array) => {
+            capturedOutput += chunk.toString();
+            return true;
+        };
+
+        try {
+            await runRun(
+                ['sh', '-c', 'echo SIG_API_KEY=$SIG_API_KEY'],
+                { provider: 'test-api', 'no-redaction': true },
+                deps,
+            );
+        } finally {
+            process.stdout.write = origWrite;
+        }
+
+        expect(capturedOutput).toContain('SIG_API_KEY=test-key-12345');
+    });
+
+    it('redacts credential values from child output by default', async () => {
+        const deps = createDeps();
+        await deps.authManager.setCredential('test-api', {
+            type: 'api-key',
+            key: 'supersecretkey9999',
+            headerName: 'Authorization',
+            headerPrefix: 'Bearer',
+        });
+
+        let capturedOutput = '';
+        const origWrite = process.stdout.write.bind(process.stdout);
+        process.stdout.write = (chunk: string | Uint8Array) => {
+            capturedOutput += chunk.toString();
+            return true;
+        };
+
+        try {
+            await runRun(['sh', '-c', 'echo supersecretkey9999'], { provider: 'test-api' }, deps);
+        } finally {
+            process.stdout.write = origWrite;
+        }
+
+        expect(capturedOutput).not.toContain('supersecretkey9999');
+        expect(capturedOutput).toContain('****');
+    });
+});

--- a/cli/tests/unit/core/constants.test.ts
+++ b/cli/tests/unit/core/constants.test.ts
@@ -34,11 +34,13 @@ describe('constants', () => {
             expect(Command.WATCH).toBe('watch');
             expect(Command.RENAME).toBe('rename');
             expect(Command.REMOVE).toBe('remove');
+            expect(Command.COMPLETION).toBe('completion');
+            expect(Command.RUN).toBe('run');
             expect(Command.HELP).toBe('help');
         });
 
         it('has exactly the expected number of commands', () => {
-            expect(Object.keys(Command)).toHaveLength(15);
+            expect(Object.keys(Command)).toHaveLength(16);
         });
 
         it('values are all lowercase strings', () => {

--- a/cli/tests/unit/utils/credential-env.test.ts
+++ b/cli/tests/unit/utils/credential-env.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import { credentialToEnvVars } from '../../../src/utils/credential-env.js';
+import type {
+    CookieCredential,
+    BearerCredential,
+    ApiKeyCredential,
+    BasicCredential,
+    Cookie,
+} from '../../../src/core/types.js';
+
+function makeCookie(name: string, value: string): Cookie {
+    return {
+        name,
+        value,
+        domain: 'example.com',
+        path: '/',
+        expires: -1,
+        httpOnly: false,
+        secure: false,
+    };
+}
+
+describe('credentialToEnvVars', () => {
+    describe('bearer credential', () => {
+        it('injects SIG_PROVIDER, SIG_CREDENTIAL_TYPE, SIG_TOKEN, SIG_AUTH_HEADER', () => {
+            const cred: BearerCredential = {
+                type: 'bearer',
+                accessToken: 'eyJhbGciOiJSUzI1NiJ9',
+            };
+            const env = credentialToEnvVars(cred, 'ms-teams', {});
+            expect(env['SIG_PROVIDER']).toBe('ms-teams');
+            expect(env['SIG_CREDENTIAL_TYPE']).toBe('bearer');
+            expect(env['SIG_TOKEN']).toBe('eyJhbGciOiJSUzI1NiJ9');
+            expect(env['SIG_AUTH_HEADER']).toBe('Bearer eyJhbGciOiJSUzI1NiJ9');
+        });
+    });
+
+    describe('cookie credential', () => {
+        it('injects SIG_COOKIE as joined string and SIG_CREDENTIAL_TYPE', () => {
+            const cred: CookieCredential = {
+                type: 'cookie',
+                cookies: [makeCookie('session', 'abc'), makeCookie('d', 'xyz')],
+                obtainedAt: new Date().toISOString(),
+            };
+            const env = credentialToEnvVars(cred, 'loki-orca', {});
+            expect(env['SIG_COOKIE']).toBe('session=abc; d=xyz');
+            expect(env['SIG_CREDENTIAL_TYPE']).toBe('cookie');
+            expect(env['SIG_AUTH_HEADER']).toBeUndefined();
+        });
+
+        it('expands individual cookies when expandCookies=true', () => {
+            const cred: CookieCredential = {
+                type: 'cookie',
+                cookies: [makeCookie('session', 'abc'), makeCookie('d', 'xyz')],
+                obtainedAt: new Date().toISOString(),
+            };
+            const env = credentialToEnvVars(cred, 'x', { expandCookies: true });
+            expect(env['SIG_COOKIE_SESSION']).toBe('abc');
+            expect(env['SIG_COOKIE_D']).toBe('xyz');
+        });
+
+        it('does not expand cookies when expandCookies is not set', () => {
+            const cred: CookieCredential = {
+                type: 'cookie',
+                cookies: [makeCookie('session', 'abc')],
+                obtainedAt: new Date().toISOString(),
+            };
+            const env = credentialToEnvVars(cred, 'x', {});
+            expect(env['SIG_COOKIE_SESSION']).toBeUndefined();
+        });
+    });
+
+    describe('api-key credential', () => {
+        it('injects SIG_API_KEY and SIG_AUTH_HEADER with prefix', () => {
+            const cred: ApiKeyCredential = {
+                type: 'api-key',
+                key: 'ghp_xxxx',
+                headerName: 'Authorization',
+                headerPrefix: 'Bearer',
+            };
+            const env = credentialToEnvVars(cred, 'github', {});
+            expect(env['SIG_API_KEY']).toBe('ghp_xxxx');
+            expect(env['SIG_AUTH_HEADER']).toBe('Bearer ghp_xxxx');
+            expect(env['SIG_CREDENTIAL_TYPE']).toBe('api-key');
+        });
+
+        it('injects SIG_AUTH_HEADER without prefix when no headerPrefix', () => {
+            const cred: ApiKeyCredential = {
+                type: 'api-key',
+                key: 'secret123',
+                headerName: 'X-API-Key',
+            };
+            const env = credentialToEnvVars(cred, 'my-api', {});
+            expect(env['SIG_AUTH_HEADER']).toBe('secret123');
+        });
+    });
+
+    describe('basic credential', () => {
+        it('injects SIG_USERNAME, SIG_PASSWORD, SIG_AUTH_HEADER as Basic base64', () => {
+            const cred: BasicCredential = {
+                type: 'basic',
+                username: 'admin',
+                password: 'secret',
+            };
+            const env = credentialToEnvVars(cred, 'my-api', {});
+            expect(env['SIG_USERNAME']).toBe('admin');
+            expect(env['SIG_PASSWORD']).toBe('secret');
+            expect(env['SIG_AUTH_HEADER']).toBe('Basic YWRtaW46c2VjcmV0');
+            expect(env['SIG_CREDENTIAL_TYPE']).toBe('basic');
+        });
+    });
+
+    describe('xHeaders', () => {
+        it('maps xHeaders to SIG_HEADER_<NAME> with dashes replaced by underscores', () => {
+            const cred: CookieCredential = {
+                type: 'cookie',
+                cookies: [],
+                obtainedAt: new Date().toISOString(),
+                xHeaders: { 'x-csrf-token': 'abc123', 'x-api-version': 'v2' },
+            };
+            const env = credentialToEnvVars(cred, 'x', {});
+            expect(env['SIG_HEADER_X_CSRF_TOKEN']).toBe('abc123');
+            expect(env['SIG_HEADER_X_API_VERSION']).toBe('v2');
+        });
+    });
+
+    describe('localStorage', () => {
+        it('maps localStorage to SIG_LOCAL_<NAME> uppercased', () => {
+            const cred: CookieCredential = {
+                type: 'cookie',
+                cookies: [],
+                obtainedAt: new Date().toISOString(),
+                localStorage: { token: 'xoxc-xxx', 'boot-data': 'xyz' },
+            };
+            const env = credentialToEnvVars(cred, 'x', {});
+            expect(env['SIG_LOCAL_TOKEN']).toBe('xoxc-xxx');
+            expect(env['SIG_LOCAL_BOOT_DATA']).toBe('xyz');
+        });
+    });
+
+    describe('SIG_PROVIDER always set', () => {
+        it('always includes SIG_PROVIDER for any credential type', () => {
+            const cred: BasicCredential = { type: 'basic', username: 'u', password: 'p' };
+            const env = credentialToEnvVars(cred, 'test-provider', {});
+            expect(env['SIG_PROVIDER']).toBe('test-provider');
+        });
+    });
+});

--- a/cli/tests/unit/utils/redact.test.ts
+++ b/cli/tests/unit/utils/redact.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import {
+    extractSensitiveValues,
+    redactOutput,
+    createRedactTransform,
+} from '../../../src/utils/redact.js';
+import type { CookieCredential, BearerCredential } from '../../../src/core/types.js';
+import type { Cookie } from '../../../src/core/types.js';
+
+function makeCookie(name: string, value: string): Cookie {
+    return {
+        name,
+        value,
+        domain: 'example.com',
+        path: '/',
+        expires: -1,
+        httpOnly: false,
+        secure: false,
+    };
+}
+
+describe('extractSensitiveValues', () => {
+    it('extracts bearer accessToken', () => {
+        const cred: BearerCredential = { type: 'bearer', accessToken: 'eyJhbGciOiJSUzI1NiJ9' };
+        const secrets = extractSensitiveValues(cred);
+        expect(secrets).toContain('eyJhbGciOiJSUzI1NiJ9');
+    });
+
+    it('extracts cookie values (long enough)', () => {
+        const cred: CookieCredential = {
+            type: 'cookie',
+            cookies: [makeCookie('session', 'abcdef123456'), makeCookie('short', 'abc')],
+            obtainedAt: new Date().toISOString(),
+        };
+        const secrets = extractSensitiveValues(cred);
+        expect(secrets).toContain('abcdef123456');
+        expect(secrets).not.toContain('abc');
+    });
+
+    it('extracts xHeader values', () => {
+        const cred: CookieCredential = {
+            type: 'cookie',
+            cookies: [],
+            obtainedAt: new Date().toISOString(),
+            xHeaders: { 'x-csrf-token': 'longcsrftokenvalue' },
+        };
+        const secrets = extractSensitiveValues(cred);
+        expect(secrets).toContain('longcsrftokenvalue');
+    });
+
+    it('extracts localStorage values', () => {
+        const cred: CookieCredential = {
+            type: 'cookie',
+            cookies: [],
+            obtainedAt: new Date().toISOString(),
+            localStorage: { token: 'xoxc-longtoken12345' },
+        };
+        const secrets = extractSensitiveValues(cred);
+        expect(secrets).toContain('xoxc-longtoken12345');
+    });
+});
+
+describe('redactOutput', () => {
+    it('replaces a known secret with ****', () => {
+        const result = redactOutput('token is eyJhbGciOiJSUzI1NiJ9 end', ['eyJhbGciOiJSUzI1NiJ9']);
+        expect(result).toBe('token is **** end');
+    });
+
+    it('replaces multiple secrets in a single string', () => {
+        const result = redactOutput('a=abcdef123456 b=longcookievalue99', [
+            'abcdef123456',
+            'longcookievalue99',
+        ]);
+        expect(result).toBe('a=**** b=****');
+    });
+
+    it('does not replace short values (< 8 chars)', () => {
+        const result = redactOutput('value is abc end', ['abc']);
+        expect(result).toBe('value is abc end');
+    });
+
+    it('returns text unchanged when no secrets', () => {
+        const result = redactOutput('hello world', []);
+        expect(result).toBe('hello world');
+    });
+
+    it('replaces all occurrences of a secret', () => {
+        const result = redactOutput('token=abcdef12345 token=abcdef12345', ['abcdef12345']);
+        expect(result).toBe('token=**** token=****');
+    });
+});
+
+describe('createRedactTransform', () => {
+    it('passes through text without secrets unchanged', async () => {
+        const transform = createRedactTransform([]);
+        const chunks: string[] = [];
+        transform.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
+
+        await new Promise<void>((resolve) => {
+            transform.on('end', resolve);
+            transform.write('hello world\n');
+            transform.end();
+        });
+
+        expect(chunks.join('')).toContain('hello world');
+    });
+
+    it('redacts secrets in streaming data', async () => {
+        const secret = 'supersecrettoken12345';
+        const transform = createRedactTransform([secret]);
+        const chunks: string[] = [];
+        transform.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
+
+        await new Promise<void>((resolve) => {
+            transform.on('end', resolve);
+            transform.write(`my token is ${secret} done\n`);
+            transform.end();
+        });
+
+        const output = chunks.join('');
+        expect(output).not.toContain(secret);
+        expect(output).toContain('****');
+    });
+});

--- a/skills/sigcli-auth/SKILL.md
+++ b/skills/sigcli-auth/SKILL.md
@@ -14,27 +14,28 @@ sigcli (`sig`) is a CLI tool that stores and manages authentication credentials 
 
 ## Available Commands
 
-| Command                        | Description                             | When to Use                               | Typical Latency                  |
-| ------------------------------ | --------------------------------------- | ----------------------------------------- | -------------------------------- |
-| `sig init`                     | Create/initialize config                | First-time setup                          | < 1s                             |
-| `sig doctor`                   | Validate environment and config         | Troubleshoot setup issues                 | 1–3s                             |
-| `sig login <url\|id>`          | Authenticate with a service             | No stored credentials, or expired         | 30–120s (browser) / < 1s (token) |
-| `sig logout [provider]`        | Clear stored credentials                | Reset auth state                          | < 1s                             |
-| `sig get <provider\|url>`      | Retrieve credential headers             | Get headers for curl or scripts           | < 1s                             |
-| `sig request <url>`            | Make authenticated HTTP request         | Test an endpoint with auth applied        | 1–5s                             |
-| `sig status [provider]`        | Show auth status for all/one provider   | Check if logged in before acting          | 1–3s                             |
-| `sig providers`                | List configured providers               | Discover what is configured               | 1–3s                             |
-| `sig rename <old> <new>`       | Rename a provider                       | Reorganize providers                      | < 1s                             |
-| `sig remove <provider>`        | Delete provider and credentials         | Clean up                                  | < 1s                             |
-| `sig remote add <name> <host>` | Add SSH remote for credential sync      | Set up headless machine sync              | < 1s                             |
-| `sig remote remove <name>`     | Remove SSH remote                       | Clean up                                  | < 1s                             |
-| `sig remote list`              | List configured remotes                 | Inspect sync targets                      | < 1s                             |
-| `sig sync push\|pull [remote]` | Sync credentials over SSH               | Share credentials with headless machines  | 5–30s                            |
-| `sig watch add <provider>`     | Add provider to auto-refresh watch list | Keep long-lived sessions alive            | < 1s                             |
-| `sig watch remove <provider>`  | Remove from watch list                  | Stop auto-refresh                         | < 1s                             |
-| `sig watch list`               | Show watched providers                  | Inspect watch config                      | < 1s                             |
-| `sig watch start`              | Start auto-refresh daemon               | Run in background for session maintenance | Continuous                       |
-| `sig watch set-interval <dur>` | Set default watch interval              | Tune refresh frequency                    | < 1s                             |
+| Command                            | Description                             | When to Use                               | Typical Latency                  |
+| ---------------------------------- | --------------------------------------- | ----------------------------------------- | -------------------------------- |
+| `sig init`                         | Create/initialize config                | First-time setup                          | < 1s                             |
+| `sig doctor`                       | Validate environment and config         | Troubleshoot setup issues                 | 1–3s                             |
+| `sig login <url\|id>`              | Authenticate with a service             | No stored credentials, or expired         | 30–120s (browser) / < 1s (token) |
+| `sig logout [provider]`            | Clear stored credentials                | Reset auth state                          | < 1s                             |
+| `sig get <provider\|url>`          | Retrieve credential headers             | Get headers for curl or scripts           | < 1s                             |
+| `sig request <url>`                | Make authenticated HTTP request         | Test an endpoint with auth applied        | 1–5s                             |
+| `sig status [provider]`            | Show auth status for all/one provider   | Check if logged in before acting          | 1–3s                             |
+| `sig providers`                    | List configured providers               | Discover what is configured               | 1–3s                             |
+| `sig rename <old> <new>`           | Rename a provider                       | Reorganize providers                      | < 1s                             |
+| `sig remove <provider>`            | Delete provider and credentials         | Clean up                                  | < 1s                             |
+| `sig remote add <name> <host>`     | Add SSH remote for credential sync      | Set up headless machine sync              | < 1s                             |
+| `sig remote remove <name>`         | Remove SSH remote                       | Clean up                                  | < 1s                             |
+| `sig remote list`                  | List configured remotes                 | Inspect sync targets                      | < 1s                             |
+| `sig sync push\|pull [remote]`     | Sync credentials over SSH               | Share credentials with headless machines  | 5–30s                            |
+| `sig watch add <provider>`         | Add provider to auto-refresh watch list | Keep long-lived sessions alive            | < 1s                             |
+| `sig watch remove <provider>`      | Remove from watch list                  | Stop auto-refresh                         | < 1s                             |
+| `sig watch list`                   | Show watched providers                  | Inspect watch config                      | < 1s                             |
+| `sig watch start`                  | Start auto-refresh daemon               | Run in background for session maintenance | Continuous                       |
+| `sig watch set-interval <dur>`     | Set default watch interval              | Tune refresh frequency                    | < 1s                             |
+| `sig run --provider <id> -- <cmd>` | Run command with credentials in env     | Scripts that need SIG\_\* env vars        | < 1s + child process             |
 
 ---
 
@@ -89,6 +90,30 @@ sig status <provider> --format json
 # Exit 3                  → no credentials, run sig login
 # Exit 0 + expired        → run: sig logout <provider> && sig login <url>
 ```
+
+### Run scripts with credentials injected (recommended for scripts)
+
+Use `sig run` to inject credentials as `SIG_*` environment variables without exposing them in shell history or `ps` output. Credential values are automatically redacted from child stdout/stderr.
+
+```bash
+# Run a script with credentials available as SIG_* env vars
+sig run --provider grafana -- python fetch_data.py
+
+# The child process can read:
+#   SIG_PROVIDER, SIG_CREDENTIAL_TYPE, SIG_TOKEN / SIG_COOKIE / SIG_API_KEY etc.
+#   SIG_AUTH_HEADER — complete Authorization header value
+
+# Expand individual cookies as SIG_COOKIE_<NAME>=value
+sig run --provider loki-orca --expand-cookies -- python script.py
+
+# Write credentials to a .env file (deleted after child exits)
+sig run --provider grafana --mount .env -- node app.js
+
+# Disable redaction (see raw values in output — use with caution)
+sig run --provider grafana --no-redaction -- env | grep SIG_
+```
+
+**Why prefer `sig run` over `sig get`:** `sig get` exposes credentials in shell variables visible to `ps`, shell history, and AI agent context. `sig run` injects credentials directly into the child environment and redacts them from output.
 
 ### Make authenticated requests (preferred — no credential leakage)
 


### PR DESCRIPTION
## Summary

- New `sig run --provider <id> -- <cmd>` command spawns a child process with credentials injected as `SIG_*` environment variables
- Output redaction masks known credential values from child stdout/stderr by default (disable with `--no-redaction`)
- Mount mode (`--mount <path>`) writes credentials to a temp file (env or JSON format), cleaned up on exit or signal
- Non-interactive credential cascade: stored → refresh → error; never opens a browser
- `--expand-cookies` expands individual cookie values as `SIG_COOKIE_<NAME>=value`

## Files changed

| File | Type | Description |
|------|------|-------------|
| `cli/src/utils/credential-env.ts` | new | Maps any credential type → `SIG_*` env vars |
| `cli/src/utils/redact.ts` | new | Secret extraction, string redaction, stream transform |
| `cli/src/cli/commands/run.ts` | new | `sig run` command handler |
| `cli/src/cli/main.ts` | modified | Wire `RUN` command, `--` separator in parseArgs, help text |
| `cli/src/core/constants.ts` | modified | Add `RUN: 'run'` |
| `cli/tests/unit/utils/credential-env.test.ts` | new | 10 tests for env var mapping |
| `cli/tests/unit/utils/redact.test.ts` | new | 11 tests for redaction |
| `cli/tests/unit/cli/run.test.ts` | new | 8 tests for command behavior |
| `cli/tests/unit/core/constants.test.ts` | modified | Bump command count to 16 |
| `README.md`, `CLAUDE.md`, `cli/CLAUDE.md`, `skills/sigcli-auth/SKILL.md` | modified | Document sig run |

## Test plan

- [ ] All 599 CLI unit tests pass (`cd cli && npm test`)
- [ ] `sig run --provider <provider> -- env | grep SIG_` shows injected variables
- [ ] `sig run --provider <provider> -- sh -c 'echo $SIG_COOKIE'` shows `****` in output
- [ ] `sig run --provider <provider> --no-redaction -- sh -c 'echo $SIG_COOKIE'` shows real value
- [ ] `sig run --provider nonexistent -- echo hello` shows error with `sig login` suggestion
- [ ] `sig run --provider <provider> -- sh -c 'exit 42'; echo $?` returns `42`
- [ ] `sig run --provider <provider> --mount .env -- cat .env` shows SIG_* lines; file deleted after