### PR TITLE
feat(cli): add zero-trust MITM proxy daemon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ core/ (types, interfaces, Result, errors) ── zero external deps, imported by
 - **`src/crypto/`** — Encryption at rest. AES-256-GCM encrypt/decrypt, key generation/loading. Key stored at `~/.sig/encryption.key`.
 - **`src/providers/`** — ProviderRegistry, config-loader.
 - **`src/sync/`** — SyncEngine + SshTransport (encrypts with remote key).
+- **`src/proxy/`** — MITM proxy daemon. CaManager (ECDSA P-256 CA + per-hostname leaf certs), ProxyServer (HTTP/HTTPS CONNECT with credential injection), daemon (proxy + watch loop), proxy-state (PID/port files at `~/.sig/proxy/`).
 - **`src/utils/`** — JWT decode, duration parse, HTTP helpers.
 
 ### Key Interfaces
@@ -81,6 +82,7 @@ core/ (types, interfaces, Result, errors) ── zero external deps, imported by
 9. **Config**: `StrategyConfig = Record<string, unknown>` — parsed inside each strategy via a private `parseConfig()`.
 10. **Exports**: Public API through `src/index.ts`.
 11. **Encryption**: All credentials encrypted at rest with AES-256-GCM. Key at `~/.sig/encryption.key` (0o400). DirectoryStorage and SshTransport handle encrypt/decrypt transparently. Legacy unencrypted files are read but re-written encrypted.
+12. **Proxy**: Local MITM daemon at `127.0.0.1`. CaManager generates ECDSA P-256 CA + leaf certs. ProxyServer handles HTTP proxy + HTTPS CONNECT. Daemon runs proxy + watch loop. State files at `~/.sig/proxy/`.
 
 ### CLI Usage
 
@@ -98,7 +100,8 @@ sig rename <old> <new>     # Rename a provider
 sig remove <provider>      # Remove provider and credentials
 sig remote add|remove|list # Manage remote credential stores
 sig sync push|pull [remote]# Sync credentials with remote
-sig watch add|remove|list|start  # Auto-refresh credentials
+sig watch add|remove|set-interval  # Auto-refresh credentials
+sig proxy start|stop|status|trust  # MITM proxy daemon for zero-trust credential injection
 sig completion <shell>     # Generate shell completion (bash|zsh|fish)
 sig run [provider...] -- <cmd>  # Run command with SIG_<PROVIDER>_* credentials injected
 ```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ sig login https://jira.example.com            # Authenticate via browser SSO
 
 sig request https://jira.example.com/rest/api/2/myself                                   # Authenticated request
 sig run my-jira -- bash -c 'python fetch.py --cookie "$SIG_MY_JIRA_COOKIE"'              # Credentials as env vars
+
+# Or use a local MITM proxy — agents set HTTP_PROXY and credentials are injected transparently
+sig proxy start
+export HTTP_PROXY=http://127.0.0.1:7891 HTTPS_PROXY=http://127.0.0.1:7891
+curl https://jira.example.com/api/me   # credentials injected by proxy, agent never sees them
 ```
 
 Credentials are injected as `SIG_<PROVIDER>_*` env vars and never appear in your shell or logs. All credential files are encrypted at rest (AES-256-GCM).
@@ -61,9 +66,18 @@ Credentials are injected as `SIG_<PROVIDER>_*` env vars and never appear in your
 
 **Watch**
 
-| Command                              | Description              |
-| ------------------------------------ | ------------------------ |
-| `sig watch add\|remove\|list\|start` | Auto-refresh credentials |
+| Command                               | Description              |
+| ------------------------------------- | ------------------------ |
+| `sig watch add\|remove\|set-interval` | Auto-refresh credentials |
+
+**Proxy**
+
+| Command                      | Description                        |
+| ---------------------------- | ---------------------------------- |
+| `sig proxy start [--port N]` | Start MITM proxy daemon            |
+| `sig proxy stop`             | Stop proxy daemon                  |
+| `sig proxy status`           | Show proxy status                  |
+| `sig proxy trust`            | Print CA cert path for trust setup |
 
 Run `sig --help` or `sig <command> --help` for full options.
 

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -19,7 +19,7 @@ core/ (types, interfaces, Result, errors) ── zero external deps, imported by
 - **`src/deps.ts`** — Composition root. Creates registries, storage, browser factory, AuthManager. No singletons. Shared by CLI and programmatic API.
 - **`src/auth-manager.ts`** — Orchestrator. Flow: stored cred → validate → refresh → authenticate. All methods return `Result<T, AuthError>`.
 - **`src/core/`** — Shared vocabulary. Zero external dependencies.
-- **`src/cli/`** — CLI commands (init, doctor, get, login, request, status, logout, providers, remote, sync, watch, rename, remove, completion). Each command is a standalone module. `init`, `doctor`, and `completion` run without deps (before config exists).
+- **`src/cli/`** — CLI commands (init, doctor, get, login, request, status, logout, providers, remote, sync, watch, rename, remove, completion, proxy). Each command is a standalone module. `init`, `doctor`, and `completion` run without deps (before config exists).
 - **`src/strategies/`** — Each strategy: private class + exported `*StrategyFactory` (IAuthStrategyFactory).
 - **`src/browser/adapters/`** — Browser automation. PlaywrightAdapter is the reference. Three-class pattern: Adapter → Session → Page.
 - **`src/browser/flows/`** — `runHybridFlow` (headless→visible fallback), `extractOAuthTokens`, `isLoginPage`, `startHeaderCapture` (x-headers).
@@ -27,6 +27,7 @@ core/ (types, interfaces, Result, errors) ── zero external deps, imported by
 - **`src/crypto/`** — Encryption at rest. AES-256-GCM encrypt/decrypt, key generation/loading. Key stored at `~/.sig/encryption.key`.
 - **`src/providers/`** — ProviderRegistry (URL→provider via domain matching), config-loader (YAML/JSON).
 - **`src/sync/`** — SyncEngine + SshTransport for credential sync to remote machines. Encrypts with per-remote key. RemoteConfig in `~/.sig/config.yaml`.
+- **`src/proxy/`** — MITM proxy daemon. CaManager (ECDSA P-256 CA + per-hostname leaf certs), ProxyServer (HTTP/HTTPS CONNECT with credential injection), daemon (proxy + watch loop), proxy-state (PID/port files at `~/.sig/proxy/`).
 - **`src/utils/`** — JWT decode, duration parse, HTTP helpers.
 
 ## Key Interfaces
@@ -85,7 +86,8 @@ sig rename <old> <new>     # Rename a provider
 sig remove <provider>      # Remove provider and credentials
 sig remote add|remove|list # Manage remote credential stores
 sig sync push|pull [remote]# Sync credentials with remote
-sig watch add|remove|list|start  # Auto-refresh credentials
+sig watch add|remove|set-interval  # Auto-refresh credentials
+sig proxy start|stop|status|trust  # MITM proxy daemon for zero-trust credential injection
 sig completion <shell>     # Generate shell completion (bash|zsh|fish)
 sig run [provider...] -- <cmd>  # Run command with SIG_<PROVIDER>_* credentials injected
 ```

--- a/cli/package.json
+++ b/cli/package.json
@@ -20,6 +20,7 @@
         "test:watch": "vitest"
     },
     "dependencies": {
+        "@peculiar/x509": "^2.0.0",
         "croner": "^10.0.1",
         "dlv": "^1.1.3",
         "playwright-core": "^1.50.0",
@@ -30,6 +31,7 @@
         "@types/dlv": "^1.1.5",
         "@types/node": "^20.10.0",
         "@types/proper-lockfile": "^4.1.4",
+        "reflect-metadata": "^0.2.2",
         "vitest": "^3.0.0"
     },
     "keywords": [

--- a/cli/src/cli/commands/proxy.ts
+++ b/cli/src/cli/commands/proxy.ts
@@ -1,0 +1,148 @@
+import { fork } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { join, dirname } from 'node:path';
+import { readState, isRunning, clearState } from '../../proxy/proxy-state.js';
+import { expandHome } from '../../utils/path.js';
+import { ExitCode } from '../exit-codes.js';
+import type { AuthDeps } from '../../deps.js';
+import { ProxySubcommand } from '../../core/constants.js';
+
+const USAGE = `Usage: sig proxy <subcommand>
+
+Subcommands:
+  start [--port 8080]    Start proxy daemon in background
+  stop                   Stop proxy daemon
+  status                 Show proxy daemon status
+  trust                  Print CA certificate path (add to system trust)
+`;
+
+export async function runProxy(
+    positionals: string[],
+    flags: Record<string, string | boolean | string[]>,
+    deps?: AuthDeps,
+): Promise<void> {
+    const subcommand = positionals[0];
+
+    switch (subcommand) {
+        case ProxySubcommand.START:
+            await handleStart(flags, deps);
+            break;
+        case ProxySubcommand.STOP:
+            await handleStop();
+            break;
+        case ProxySubcommand.STATUS:
+            await handleStatus();
+            break;
+        case ProxySubcommand.TRUST:
+            handleTrust();
+            break;
+        default:
+            process.stderr.write(USAGE);
+            process.exitCode = subcommand ? ExitCode.GENERAL_ERROR : ExitCode.SUCCESS;
+    }
+}
+
+async function handleStart(
+    flags: Record<string, string | boolean | string[]>,
+    deps?: AuthDeps,
+): Promise<void> {
+    if (!deps) {
+        process.stderr.write('Error: Config required. Run "sig init" first.\n');
+        process.exitCode = ExitCode.GENERAL_ERROR;
+        return;
+    }
+
+    if (await isRunning()) {
+        const state = await readState();
+        if (state) {
+            process.stderr.write(
+                `Proxy is already running (pid=${state.pid}, port=${state.port})\n`,
+            );
+        }
+        return;
+    }
+
+    const portFlag = flags.port;
+    const port = typeof portFlag === 'string' ? parseInt(portFlag, 10) : 0;
+
+    // If PROXY_DAEMON=1 env var is set, run in-process (we are the daemon child)
+    if (process.env.PROXY_DAEMON === '1') {
+        const { startDaemon } = await import('../../proxy/daemon.js');
+        const controller = new AbortController();
+        const shutdown = () => controller.abort();
+        process.on('SIGINT', shutdown);
+        process.on('SIGTERM', shutdown);
+        await startDaemon({ port, authDeps: deps }, controller.signal);
+        return;
+    }
+
+    // Fork a detached background child
+    const entry = join(dirname(fileURLToPath(import.meta.url)), '../../../../bin/sig.js');
+
+    const child = fork(entry, ['proxy', 'start', ...(port ? ['--port', String(port)] : [])], {
+        detached: true,
+        stdio: 'ignore',
+        env: { ...process.env, PROXY_DAEMON: '1' },
+    });
+
+    child.unref();
+    process.stderr.write('Proxy daemon started in background.\n');
+    process.stderr.write('Run "sig proxy status" to check, "sig proxy stop" to stop.\n');
+}
+
+async function handleStop(): Promise<void> {
+    const state = await readState();
+    if (!state) {
+        process.stderr.write('Proxy is not running.\n');
+        return;
+    }
+
+    if (!(await isRunning())) {
+        await clearState();
+        process.stderr.write('Proxy was not running (stale state cleared).\n');
+        return;
+    }
+
+    try {
+        process.kill(state.pid, 'SIGTERM');
+        process.stderr.write(`Proxy stopped (pid=${state.pid}).\n`);
+    } catch {
+        process.stderr.write(`Failed to stop proxy (pid=${state.pid}).\n`);
+        process.exitCode = ExitCode.GENERAL_ERROR;
+    }
+}
+
+async function handleStatus(): Promise<void> {
+    const state = await readState();
+    if (!state) {
+        process.stdout.write('Proxy: not running\n');
+        return;
+    }
+
+    const running = await isRunning();
+    if (running) {
+        process.stdout.write(`Proxy: running  pid=${state.pid}  port=${state.port}\n`);
+        process.stdout.write(`  http_proxy=http://127.0.0.1:${state.port}\n`);
+        process.stdout.write(`  https_proxy=http://127.0.0.1:${state.port}\n`);
+    } else {
+        await clearState();
+        process.stdout.write('Proxy: not running (stale state cleared)\n');
+    }
+}
+
+function handleTrust(): void {
+    const caPath = expandHome('~/.sig/proxy/ca.crt');
+    process.stdout.write(`CA certificate: ${caPath}\n\n`);
+    process.stdout.write('To trust the proxy CA:\n');
+    process.stdout.write(
+        '  macOS:   sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ' +
+            caPath +
+            '\n',
+    );
+    process.stdout.write(
+        '  Ubuntu:  sudo cp ' +
+            caPath +
+            ' /usr/local/share/ca-certificates/sigcli-proxy.crt && sudo update-ca-certificates\n',
+    );
+    process.stdout.write('  curl:    curl --cacert ' + caPath + ' ...\n');
+}

--- a/cli/src/cli/commands/watch.ts
+++ b/cli/src/cli/commands/watch.ts
@@ -1,15 +1,11 @@
 import type { AuthDeps } from '../../deps.js';
 import {
-    getWatchConfig,
-    getWatchProviders,
     addWatchProvider,
     removeWatchProvider,
     setWatchInterval,
 } from '../../watch/watch-config.js';
-import { startWatchLoop } from '../../watch/watch-loop.js';
 import { getRemote } from '../../sync/remote-config.js';
-import { parseDuration, formatDuration } from '../../utils/duration.js';
-import { formatJson, formatTable } from '../formatters.js';
+import { parseDuration } from '../../utils/duration.js';
 import { ExitCode } from '../exit-codes.js';
 import { WatchSubcommand } from '../../core/constants.js';
 
@@ -18,8 +14,6 @@ const USAGE = `Usage: sig watch <subcommand>
 Subcommands:
   add <provider> [--auto-sync <remote>]    Add provider to watch list
   remove <provider>                        Remove provider from watch list
-  list                                     Show watched providers
-  start [--interval 5m] [--once]           Start the watch daemon
   set-interval <duration>                  Set default interval (e.g. 5m, 1h)
 `;
 
@@ -36,17 +30,6 @@ export async function runWatch(
             break;
         case WatchSubcommand.REMOVE:
             await handleRemove(positionals.slice(1));
-            break;
-        case WatchSubcommand.LIST:
-            await handleList(flags);
-            break;
-        case WatchSubcommand.START:
-            if (!deps) {
-                process.stderr.write('Error: Config required. Run "sig init" first.\n');
-                process.exitCode = ExitCode.GENERAL_ERROR;
-                return;
-            }
-            await handleStart(flags, deps);
             break;
         case WatchSubcommand.SET_INTERVAL:
             await handleSetInterval(positionals.slice(1));
@@ -125,30 +108,6 @@ async function handleRemove(positionals: string[]): Promise<void> {
     process.stderr.write(`Removed "${providerId}" from watch list.\n`);
 }
 
-async function handleList(flags: Record<string, string | boolean | string[]>): Promise<void> {
-    const config = await getWatchConfig();
-    if (!config || Object.keys(config.providers).length === 0) {
-        process.stderr.write(
-            'No providers in watch list. Use "sig watch add <provider>" to add one.\n',
-        );
-        return;
-    }
-
-    const format = (flags.format as string) ?? (process.stdout.isTTY ? 'table' : 'json');
-    const entries = Object.entries(config.providers).map(([id, opts]) => ({
-        provider: id,
-        autoSync: opts.autoSync.length > 0 ? opts.autoSync.join(', ') : '-',
-    }));
-
-    if (format === 'json') {
-        const providers = await getWatchProviders();
-        process.stdout.write(formatJson({ interval: config.interval, providers }) + '\n');
-    } else {
-        process.stderr.write(`Interval: ${config.interval}\n\n`);
-        process.stdout.write(formatTable(entries) + '\n');
-    }
-}
-
 async function handleSetInterval(positionals: string[]): Promise<void> {
     const interval = positionals[0];
     if (!interval) {
@@ -169,108 +128,4 @@ async function handleSetInterval(positionals: string[]): Promise<void> {
 
     await setWatchInterval(interval);
     process.stderr.write(`Watch interval set to ${interval}.\n`);
-}
-
-async function handleStart(
-    flags: Record<string, string | boolean | string[]>,
-    deps: AuthDeps,
-): Promise<void> {
-    // Load watch config
-    const watchConfig = await getWatchConfig();
-    if (!watchConfig || Object.keys(watchConfig.providers).length === 0) {
-        process.stderr.write('No providers in watch list. Use "sig watch add <provider>" first.\n');
-        process.exitCode = ExitCode.GENERAL_ERROR;
-        return;
-    }
-
-    // Parse interval (flag overrides config)
-    const intervalStr = typeof flags.interval === 'string' ? flags.interval : watchConfig.interval;
-    let intervalMs: number;
-    try {
-        intervalMs = parseDuration(intervalStr);
-    } catch {
-        process.stderr.write(
-            `Invalid interval: "${intervalStr}". Use format like "30s", "5m", "1h".\n`,
-        );
-        process.exitCode = ExitCode.GENERAL_ERROR;
-        return;
-    }
-
-    const once = flags.once === true;
-
-    // Validate all autoSync remotes exist
-    for (const [providerId, opts] of Object.entries(watchConfig.providers)) {
-        for (const remoteName of opts.autoSync) {
-            const remote = await getRemote(remoteName);
-            if (!remote) {
-                process.stderr.write(
-                    `Error: Provider "${providerId}" has autoSync remote "${remoteName}" which does not exist.\n`,
-                );
-                process.exitCode = ExitCode.GENERAL_ERROR;
-                return;
-            }
-        }
-    }
-
-    // Graceful shutdown
-    const controller = new AbortController();
-    const shutdown = () => {
-        process.stderr.write('\nShutting down...\n');
-        controller.abort();
-    };
-    process.on('SIGINT', shutdown);
-    process.on('SIGTERM', shutdown);
-
-    const providerIds = Object.keys(watchConfig.providers);
-    process.stderr.write(
-        `Watching ${providerIds.length} provider(s): ${providerIds.join(', ')}\n` +
-            `Interval: ${formatDuration(intervalMs)}` +
-            (once ? ' | Mode: single cycle' : '') +
-            '\n\n',
-    );
-
-    const logger = {
-        debug: (msg: string) => process.stderr.write(`  ${msg}\n`),
-        info: (msg: string) => process.stderr.write(`  ${msg}\n`),
-        warn: (msg: string) => process.stderr.write(`  WARN: ${msg}\n`),
-        error: (msg: string) => process.stderr.write(`  ERROR: ${msg}\n`),
-    };
-
-    await startWatchLoop(
-        {
-            authManager: deps.authManager,
-            storage: deps.storage,
-            config: deps.config,
-            logger,
-        },
-        { intervalMs, once },
-        getWatchProviders,
-        controller.signal,
-        (result) => {
-            const summary = {
-                cycle: result.cycle,
-                checked: result.checked,
-                refreshed: result.refreshed,
-                synced: result.synced,
-                errors: result.errors,
-            };
-            process.stdout.write(formatJson(summary) + '\n');
-
-            if (result.errors.length === 0 && result.refreshed.length === 0) {
-                process.stderr.write(`  Cycle ${result.cycle}: all valid\n`);
-            } else if (result.errors.length > 0) {
-                process.stderr.write(
-                    `  Cycle ${result.cycle}: ${result.refreshed.length} refreshed, ${result.errors.length} error(s)\n`,
-                );
-            } else {
-                process.stderr.write(
-                    `  Cycle ${result.cycle}: ${result.refreshed.length} refreshed\n`,
-                );
-            }
-        },
-    );
-
-    // Cleanup
-    process.off('SIGINT', shutdown);
-    process.off('SIGTERM', shutdown);
 }

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -20,6 +20,7 @@ import { runRename } from './commands/rename.js';
 import { runRemove } from './commands/remove.js';
 import { runCompletion } from './commands/completion.js';
 import { runRun } from './commands/run.js';
+import { runProxy } from './commands/proxy.js';
 import { ExitCode } from './exit-codes.js';
 
 interface ParsedArgs {
@@ -126,12 +127,13 @@ Watch:
   watch add <provider>         Add provider to watch list
     --auto-sync <remote>         Auto-sync to remote after refresh
   watch remove <provider>      Remove provider from watch list
-  watch list                   Show watched providers
-    --format json|table          Output format
-  watch start                  Start auto-refresh daemon
-    --interval <duration>        Override check interval (e.g. 5m, 1h)
-    --once                       Single check cycle, then exit
   watch set-interval <dur>     Set default check interval
+
+Proxy:
+  proxy start [--port 8080]    Start MITM proxy daemon in background
+  proxy stop                   Stop proxy daemon
+  proxy status                 Show proxy status and env-var hints
+  proxy trust                  Print CA cert path for OS trust setup
 
 Setup:
   init                         Create ~/.sig/config.yaml
@@ -159,6 +161,7 @@ const DEPS_COMMANDS: ReadonlySet<string> = new Set([
     Command.RENAME,
     Command.REMOVE,
     Command.RUN,
+    Command.PROXY,
 ]);
 
 export async function run(args: string[]): Promise<void> {
@@ -244,6 +247,9 @@ export async function run(args: string[]): Promise<void> {
             break;
         case Command.RUN:
             await runRun(positionals, flags, deps as AuthDeps);
+            break;
+        case Command.PROXY:
+            await runProxy(positionals, flags, deps);
             break;
         default:
             process.stderr.write(`Unknown command: ${command}\n\n`);

--- a/cli/src/config/schema.ts
+++ b/cli/src/config/schema.ts
@@ -11,6 +11,7 @@ import type {
     XHeaderConfig,
     LocalStorageConfig,
     StrategyName,
+    ProxyConfig,
 } from '../core/types.js';
 import type { WaitUntilValue } from '../core/constants.js';
 
@@ -22,6 +23,8 @@ export type {
     BasicStrategyConfig,
     StrategyConfig,
     StrategyName,
+    ProxyConfig,
+    ProxyInjectRule,
 } from '../core/types.js';
 
 // ============================================================================
@@ -91,4 +94,5 @@ export interface ProviderEntry {
     xHeaders?: XHeaderConfig[];
     localStorage?: LocalStorageConfig[];
     forceVisible?: boolean;
+    proxy?: ProxyConfig;
 }

--- a/cli/src/config/validator.ts
+++ b/cli/src/config/validator.ts
@@ -419,5 +419,25 @@ function parseProviderEntry(raw: Record<string, unknown>): ProviderEntry {
         ...(Array.isArray(raw.xHeaders) ? { xHeaders: raw.xHeaders } : {}),
         ...(Array.isArray(raw.localStorage) ? { localStorage: raw.localStorage } : {}),
         ...(typeof raw.forceVisible === 'boolean' ? { forceVisible: raw.forceVisible } : {}),
+        ...(raw.proxy && typeof raw.proxy === 'object'
+            ? {
+                  proxy: {
+                      inject: Array.isArray((raw.proxy as Record<string, unknown>).inject)
+                          ? (
+                                (raw.proxy as Record<string, unknown>).inject as Array<
+                                    Record<string, unknown>
+                                >
+                            ).map((r) => ({
+                                in: r.in as 'header' | 'body' | 'query',
+                                ...(r.action !== undefined
+                                    ? { action: r.action as 'set' | 'append' | 'remove' }
+                                    : {}),
+                                name: r.name as string,
+                                ...(r.from !== undefined ? { from: r.from as string } : {}),
+                            }))
+                          : undefined,
+                  },
+              }
+            : {}),
     };
 }

--- a/cli/src/config/validator.ts
+++ b/cli/src/config/validator.ts
@@ -429,9 +429,7 @@ function parseProviderEntry(raw: Record<string, unknown>): ProviderEntry {
                                 >
                             ).map((r) => ({
                                 in: r.in as 'header' | 'body' | 'query',
-                                ...(r.action !== undefined
-                                    ? { action: r.action as 'set' | 'append' | 'remove' }
-                                    : {}),
+                                action: r.action as 'set' | 'append' | 'remove',
                                 name: r.name as string,
                                 ...(r.from !== undefined ? { from: r.from as string } : {}),
                             }))

--- a/cli/src/core/constants.ts
+++ b/cli/src/core/constants.ts
@@ -24,6 +24,7 @@ export const Command = {
     REMOVE: 'remove',
     COMPLETION: 'completion',
     RUN: 'run',
+    PROXY: 'proxy',
     HELP: 'help',
 } as const;
 
@@ -50,9 +51,17 @@ export const SyncSubcommand = {
 export const WatchSubcommand = {
     ADD: 'add',
     REMOVE: 'remove',
-    LIST: 'list',
-    START: 'start',
     SET_INTERVAL: 'set-interval',
+} as const;
+
+/**
+ * Subcommands for the 'proxy' command.
+ */
+export const ProxySubcommand = {
+    START: 'start',
+    STOP: 'stop',
+    STATUS: 'status',
+    TRUST: 'trust',
 } as const;
 
 /**

--- a/cli/src/core/types.ts
+++ b/cli/src/core/types.ts
@@ -122,7 +122,7 @@ export interface LocalStorageConfig {
 
 export interface ProxyInjectRule {
     in: 'header' | 'body' | 'query';
-    action?: 'set' | 'append' | 'remove';
+    action: 'set' | 'append' | 'remove';
     name: string;
     from?: string;
 }

--- a/cli/src/core/types.ts
+++ b/cli/src/core/types.ts
@@ -117,6 +117,21 @@ export interface LocalStorageConfig {
 }
 
 // ============================================================================
+// Proxy Injection Rules
+// ============================================================================
+
+export interface ProxyInjectRule {
+    in: 'header' | 'body' | 'query';
+    action?: 'set' | 'append' | 'remove';
+    name: string;
+    from?: string;
+}
+
+export interface ProxyConfig {
+    inject?: ProxyInjectRule[];
+}
+
+// ============================================================================
 // Provider Configuration
 // ============================================================================
 
@@ -133,6 +148,7 @@ export interface ProviderConfig {
     localStorage?: LocalStorageConfig[]; // localStorage values to extract during browser auth
     autoProvisioned?: boolean; // True if created by auto-provision (not from config file)
     forceVisible?: boolean; // Skip headless, go straight to visible browser mode
+    proxy?: ProxyConfig; // MITM proxy injection rules
 }
 
 // ============================================================================

--- a/cli/src/deps.ts
+++ b/cli/src/deps.ts
@@ -78,6 +78,7 @@ export async function createAuthDeps(
             xHeaders: entry.xHeaders,
             localStorage: entry.localStorage,
             ...(entry.forceVisible !== undefined ? { forceVisible: entry.forceVisible } : {}),
+            ...(entry.proxy !== undefined ? { proxy: entry.proxy } : {}),
         }),
     );
 

--- a/cli/src/proxy/ca-manager.ts
+++ b/cli/src/proxy/ca-manager.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import {
     X509CertificateGenerator,
     X509Certificate,

--- a/cli/src/proxy/ca-manager.ts
+++ b/cli/src/proxy/ca-manager.ts
@@ -1,0 +1,153 @@
+import {
+    X509CertificateGenerator,
+    X509Certificate,
+    KeyUsagesExtension,
+    KeyUsageFlags,
+    BasicConstraintsExtension,
+    SubjectAlternativeNameExtension,
+    cryptoProvider,
+} from '@peculiar/x509';
+import { webcrypto } from 'node:crypto';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+cryptoProvider.set(webcrypto as Crypto);
+
+const MAX_CACHE = 200;
+const CA_CN = 'SigCLI Local Proxy CA';
+
+interface LeafEntry {
+    cert: string;
+    key: string;
+    expiresAt: Date;
+}
+
+function bufToPem(type: string, buf: ArrayBuffer): string {
+    const b64 = Buffer.from(buf).toString('base64');
+    const lines = b64.match(/.{1,64}/g) ?? [];
+    return `-----BEGIN ${type}-----\n${lines.join('\n')}\n-----END ${type}-----\n`;
+}
+
+function pemToBuf(pem: string): ArrayBuffer {
+    const b64 = pem
+        .split('\n')
+        .filter((l) => !l.startsWith('-----'))
+        .join('');
+    const bytes = Buffer.from(b64, 'base64');
+    return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+}
+
+export class CaManager {
+    private caCert: X509Certificate | null = null;
+    private caPrivKey: CryptoKey | null = null;
+    private readonly leafCache = new Map<string, LeafEntry>();
+    private readonly proxyDir: string;
+
+    constructor(proxyDir: string) {
+        this.proxyDir = proxyDir;
+    }
+
+    async ensureCa(): Promise<void> {
+        const keyPath = join(this.proxyDir, 'ca.key');
+        const crtPath = join(this.proxyDir, 'ca.crt');
+
+        try {
+            const keyPem = await readFile(keyPath, 'utf8');
+            const crtPem = await readFile(crtPath, 'utf8');
+
+            const privKey = await webcrypto.subtle.importKey(
+                'pkcs8',
+                pemToBuf(keyPem),
+                { name: 'ECDSA', namedCurve: 'P-256' },
+                false,
+                ['sign'],
+            );
+
+            this.caCert = new X509Certificate(crtPem);
+            this.caPrivKey = privKey;
+            return;
+        } catch {
+            // Generate a fresh CA below
+        }
+
+        await mkdir(this.proxyDir, { recursive: true });
+
+        const keys = await webcrypto.subtle.generateKey(
+            { name: 'ECDSA', namedCurve: 'P-256' },
+            true,
+            ['sign', 'verify'],
+        );
+
+        const notBefore = new Date();
+        const notAfter = new Date(notBefore.getTime() + 10 * 365 * 24 * 60 * 60 * 1000);
+
+        const cert = await X509CertificateGenerator.createSelfSigned({
+            keys,
+            name: `CN=${CA_CN}`,
+            notBefore,
+            notAfter,
+            signingAlgorithm: { name: 'ECDSA', hash: 'SHA-256' },
+            extensions: [
+                new BasicConstraintsExtension(true, 0, true),
+                new KeyUsagesExtension(KeyUsageFlags.keyCertSign | KeyUsageFlags.cRLSign, true),
+            ],
+        });
+
+        const keyDer = await webcrypto.subtle.exportKey('pkcs8', keys.privateKey);
+        await writeFile(keyPath, bufToPem('EC PRIVATE KEY', keyDer), { mode: 0o400 });
+        await writeFile(crtPath, cert.toString('pem'), { mode: 0o644 });
+
+        this.caCert = cert;
+        this.caPrivKey = keys.privateKey;
+    }
+
+    async leafCertFor(hostname: string): Promise<{ cert: string; key: string }> {
+        if (!this.caCert || !this.caPrivKey) {
+            throw new Error('CA not initialized — call ensureCa() first');
+        }
+
+        const cached = this.leafCache.get(hostname);
+        if (cached && cached.expiresAt > new Date()) {
+            return { cert: cached.cert, key: cached.key };
+        }
+
+        const keys = await webcrypto.subtle.generateKey(
+            { name: 'ECDSA', namedCurve: 'P-256' },
+            true,
+            ['sign', 'verify'],
+        );
+
+        const notBefore = new Date();
+        const notAfter = new Date(notBefore.getTime() + 365 * 24 * 60 * 60 * 1000);
+
+        const cert = await X509CertificateGenerator.create({
+            publicKey: keys.publicKey,
+            signingKey: this.caPrivKey,
+            subject: `CN=${hostname}`,
+            issuer: `CN=${CA_CN}`,
+            notBefore,
+            notAfter,
+            signingAlgorithm: { name: 'ECDSA', hash: 'SHA-256' },
+            extensions: [new SubjectAlternativeNameExtension([{ type: 'dns', value: hostname }])],
+        });
+
+        const keyDer = await webcrypto.subtle.exportKey('pkcs8', keys.privateKey);
+        const entry: LeafEntry = {
+            cert: cert.toString('pem'),
+            key: bufToPem('EC PRIVATE KEY', keyDer),
+            expiresAt: notAfter,
+        };
+
+        if (this.leafCache.size >= MAX_CACHE) {
+            const oldest = this.leafCache.keys().next().value;
+            if (oldest !== undefined) this.leafCache.delete(oldest);
+        }
+        this.leafCache.set(hostname, entry);
+
+        return { cert: entry.cert, key: entry.key };
+    }
+
+    getCaPath(): string {
+        return join(this.proxyDir, 'ca.crt');
+    }
+}

--- a/cli/src/proxy/daemon.ts
+++ b/cli/src/proxy/daemon.ts
@@ -1,0 +1,76 @@
+import { startWatchLoop } from '../watch/watch-loop.js';
+import { getWatchConfig, getWatchProviders } from '../watch/watch-config.js';
+import { parseDuration } from '../utils/duration.js';
+import { ProxyServer } from './proxy-server.js';
+import { CaManager } from './ca-manager.js';
+import { writeState, clearState } from './proxy-state.js';
+import { expandHome } from '../utils/path.js';
+import type { AuthDeps } from '../deps.js';
+
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
+
+export interface DaemonOptions {
+    port: number;
+    authDeps: AuthDeps;
+}
+
+export async function startDaemon(opts: DaemonOptions, signal: AbortSignal): Promise<void> {
+    const proxyDir = expandHome('~/.sig/proxy');
+    const caManager = new CaManager(proxyDir);
+    const server = new ProxyServer({ port: opts.port, authDeps: opts.authDeps, caManager });
+
+    const { port } = await server.start();
+    await writeState({ pid: process.pid, port });
+
+    const logger = {
+        debug: (msg: string) => process.stderr.write(`[proxy] ${msg}\n`),
+        info: (msg: string) => process.stderr.write(`[proxy] ${msg}\n`),
+        warn: (msg: string) => process.stderr.write(`[proxy] WARN: ${msg}\n`),
+        error: (msg: string) => process.stderr.write(`[proxy] ERROR: ${msg}\n`),
+    };
+
+    process.stderr.write(`[proxy] Listening on 127.0.0.1:${port}\n`);
+
+    // Graceful shutdown
+    const cleanup = async () => {
+        await server.stop();
+        await clearState();
+    };
+
+    signal.addEventListener(
+        'abort',
+        () => {
+            cleanup().catch(() => undefined);
+        },
+        { once: true },
+    );
+
+    // Watch loop — optional, runs if watch config exists
+    const watchConfig = await getWatchConfig();
+    if (watchConfig && Object.keys(watchConfig.providers).length > 0) {
+        let intervalMs = DEFAULT_INTERVAL_MS;
+        try {
+            intervalMs = parseDuration(watchConfig.interval);
+        } catch {
+            // use default
+        }
+
+        await startWatchLoop(
+            {
+                authManager: opts.authDeps.authManager,
+                storage: opts.authDeps.storage,
+                config: opts.authDeps.config,
+                logger,
+            },
+            { intervalMs, once: false },
+            getWatchProviders,
+            signal,
+            () => undefined,
+        );
+    } else {
+        // No watch config — wait for abort
+        await new Promise<void>((resolve) => {
+            signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+    }
+}

--- a/cli/src/proxy/inject.ts
+++ b/cli/src/proxy/inject.ts
@@ -67,7 +67,7 @@ export function applyInjectRules(
     let outUrl = url;
 
     for (const rule of rules) {
-        const action = rule.action ?? 'set';
+        const { action } = rule;
         const value = rule.from ? resolveFrom(credential, rule.from) : null;
 
         if (rule.in === 'header') {

--- a/cli/src/proxy/inject.ts
+++ b/cli/src/proxy/inject.ts
@@ -1,0 +1,117 @@
+import type { Credential, ProxyInjectRule } from '../core/types.js';
+import type * as http from 'node:http';
+
+export function resolveFrom(credential: Credential, fromPath: string): string | null {
+    if (!fromPath.startsWith('credential.')) return null;
+    const rest = fromPath.slice('credential.'.length);
+
+    if (rest === 'cookies') {
+        if (credential.type === 'cookie') {
+            return credential.cookies.map((c) => `${c.name}=${c.value}`).join('; ');
+        }
+        return null;
+    }
+
+    if (rest === 'accessToken') {
+        if (credential.type === 'bearer') return credential.accessToken;
+        return null;
+    }
+
+    if (rest === 'key') {
+        if (credential.type === 'api-key') return credential.key;
+        return null;
+    }
+
+    if (rest === 'username') {
+        if (credential.type === 'basic') return credential.username;
+        return null;
+    }
+
+    if (rest === 'password') {
+        if (credential.type === 'basic') return credential.password;
+        return null;
+    }
+
+    if (rest.startsWith('xHeaders.')) {
+        const headerKey = rest.slice('xHeaders.'.length);
+        if ((credential.type === 'cookie' || credential.type === 'bearer') && credential.xHeaders) {
+            return credential.xHeaders[headerKey] ?? null;
+        }
+        return null;
+    }
+
+    if (rest.startsWith('localStorage.')) {
+        const lsKey = rest.slice('localStorage.'.length);
+        if (
+            (credential.type === 'cookie' || credential.type === 'bearer') &&
+            credential.localStorage
+        ) {
+            return credential.localStorage[lsKey] ?? null;
+        }
+        return null;
+    }
+
+    return null;
+}
+
+export function applyInjectRules(
+    rules: ProxyInjectRule[],
+    credential: Credential,
+    headers: http.OutgoingHttpHeaders,
+    bodyBuffer: Buffer | undefined,
+    contentType: string | undefined,
+    url: string,
+): { headers: http.OutgoingHttpHeaders; body: Buffer | undefined; url: string } {
+    const outHeaders = { ...headers };
+    let outBody = bodyBuffer;
+    let outUrl = url;
+
+    for (const rule of rules) {
+        const action = rule.action ?? 'set';
+        const value = rule.from ? resolveFrom(credential, rule.from) : null;
+
+        if (rule.in === 'header') {
+            if (action === 'remove') {
+                delete outHeaders[rule.name.toLowerCase()];
+            } else if (value !== null) {
+                const key = rule.name.toLowerCase();
+                if (action === 'append') {
+                    const existing = outHeaders[key];
+                    const existingStr = Array.isArray(existing)
+                        ? existing.join(', ')
+                        : existing != null
+                          ? String(existing)
+                          : undefined;
+                    outHeaders[key] = existingStr ? `${existingStr}; ${value}` : value;
+                } else {
+                    outHeaders[key] = value;
+                }
+            }
+        } else if (rule.in === 'body' && action === 'set' && value !== null) {
+            const ct = (contentType ?? '').toLowerCase().split(';')[0].trim();
+            if (ct === 'application/x-www-form-urlencoded') {
+                const params = new URLSearchParams(outBody ? outBody.toString() : '');
+                params.set(rule.name, value);
+                outBody = Buffer.from(params.toString());
+            } else if (ct === 'application/json') {
+                let json: Record<string, unknown> = {};
+                try {
+                    json = JSON.parse(outBody ? outBody.toString() : '{}') as Record<
+                        string,
+                        unknown
+                    >;
+                } catch {
+                    // keep empty object
+                }
+                json[rule.name] = value;
+                outBody = Buffer.from(JSON.stringify(json));
+            }
+        } else if (rule.in === 'query' && action === 'set' && value !== null) {
+            const parsed = new URL(outUrl);
+            parsed.searchParams.set(rule.name, value);
+            outUrl = parsed.toString();
+        }
+    }
+
+    return { headers: outHeaders, body: outBody, url: outUrl };
+}

--- a/cli/src/proxy/proxy-server.ts
+++ b/cli/src/proxy/proxy-server.ts
@@ -43,8 +43,17 @@ async function injectHeaders(
     const credResult = await deps.authManager.getCredentials(provider.id);
     if (!isOk(credResult)) return baseHeaders;
 
-    const injected = deps.authManager.applyToRequest(provider.id, credResult.value);
-    return { ...baseHeaders, ...injected };
+    const cred = credResult.value;
+    const injected = deps.authManager.applyToRequest(provider.id, cred);
+    const headers = { ...baseHeaders, ...injected };
+
+    if ('localStorage' in cred && cred.localStorage) {
+        for (const [key, value] of Object.entries(cred.localStorage)) {
+            headers[`x-sig-local-${key}`] = value;
+        }
+    }
+
+    return headers;
 }
 
 async function handlePlainHttp(

--- a/cli/src/proxy/proxy-server.ts
+++ b/cli/src/proxy/proxy-server.ts
@@ -5,6 +5,7 @@ import * as tls from 'node:tls';
 import { isOk } from '../core/result.js';
 import type { AuthDeps } from '../deps.js';
 import type { CaManager } from './ca-manager.js';
+import { applyInjectRules } from './inject.js';
 
 const HOP_BY_HOP = new Set([
     'connection',
@@ -32,18 +33,32 @@ function resolveProvider(url: string, deps: AuthDeps) {
     return deps.providerRegistry.resolve(url);
 }
 
-async function injectHeaders(
+async function applyInjection(
     url: string,
     baseHeaders: http.OutgoingHttpHeaders,
+    bodyBuffer: Buffer | undefined,
+    contentType: string | undefined,
     deps: AuthDeps,
-): Promise<http.OutgoingHttpHeaders> {
+): Promise<{ headers: http.OutgoingHttpHeaders; body: Buffer | undefined; url: string }> {
     const provider = resolveProvider(url, deps);
-    if (!provider) return baseHeaders;
+    if (!provider) return { headers: baseHeaders, body: bodyBuffer, url };
 
     const credResult = await deps.authManager.getCredentials(provider.id);
-    if (!isOk(credResult)) return baseHeaders;
+    if (!isOk(credResult)) return { headers: baseHeaders, body: bodyBuffer, url };
 
     const cred = credResult.value;
+
+    if (provider.proxy?.inject) {
+        return applyInjectRules(
+            provider.proxy.inject,
+            cred,
+            baseHeaders,
+            bodyBuffer,
+            contentType,
+            url,
+        );
+    }
+
     const injected = deps.authManager.applyToRequest(provider.id, cred);
     const headers = { ...baseHeaders, ...injected };
 
@@ -53,7 +68,7 @@ async function injectHeaders(
         }
     }
 
-    return headers;
+    return { headers, body: bodyBuffer, url };
 }
 
 async function handlePlainHttp(
@@ -63,9 +78,8 @@ async function handlePlainHttp(
 ): Promise<void> {
     const rawUrl = req.url ?? '/';
     const targetUrl = rawUrl.startsWith('http') ? rawUrl : `http://${req.headers.host}${rawUrl}`;
-    let parsed: URL;
     try {
-        parsed = new URL(targetUrl);
+        new URL(targetUrl);
     } catch {
         res.writeHead(400);
         res.end('Bad Request');
@@ -73,28 +87,79 @@ async function handlePlainHttp(
     }
 
     const baseHeaders = stripHopByHop(req.headers);
-    const headers = await injectHeaders(targetUrl, baseHeaders, deps);
+    const contentType = req.headers['content-type'];
 
-    const options: http.RequestOptions = {
-        hostname: parsed.hostname,
-        port: parsed.port || 80,
-        path: parsed.pathname + parsed.search,
-        method: req.method,
-        headers,
-    };
+    const provider = resolveProvider(targetUrl, deps);
+    const hasBodyRule = provider?.proxy?.inject?.some((r) => r.in === 'body') ?? false;
 
-    const proxyReq = http.request(options, (proxyRes) => {
-        const outHeaders = stripHopByHop(proxyRes.headers);
-        res.writeHead(proxyRes.statusCode ?? 200, outHeaders);
-        proxyRes.pipe(res, { end: true });
-    });
+    if (hasBodyRule) {
+        const chunks: Buffer[] = [];
+        req.on('data', (chunk: Buffer) => chunks.push(chunk));
+        await new Promise<void>((resolve) => req.on('end', resolve));
+        const bodyBuffer = Buffer.concat(chunks);
 
-    proxyReq.on('error', () => {
-        if (!res.headersSent) res.writeHead(502);
-        res.end('Bad Gateway');
-    });
+        const {
+            headers,
+            body,
+            url: injectedUrl,
+        } = await applyInjection(targetUrl, baseHeaders, bodyBuffer, contentType, deps);
 
-    req.pipe(proxyReq, { end: true });
+        const injParsed = new URL(injectedUrl);
+        const outHeaders =
+            body !== undefined ? { ...headers, 'content-length': String(body.length) } : headers;
+
+        const options: http.RequestOptions = {
+            hostname: injParsed.hostname,
+            port: injParsed.port || 80,
+            path: injParsed.pathname + injParsed.search,
+            method: req.method,
+            headers: outHeaders,
+        };
+
+        const proxyReq = http.request(options, (proxyRes) => {
+            const outResHeaders = stripHopByHop(proxyRes.headers);
+            res.writeHead(proxyRes.statusCode ?? 200, outResHeaders);
+            proxyRes.pipe(res, { end: true });
+        });
+
+        proxyReq.on('error', () => {
+            if (!res.headersSent) res.writeHead(502);
+            res.end('Bad Gateway');
+        });
+
+        if (body && body.length > 0) proxyReq.write(body);
+        proxyReq.end();
+    } else {
+        const { headers, url: injectedUrl } = await applyInjection(
+            targetUrl,
+            baseHeaders,
+            undefined,
+            contentType,
+            deps,
+        );
+
+        const injParsed = new URL(injectedUrl);
+        const options: http.RequestOptions = {
+            hostname: injParsed.hostname,
+            port: injParsed.port || 80,
+            path: injParsed.pathname + injParsed.search,
+            method: req.method,
+            headers,
+        };
+
+        const proxyReq = http.request(options, (proxyRes) => {
+            const outHeaders = stripHopByHop(proxyRes.headers);
+            res.writeHead(proxyRes.statusCode ?? 200, outHeaders);
+            proxyRes.pipe(res, { end: true });
+        });
+
+        proxyReq.on('error', () => {
+            if (!res.headersSent) res.writeHead(502);
+            res.end('Bad Gateway');
+        });
+
+        req.pipe(proxyReq, { end: true });
+    }
 }
 
 async function handleConnectMitm(
@@ -147,7 +212,7 @@ async function handleConnectMitm(
             }
 
             const baseHeaders = stripHopByHop(parsedHeaders);
-            const headers = await injectHeaders(targetUrl, baseHeaders, deps);
+            const contentType = parsedHeaders['content-type'];
 
             const bodyStart = raw.indexOf('\r\n\r\n');
             const bodyBuf =
@@ -155,10 +220,59 @@ async function handleConnectMitm(
                     ? chunk.slice(Buffer.byteLength(raw.slice(0, bodyStart + 4)))
                     : undefined;
 
+            const provider = resolveProvider(targetUrl, deps);
+            const hasBodyRule = provider?.proxy?.inject?.some((r) => r.in === 'body') ?? false;
+
+            if (hasBodyRule && bodyBuf !== undefined && bodyBuf.length > 0) {
+                const result = await applyInjection(
+                    targetUrl,
+                    baseHeaders,
+                    bodyBuf,
+                    contentType,
+                    deps,
+                );
+                const outHeaders = {
+                    ...result.headers,
+                    'content-length': String(result.body?.length ?? 0),
+                };
+                const options: https.RequestOptions = {
+                    hostname,
+                    port,
+                    path,
+                    method,
+                    headers: outHeaders,
+                    rejectUnauthorized: false,
+                };
+                const proxyReq = https.request(options, (proxyRes) => {
+                    const outResHeaders = stripHopByHop(proxyRes.headers);
+                    let statusLine = `HTTP/1.1 ${proxyRes.statusCode ?? 200} ${proxyRes.statusMessage ?? 'OK'}\r\n`;
+                    for (const [k, v] of Object.entries(outResHeaders)) {
+                        const val = Array.isArray(v) ? v.join(', ') : v;
+                        if (val !== undefined) statusLine += `${k}: ${val}\r\n`;
+                    }
+                    statusLine += '\r\n';
+                    tlsServer.write(statusLine);
+                    proxyRes.pipe(tlsServer, { end: true });
+                });
+                proxyReq.on('error', () => tlsServer.destroy());
+                if (result.body && result.body.length > 0) proxyReq.write(result.body);
+                proxyReq.end();
+                return;
+            }
+
+            const { headers, url: injectedUrl } = await applyInjection(
+                targetUrl,
+                baseHeaders,
+                undefined,
+                contentType,
+                deps,
+            );
+            const injPath = new URL(injectedUrl).pathname + new URL(injectedUrl).search;
+
             const options: https.RequestOptions = {
                 hostname,
                 port,
-                path,
+                path: injPath,
                 method,
                 headers,
                 rejectUnauthorized: false,

--- a/cli/src/proxy/proxy-server.ts
+++ b/cli/src/proxy/proxy-server.ts
@@ -174,99 +174,46 @@ async function handleConnectMitm(
 
     tlsServer.on('error', () => tlsServer.destroy());
 
-    tlsServer.once('data', (chunk: Buffer) => {
-        void (async () => {
-            const raw = chunk.toString();
-            const lines = raw.split('\r\n');
-            const requestLine = lines[0] ?? '';
-            const [method, path] = requestLine.split(' ');
+    const chunks: Buffer[] = [];
+    let headersParsed = false;
+    let method = '';
+    let path = '';
+    const parsedHeaders: http.IncomingHttpHeaders = {};
+    let expectedBodyLen = 0;
+    let headerEndOffset = 0;
 
-            if (!method || !path) {
-                tlsServer.destroy();
-                return;
-            }
+    const processRequest = async (bodyBuf: Buffer | undefined) => {
+        const targetUrl = `https://${hostname}${path}`;
+        const baseHeaders = stripHopByHop(parsedHeaders);
+        const contentType = parsedHeaders['content-type'];
 
-            const targetUrl = `https://${hostname}${path}`;
-            const parsedHeaders: http.IncomingHttpHeaders = {};
-            for (let i = 1; i < lines.length; i++) {
-                const colonIdx = lines[i].indexOf(':');
-                if (colonIdx === -1) break;
-                const name = lines[i].slice(0, colonIdx).trim().toLowerCase();
-                const value = lines[i].slice(colonIdx + 1).trim();
-                parsedHeaders[name] = value;
-            }
+        const provider = resolveProvider(targetUrl, deps);
+        const hasBodyRule = provider?.proxy?.inject?.some((r) => r.in === 'body') ?? false;
 
-            const baseHeaders = stripHopByHop(parsedHeaders);
-            const contentType = parsedHeaders['content-type'];
-
-            const bodyStart = raw.indexOf('\r\n\r\n');
-            const bodyBuf =
-                bodyStart >= 0
-                    ? chunk.slice(Buffer.byteLength(raw.slice(0, bodyStart + 4)))
-                    : undefined;
-
-            const provider = resolveProvider(targetUrl, deps);
-            const hasBodyRule = provider?.proxy?.inject?.some((r) => r.in === 'body') ?? false;
-
-            if (hasBodyRule && bodyBuf !== undefined && bodyBuf.length > 0) {
-                const result = await applyInjection(
-                    targetUrl,
-                    baseHeaders,
-                    bodyBuf,
-                    contentType,
-                    deps,
-                );
-                const outHeaders = {
-                    ...result.headers,
-                    'content-length': String(result.body?.length ?? 0),
-                };
-                const options: https.RequestOptions = {
-                    hostname,
-                    port,
-                    path,
-                    method,
-                    headers: outHeaders,
-                    rejectUnauthorized: false,
-                };
-                const proxyReq = https.request(options, (proxyRes) => {
-                    const outResHeaders = stripHopByHop(proxyRes.headers);
-                    let statusLine = `HTTP/1.1 ${proxyRes.statusCode ?? 200} ${proxyRes.statusMessage ?? 'OK'}\r\n`;
-                    for (const [k, v] of Object.entries(outResHeaders)) {
-                        const val = Array.isArray(v) ? v.join(', ') : v;
-                        if (val !== undefined) statusLine += `${k}: ${val}\r\n`;
-                    }
-                    statusLine += '\r\n';
-                    tlsServer.write(statusLine);
-                    proxyRes.pipe(tlsServer, { end: true });
-                });
-                proxyReq.on('error', () => tlsServer.destroy());
-                if (result.body && result.body.length > 0) proxyReq.write(result.body);
-                proxyReq.end();
-                return;
-            }
-
-            const { headers, url: injectedUrl } = await applyInjection(
+        if (hasBodyRule) {
+            const result = await applyInjection(
                 targetUrl,
                 baseHeaders,
-                undefined,
+                bodyBuf ?? Buffer.alloc(0),
                 contentType,
                 deps,
             );
-            const injPath = new URL(injectedUrl).pathname + new URL(injectedUrl).search;
-
+            const outHeaders = {
+                ...result.headers,
+                'content-length': String(result.body?.length ?? 0),
+            };
             const options: https.RequestOptions = {
                 hostname,
                 port,
-                path: injPath,
+                path,
                 method,
-                headers,
+                headers: outHeaders,
                 rejectUnauthorized: false,
             };
-
             const proxyReq = https.request(options, (proxyRes) => {
-                const outHeaders = stripHopByHop(proxyRes.headers);
+                const outResHeaders = stripHopByHop(proxyRes.headers);
                 let statusLine = `HTTP/1.1 ${proxyRes.statusCode ?? 200} ${proxyRes.statusMessage ?? 'OK'}\r\n`;
-                for (const [k, v] of Object.entries(outHeaders)) {
+                for (const [k, v] of Object.entries(outResHeaders)) {
                     const val = Array.isArray(v) ? v.join(', ') : v;
                     if (val !== undefined) statusLine += `${k}: ${val}\r\n`;
                 }
@@ -274,12 +221,90 @@ async function handleConnectMitm(
                 tlsServer.write(statusLine);
                 proxyRes.pipe(tlsServer, { end: true });
             });
-
             proxyReq.on('error', () => tlsServer.destroy());
-
-            if (bodyBuf && bodyBuf.length > 0) proxyReq.write(bodyBuf);
+            if (result.body && result.body.length > 0) proxyReq.write(result.body);
             proxyReq.end();
-        })();
+            return;
+        }
+
+        const { headers, url: injectedUrl } = await applyInjection(
+            targetUrl,
+            baseHeaders,
+            undefined,
+            contentType,
+            deps,
+        );
+        const injPath = new URL(injectedUrl).pathname + new URL(injectedUrl).search;
+
+        const options: https.RequestOptions = {
+            hostname,
+            port,
+            path: injPath,
+            method,
+            headers,
+            rejectUnauthorized: false,
+        };
+
+        const proxyReq = https.request(options, (proxyRes) => {
+            const outHeaders = stripHopByHop(proxyRes.headers);
+            let statusLine = `HTTP/1.1 ${proxyRes.statusCode ?? 200} ${proxyRes.statusMessage ?? 'OK'}\r\n`;
+            for (const [k, v] of Object.entries(outHeaders)) {
+                const val = Array.isArray(v) ? v.join(', ') : v;
+                if (val !== undefined) statusLine += `${k}: ${val}\r\n`;
+            }
+            statusLine += '\r\n';
+            tlsServer.write(statusLine);
+            proxyRes.pipe(tlsServer, { end: true });
+        });
+
+        proxyReq.on('error', () => tlsServer.destroy());
+
+        if (bodyBuf && bodyBuf.length > 0) proxyReq.write(bodyBuf);
+        proxyReq.end();
+    };
+
+    tlsServer.on('data', (chunk: Buffer) => {
+        chunks.push(chunk);
+        const accumulated = Buffer.concat(chunks);
+
+        if (!headersParsed) {
+            const headerEnd = accumulated.indexOf('\r\n\r\n');
+            if (headerEnd === -1) return;
+
+            headersParsed = true;
+            headerEndOffset = headerEnd + 4;
+            const headerStr = accumulated.slice(0, headerEnd).toString();
+            const lines = headerStr.split('\r\n');
+            const requestLine = lines[0] ?? '';
+            const parts = requestLine.split(' ');
+            method = parts[0] ?? '';
+            path = parts[1] ?? '';
+
+            if (!method || !path) {
+                tlsServer.destroy();
+                return;
+            }
+
+            for (let i = 1; i < lines.length; i++) {
+                const colonIdx = lines[i].indexOf(':');
+                if (colonIdx === -1) continue;
+                const name = lines[i].slice(0, colonIdx).trim().toLowerCase();
+                const value = lines[i].slice(colonIdx + 1).trim();
+                parsedHeaders[name] = value;
+            }
+
+            expectedBodyLen = parseInt(parsedHeaders['content-length'] ?? '0', 10);
+        }
+
+        const bodyReceived = accumulated.length - headerEndOffset;
+        if (bodyReceived >= expectedBodyLen) {
+            tlsServer.removeAllListeners('data');
+            const bodyBuf =
+                expectedBodyLen > 0
+                    ? accumulated.slice(headerEndOffset, headerEndOffset + expectedBodyLen)
+                    : undefined;
+            processRequest(bodyBuf).catch(() => tlsServer.destroy());
+        }
     });
 }
 

--- a/cli/src/proxy/proxy-server.ts
+++ b/cli/src/proxy/proxy-server.ts
@@ -41,34 +41,19 @@ async function applyInjection(
     deps: AuthDeps,
 ): Promise<{ headers: http.OutgoingHttpHeaders; body: Buffer | undefined; url: string }> {
     const provider = resolveProvider(url, deps);
-    if (!provider) return { headers: baseHeaders, body: bodyBuffer, url };
+    if (!provider?.proxy?.inject?.length) return { headers: baseHeaders, body: bodyBuffer, url };
 
     const credResult = await deps.authManager.getCredentials(provider.id);
     if (!isOk(credResult)) return { headers: baseHeaders, body: bodyBuffer, url };
 
-    const cred = credResult.value;
-
-    if (provider.proxy?.inject) {
-        return applyInjectRules(
-            provider.proxy.inject,
-            cred,
-            baseHeaders,
-            bodyBuffer,
-            contentType,
-            url,
-        );
-    }
-
-    const injected = deps.authManager.applyToRequest(provider.id, cred);
-    const headers = { ...baseHeaders, ...injected };
-
-    if ('localStorage' in cred && cred.localStorage) {
-        for (const [key, value] of Object.entries(cred.localStorage)) {
-            headers[`x-sig-local-${key}`] = value;
-        }
-    }
-
-    return { headers, body: bodyBuffer, url };
+    return applyInjectRules(
+        provider.proxy.inject,
+        credResult.value,
+        baseHeaders,
+        bodyBuffer,
+        contentType,
+        url,
+    );
 }
 
 async function handlePlainHttp(

--- a/cli/src/proxy/proxy-server.ts
+++ b/cli/src/proxy/proxy-server.ts
@@ -1,0 +1,258 @@
+import * as http from 'node:http';
+import * as https from 'node:https';
+import * as net from 'node:net';
+import * as tls from 'node:tls';
+import { isOk } from '../core/result.js';
+import type { AuthDeps } from '../deps.js';
+import type { CaManager } from './ca-manager.js';
+
+const HOP_BY_HOP = new Set([
+    'connection',
+    'keep-alive',
+    'proxy-authenticate',
+    'proxy-authorization',
+    'proxy-connection',
+    'te',
+    'trailers',
+    'transfer-encoding',
+    'upgrade',
+]);
+
+function stripHopByHop(headers: http.IncomingHttpHeaders): http.OutgoingHttpHeaders {
+    const out: http.OutgoingHttpHeaders = {};
+    for (const [k, v] of Object.entries(headers)) {
+        if (!HOP_BY_HOP.has(k.toLowerCase())) {
+            out[k] = v;
+        }
+    }
+    return out;
+}
+
+function resolveProvider(url: string, deps: AuthDeps) {
+    return deps.providerRegistry.resolve(url);
+}
+
+async function injectHeaders(
+    url: string,
+    baseHeaders: http.OutgoingHttpHeaders,
+    deps: AuthDeps,
+): Promise<http.OutgoingHttpHeaders> {
+    const provider = resolveProvider(url, deps);
+    if (!provider) return baseHeaders;
+
+    const credResult = await deps.authManager.getCredentials(provider.id);
+    if (!isOk(credResult)) return baseHeaders;
+
+    const injected = deps.authManager.applyToRequest(provider.id, credResult.value);
+    return { ...baseHeaders, ...injected };
+}
+
+async function handlePlainHttp(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    deps: AuthDeps,
+): Promise<void> {
+    const rawUrl = req.url ?? '/';
+    const targetUrl = rawUrl.startsWith('http') ? rawUrl : `http://${req.headers.host}${rawUrl}`;
+    let parsed: URL;
+    try {
+        parsed = new URL(targetUrl);
+    } catch {
+        res.writeHead(400);
+        res.end('Bad Request');
+        return;
+    }
+
+    const baseHeaders = stripHopByHop(req.headers);
+    const headers = await injectHeaders(targetUrl, baseHeaders, deps);
+
+    const options: http.RequestOptions = {
+        hostname: parsed.hostname,
+        port: parsed.port || 80,
+        path: parsed.pathname + parsed.search,
+        method: req.method,
+        headers,
+    };
+
+    const proxyReq = http.request(options, (proxyRes) => {
+        const outHeaders = stripHopByHop(proxyRes.headers);
+        res.writeHead(proxyRes.statusCode ?? 200, outHeaders);
+        proxyRes.pipe(res, { end: true });
+    });
+
+    proxyReq.on('error', () => {
+        if (!res.headersSent) res.writeHead(502);
+        res.end('Bad Gateway');
+    });
+
+    req.pipe(proxyReq, { end: true });
+}
+
+async function handleConnectMitm(
+    req: http.IncomingMessage,
+    clientSocket: net.Socket,
+    hostname: string,
+    port: number,
+    deps: AuthDeps,
+    caManager: CaManager,
+): Promise<void> {
+    let leafCert: { cert: string; key: string };
+    try {
+        leafCert = await caManager.leafCertFor(hostname);
+    } catch {
+        clientSocket.write('HTTP/1.1 502 Bad Gateway\r\n\r\n');
+        clientSocket.destroy();
+        return;
+    }
+
+    clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+
+    const tlsServer = new tls.TLSSocket(clientSocket, {
+        isServer: true,
+        cert: leafCert.cert,
+        key: leafCert.key,
+    });
+
+    tlsServer.on('error', () => tlsServer.destroy());
+
+    tlsServer.once('data', (chunk: Buffer) => {
+        void (async () => {
+            const raw = chunk.toString();
+            const lines = raw.split('\r\n');
+            const requestLine = lines[0] ?? '';
+            const [method, path] = requestLine.split(' ');
+
+            if (!method || !path) {
+                tlsServer.destroy();
+                return;
+            }
+
+            const targetUrl = `https://${hostname}${path}`;
+            const parsedHeaders: http.IncomingHttpHeaders = {};
+            for (let i = 1; i < lines.length; i++) {
+                const colonIdx = lines[i].indexOf(':');
+                if (colonIdx === -1) break;
+                const name = lines[i].slice(0, colonIdx).trim().toLowerCase();
+                const value = lines[i].slice(colonIdx + 1).trim();
+                parsedHeaders[name] = value;
+            }
+
+            const baseHeaders = stripHopByHop(parsedHeaders);
+            const headers = await injectHeaders(targetUrl, baseHeaders, deps);
+
+            const bodyStart = raw.indexOf('\r\n\r\n');
+            const bodyBuf =
+                bodyStart >= 0
+                    ? chunk.slice(Buffer.byteLength(raw.slice(0, bodyStart + 4)))
+                    : undefined;
+
+            const options: https.RequestOptions = {
+                hostname,
+                port,
+                path,
+                method,
+                headers,
+                rejectUnauthorized: false,
+            };
+
+            const proxyReq = https.request(options, (proxyRes) => {
+                const outHeaders = stripHopByHop(proxyRes.headers);
+                let statusLine = `HTTP/1.1 ${proxyRes.statusCode ?? 200} ${proxyRes.statusMessage ?? 'OK'}\r\n`;
+                for (const [k, v] of Object.entries(outHeaders)) {
+                    const val = Array.isArray(v) ? v.join(', ') : v;
+                    if (val !== undefined) statusLine += `${k}: ${val}\r\n`;
+                }
+                statusLine += '\r\n';
+                tlsServer.write(statusLine);
+                proxyRes.pipe(tlsServer, { end: true });
+            });
+
+            proxyReq.on('error', () => tlsServer.destroy());
+
+            if (bodyBuf && bodyBuf.length > 0) proxyReq.write(bodyBuf);
+            proxyReq.end();
+        })();
+    });
+}
+
+function handleConnectTunnel(clientSocket: net.Socket, hostname: string, port: number): void {
+    const upstream = net.connect(port, hostname, () => {
+        clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+        upstream.pipe(clientSocket, { end: true });
+        clientSocket.pipe(upstream, { end: true });
+    });
+    upstream.on('error', () => clientSocket.destroy());
+    clientSocket.on('error', () => upstream.destroy());
+}
+
+export interface ProxyServerOptions {
+    port: number;
+    authDeps: AuthDeps;
+    caManager: CaManager;
+}
+
+export class ProxyServer {
+    private server: http.Server;
+    private _port: number;
+    private readonly deps: AuthDeps;
+    private readonly caManager: CaManager;
+
+    constructor(opts: ProxyServerOptions) {
+        this._port = opts.port;
+        this.deps = opts.authDeps;
+        this.caManager = opts.caManager;
+        this.server = http.createServer();
+        this.server.on('request', (req, res) => {
+            handlePlainHttp(req, res, this.deps).catch(() => {
+                if (!res.headersSent) res.writeHead(500);
+                res.end();
+            });
+        });
+        this.server.on('connect', (req, clientSocket: net.Socket, head: Buffer) => {
+            const hostHeader = req.url ?? '';
+            const colonIdx = hostHeader.lastIndexOf(':');
+            const hostname = colonIdx >= 0 ? hostHeader.slice(0, colonIdx) : hostHeader;
+            const port = colonIdx >= 0 ? parseInt(hostHeader.slice(colonIdx + 1), 10) : 443;
+
+            if (head.length > 0) clientSocket.unshift(head);
+
+            const provider = resolveProvider(`https://${hostname}`, this.deps);
+            if (provider) {
+                handleConnectMitm(
+                    req,
+                    clientSocket,
+                    hostname,
+                    port,
+                    this.deps,
+                    this.caManager,
+                ).catch(() => {
+                    clientSocket.destroy();
+                });
+            } else {
+                handleConnectTunnel(clientSocket, hostname, port);
+            }
+        });
+    }
+
+    async start(): Promise<{ port: number }> {
+        await this.caManager.ensureCa();
+        return new Promise((resolve, reject) => {
+            this.server.listen(this._port, '127.0.0.1', () => {
+                const addr = this.server.address();
+                this._port = typeof addr === 'object' && addr ? addr.port : this._port;
+                resolve({ port: this._port });
+            });
+            this.server.once('error', reject);
+        });
+    }
+
+    async stop(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            this.server.close((err) => (err ? reject(err) : resolve()));
+        });
+    }
+
+    get port(): number {
+        return this._port;
+    }
+}

--- a/cli/src/proxy/proxy-state.ts
+++ b/cli/src/proxy/proxy-state.ts
@@ -1,0 +1,44 @@
+import { readFile, writeFile, unlink, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { expandHome } from '../utils/path.js';
+
+const PROXY_DIR = expandHome('~/.sig/proxy');
+const PID_FILE = join(PROXY_DIR, 'proxy.pid');
+const PORT_FILE = join(PROXY_DIR, 'proxy.port');
+
+export interface ProxyState {
+    pid: number;
+    port: number;
+}
+
+export async function writeState(state: ProxyState): Promise<void> {
+    await mkdir(PROXY_DIR, { recursive: true });
+    await writeFile(PID_FILE, String(state.pid));
+    await writeFile(PORT_FILE, String(state.port));
+}
+
+export async function readState(): Promise<ProxyState | null> {
+    try {
+        const pid = parseInt(await readFile(PID_FILE, 'utf8'), 10);
+        const port = parseInt(await readFile(PORT_FILE, 'utf8'), 10);
+        if (isNaN(pid) || isNaN(port)) return null;
+        return { pid, port };
+    } catch {
+        return null;
+    }
+}
+
+export async function clearState(): Promise<void> {
+    await Promise.allSettled([unlink(PID_FILE), unlink(PORT_FILE)]);
+}
+
+export async function isRunning(): Promise<boolean> {
+    const state = await readState();
+    if (!state) return false;
+    try {
+        process.kill(state.pid, 0);
+        return true;
+    } catch {
+        return false;
+    }
+}

--- a/cli/tests/unit/cli/help-text.test.ts
+++ b/cli/tests/unit/cli/help-text.test.ts
@@ -84,7 +84,6 @@ describe('CLI help text grouping (#9)', () => {
         expect(output).toContain('--keep-config');
         expect(output).toContain('--provider <id>');
         expect(output).toContain('--auto-sync <remote>');
-        expect(output).toContain('--once');
     });
 
     it('help output lists remote subcommands and flags', async () => {
@@ -127,7 +126,7 @@ describe('CLI help text grouping (#9)', () => {
         expect(output).toContain('Authentication:');
     });
 
-    it('sections appear in correct order: Auth > Credentials > Provider > Remote > Watch > Setup > Global', async () => {
+    it('sections appear in correct order: Auth > Credentials > Provider > Remote > Watch > Proxy > Setup > Global', async () => {
         await run(['help']);
         const output = stdoutChunks.join('');
         const authIdx = output.indexOf('Authentication:');
@@ -135,6 +134,7 @@ describe('CLI help text grouping (#9)', () => {
         const providerIdx = output.indexOf('Provider management:');
         const remoteIdx = output.indexOf('Remote & sync:');
         const watchIdx = output.indexOf('Watch:');
+        const proxyIdx = output.indexOf('Proxy:');
         const setupIdx = output.indexOf('Setup:');
         const globalIdx = output.indexOf('Global options:');
 
@@ -143,7 +143,8 @@ describe('CLI help text grouping (#9)', () => {
         expect(providerIdx).toBeGreaterThan(credIdx);
         expect(remoteIdx).toBeGreaterThan(providerIdx);
         expect(watchIdx).toBeGreaterThan(remoteIdx);
-        expect(setupIdx).toBeGreaterThan(watchIdx);
+        expect(proxyIdx).toBeGreaterThan(watchIdx);
+        expect(setupIdx).toBeGreaterThan(proxyIdx);
         expect(globalIdx).toBeGreaterThan(setupIdx);
     });
 });

--- a/cli/tests/unit/core/constants.test.ts
+++ b/cli/tests/unit/core/constants.test.ts
@@ -4,6 +4,7 @@ import {
     RemoteSubcommand,
     SyncSubcommand,
     WatchSubcommand,
+    ProxySubcommand,
     WaitUntil,
     StrategyName,
     CredentialTypeName,
@@ -36,11 +37,12 @@ describe('constants', () => {
             expect(Command.REMOVE).toBe('remove');
             expect(Command.COMPLETION).toBe('completion');
             expect(Command.RUN).toBe('run');
+            expect(Command.PROXY).toBe('proxy');
             expect(Command.HELP).toBe('help');
         });
 
         it('has exactly the expected number of commands', () => {
-            expect(Object.keys(Command)).toHaveLength(16);
+            expect(Object.keys(Command)).toHaveLength(17);
         });
 
         it('values are all lowercase strings', () => {
@@ -75,16 +77,27 @@ describe('constants', () => {
     });
 
     describe('WatchSubcommand', () => {
-        it('has add, remove, list, start, and set-interval', () => {
+        it('has add, remove, and set-interval', () => {
             expect(WatchSubcommand.ADD).toBe('add');
             expect(WatchSubcommand.REMOVE).toBe('remove');
-            expect(WatchSubcommand.LIST).toBe('list');
-            expect(WatchSubcommand.START).toBe('start');
             expect(WatchSubcommand.SET_INTERVAL).toBe('set-interval');
         });
 
-        it('has exactly 5 subcommands', () => {
-            expect(Object.keys(WatchSubcommand)).toHaveLength(5);
+        it('has exactly 3 subcommands', () => {
+            expect(Object.keys(WatchSubcommand)).toHaveLength(3);
+        });
+    });
+
+    describe('ProxySubcommand', () => {
+        it('has start, stop, status, and trust', () => {
+            expect(ProxySubcommand.START).toBe('start');
+            expect(ProxySubcommand.STOP).toBe('stop');
+            expect(ProxySubcommand.STATUS).toBe('status');
+            expect(ProxySubcommand.TRUST).toBe('trust');
+        });
+
+        it('has exactly 4 subcommands', () => {
+            expect(Object.keys(ProxySubcommand)).toHaveLength(4);
         });
     });
 

--- a/cli/tests/unit/proxy/ca-manager.test.ts
+++ b/cli/tests/unit/proxy/ca-manager.test.ts
@@ -1,0 +1,54 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { CaManager } from '../../../src/proxy/ca-manager.js';
+
+describe('CaManager', () => {
+    let dir: string;
+    let ca: CaManager;
+
+    beforeEach(async () => {
+        dir = await mkdtemp(join(tmpdir(), 'sigcli-ca-test-'));
+        ca = new CaManager(dir);
+    });
+
+    afterEach(async () => {
+        await rm(dir, { recursive: true, force: true });
+    });
+
+    it('generates CA on first ensureCa()', async () => {
+        await ca.ensureCa();
+        expect(ca.getCaPath()).toBe(join(dir, 'ca.crt'));
+    });
+
+    it('reloads existing CA on second ensureCa()', async () => {
+        await ca.ensureCa();
+        const ca2 = new CaManager(dir);
+        await ca2.ensureCa();
+        const leaf1 = await ca.leafCertFor('example.com');
+        const leaf2 = await ca2.leafCertFor('example.com');
+        // Both issued by the same CA — just verify they have PEM structure
+        expect(leaf1.cert).toMatch(/BEGIN CERTIFICATE/);
+        expect(leaf2.cert).toMatch(/BEGIN CERTIFICATE/);
+    });
+
+    it('issues leaf cert for a hostname', async () => {
+        await ca.ensureCa();
+        const { cert, key } = await ca.leafCertFor('api.example.com');
+        expect(cert).toMatch(/BEGIN CERTIFICATE/);
+        expect(key).toMatch(/BEGIN EC PRIVATE KEY/);
+    });
+
+    it('caches leaf certs', async () => {
+        await ca.ensureCa();
+        const first = await ca.leafCertFor('cached.test');
+        const second = await ca.leafCertFor('cached.test');
+        expect(first.cert).toBe(second.cert);
+    });
+
+    it('throws if leafCertFor called before ensureCa', async () => {
+        await expect(ca.leafCertFor('test.com')).rejects.toThrow('CA not initialized');
+    });
+});

--- a/cli/tests/unit/proxy/inject.test.ts
+++ b/cli/tests/unit/proxy/inject.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import { resolveFrom, applyInjectRules } from '../../../src/proxy/inject.js';
+import type { CookieCredential, BearerCredential } from '../../../src/core/types.js';
+
+const cookieCred: CookieCredential = {
+    type: 'cookie',
+    cookies: [
+        {
+            name: 'xoxd',
+            value: 'xoxd-abc',
+            domain: 'slack.com',
+            path: '/',
+            expires: -1,
+            httpOnly: true,
+            secure: true,
+        },
+        {
+            name: 'session',
+            value: 'sess-123',
+            domain: 'slack.com',
+            path: '/',
+            expires: -1,
+            httpOnly: true,
+            secure: true,
+        },
+    ],
+    obtainedAt: '2026-01-01T00:00:00Z',
+    xHeaders: { 'x-sig': 'sig-value' },
+    localStorage: { 'xoxc-token': 'xoxc-xyz' },
+};
+
+const bearerCred: BearerCredential = {
+    type: 'bearer',
+    accessToken: 'my-token',
+    obtainedAt: '2026-01-01T00:00:00Z',
+    localStorage: { 'app-token': 'app-val' },
+};
+
+describe('resolveFrom', () => {
+    it('returns joined cookie string for credential.cookies', () => {
+        expect(resolveFrom(cookieCred, 'credential.cookies')).toBe(
+            'xoxd=xoxd-abc; session=sess-123',
+        );
+    });
+
+    it('returns null for credential.cookies on non-cookie credential', () => {
+        expect(resolveFrom(bearerCred, 'credential.cookies')).toBeNull();
+    });
+
+    it('returns accessToken for bearer credential', () => {
+        expect(resolveFrom(bearerCred, 'credential.accessToken')).toBe('my-token');
+    });
+
+    it('returns null for credential.accessToken on cookie credential', () => {
+        expect(resolveFrom(cookieCred, 'credential.accessToken')).toBeNull();
+    });
+
+    it('resolves credential.localStorage.<key>', () => {
+        expect(resolveFrom(cookieCred, 'credential.localStorage.xoxc-token')).toBe('xoxc-xyz');
+    });
+
+    it('resolves credential.xHeaders.<name>', () => {
+        expect(resolveFrom(cookieCred, 'credential.xHeaders.x-sig')).toBe('sig-value');
+    });
+
+    it('returns null for missing localStorage key', () => {
+        expect(resolveFrom(cookieCred, 'credential.localStorage.missing')).toBeNull();
+    });
+
+    it('returns null for path without credential. prefix', () => {
+        expect(resolveFrom(cookieCred, 'cookies')).toBeNull();
+    });
+
+    it('returns null for unknown path', () => {
+        expect(resolveFrom(cookieCred, 'credential.unknown')).toBeNull();
+    });
+});
+
+describe('applyInjectRules', () => {
+    const baseHeaders = { 'content-type': 'text/html' };
+
+    it('sets a header', () => {
+        const { headers } = applyInjectRules(
+            [
+                {
+                    in: 'header',
+                    action: 'set',
+                    name: 'authorization',
+                    from: 'credential.accessToken',
+                },
+            ],
+            bearerCred,
+            baseHeaders,
+            undefined,
+            undefined,
+            'https://example.com/',
+        );
+        expect(headers['authorization']).toBe('my-token');
+    });
+
+    it('appends to existing header', () => {
+        const initial = { cookie: 'existing=val' };
+        const { headers } = applyInjectRules(
+            [{ in: 'header', action: 'append', name: 'cookie', from: 'credential.cookies' }],
+            cookieCred,
+            initial,
+            undefined,
+            undefined,
+            'https://example.com/',
+        );
+        expect(headers['cookie']).toBe('existing=val; xoxd=xoxd-abc; session=sess-123');
+    });
+
+    it('removes a header', () => {
+        const initial = { 'x-custom': 'value' };
+        const { headers } = applyInjectRules(
+            [{ in: 'header', action: 'remove', name: 'x-custom' }],
+            bearerCred,
+            initial,
+            undefined,
+            undefined,
+            'https://example.com/',
+        );
+        expect(headers['x-custom']).toBeUndefined();
+    });
+
+    it('injects into urlencoded body', () => {
+        const body = Buffer.from('field1=value1');
+        const { body: outBody } = applyInjectRules(
+            [{ in: 'body', action: 'set', name: 'token', from: 'credential.accessToken' }],
+            bearerCred,
+            baseHeaders,
+            body,
+            'application/x-www-form-urlencoded',
+            'https://example.com/',
+        );
+        const params = new URLSearchParams(outBody!.toString());
+        expect(params.get('field1')).toBe('value1');
+        expect(params.get('token')).toBe('my-token');
+    });
+
+    it('injects into json body', () => {
+        const body = Buffer.from(JSON.stringify({ existing: true }));
+        const { body: outBody } = applyInjectRules(
+            [{ in: 'body', action: 'set', name: 'token', from: 'credential.accessToken' }],
+            bearerCred,
+            baseHeaders,
+            body,
+            'application/json',
+            'https://example.com/',
+        );
+        const parsed = JSON.parse(outBody!.toString()) as Record<string, unknown>;
+        expect(parsed['existing']).toBe(true);
+        expect(parsed['token']).toBe('my-token');
+    });
+
+    it('injects into query params', () => {
+        const { url } = applyInjectRules(
+            [{ in: 'query', action: 'set', name: 'access_token', from: 'credential.accessToken' }],
+            bearerCred,
+            baseHeaders,
+            undefined,
+            undefined,
+            'https://example.com/api?foo=bar',
+        );
+        const parsed = new URL(url);
+        expect(parsed.searchParams.get('foo')).toBe('bar');
+        expect(parsed.searchParams.get('access_token')).toBe('my-token');
+    });
+});

--- a/cli/tests/unit/proxy/proxy-server.test.ts
+++ b/cli/tests/unit/proxy/proxy-server.test.ts
@@ -10,10 +10,15 @@ import { MemoryStorage } from '../../../src/storage/memory-storage.js';
 import { ProviderRegistry } from '../../../src/providers/provider-registry.js';
 import { StrategyRegistry } from '../../../src/strategies/registry.js';
 import { ApiTokenStrategyFactory } from '../../../src/strategies/api-token.strategy.js';
+import { CookieStrategyFactory } from '../../../src/strategies/cookie.strategy.js';
 import { AuthManager } from '../../../src/auth-manager.js';
 import type { AuthDeps } from '../../../src/deps.js';
 import type { IBrowserAdapter } from '../../../src/core/interfaces/browser-adapter.js';
-import type { ProviderConfig, ApiKeyCredential } from '../../../src/core/types.js';
+import type {
+    ProviderConfig,
+    ApiKeyCredential,
+    CookieCredential,
+} from '../../../src/core/types.js';
 import type { SigConfig } from '../../../src/config/schema.js';
 
 const testProvider: ProviderConfig = {
@@ -42,6 +47,7 @@ function makeMinimalConfig(): SigConfig {
 function makeAuthDeps(providers: ProviderConfig[] = [], storage = new MemoryStorage()): AuthDeps {
     const strategyRegistry = new StrategyRegistry();
     strategyRegistry.register(new ApiTokenStrategyFactory());
+    strategyRegistry.register(new CookieStrategyFactory());
     const providerRegistry = new ProviderRegistry(providers);
     const authManager = new AuthManager({
         storage,
@@ -90,6 +96,39 @@ function makeRequest(
             },
         );
         req.on('error', reject);
+        req.end();
+    });
+}
+
+function makePostRequest(
+    proxyPort: number,
+    targetHost: string,
+    targetPort: number,
+    formBody: string,
+    path = '/',
+): Promise<{ status: number; body: string }> {
+    return new Promise((resolve, reject) => {
+        const bodyBuf = Buffer.from(formBody);
+        const req = http.request(
+            {
+                hostname: '127.0.0.1',
+                port: proxyPort,
+                method: 'POST',
+                path: `http://${targetHost}:${targetPort}${path}`,
+                headers: {
+                    host: `${targetHost}:${targetPort}`,
+                    'content-type': 'application/x-www-form-urlencoded',
+                    'content-length': String(bodyBuf.length),
+                },
+            },
+            (res) => {
+                let body = '';
+                res.on('data', (chunk: Buffer) => (body += chunk.toString()));
+                res.on('end', () => resolve({ status: res.statusCode ?? 0, body }));
+            },
+        );
+        req.on('error', reject);
+        req.write(bodyBuf);
         req.end();
     });
 }
@@ -149,6 +188,70 @@ describe('ProxyServer', () => {
 
         const body = JSON.parse(result.body) as { receivedHeaders: Record<string, string> };
         expect(body.receivedHeaders['authorization']).toBe('Bearer test-token-xyz');
+
+        await proxy.stop();
+    });
+
+    it('injects token into POST body via proxy.inject rules', async () => {
+        const storage = new MemoryStorage();
+        const credential: CookieCredential = {
+            type: 'cookie',
+            cookies: [
+                {
+                    name: 'xoxd',
+                    value: 'xoxd-abc',
+                    domain: '127.0.0.1',
+                    path: '/',
+                    expires: -1,
+                    httpOnly: true,
+                    secure: false,
+                },
+            ],
+            obtainedAt: new Date().toISOString(),
+            localStorage: { 'xoxc-token': 'xoxc-xyz' },
+        };
+        const bodyProvider: ProviderConfig = {
+            id: 'body-provider',
+            name: 'Body',
+            domains: ['127.0.0.1'],
+            strategy: 'cookie',
+            strategyConfig: { strategy: 'cookie' },
+            proxy: {
+                inject: [
+                    {
+                        in: 'body',
+                        action: 'set',
+                        name: 'token',
+                        from: 'credential.localStorage.xoxc-token',
+                    },
+                ],
+            },
+        };
+
+        await storage.set('body-provider', { credential, providerId: 'body-provider' });
+
+        upstream.removeAllListeners('request');
+        upstream.on('request', (req: http.IncomingMessage, res: http.ServerResponse) => {
+            const chunks: Buffer[] = [];
+            req.on('data', (chunk: Buffer) => chunks.push(chunk));
+            req.on('end', () => {
+                const received = Buffer.concat(chunks).toString();
+                res.writeHead(200, { 'content-type': 'text/plain' });
+                res.end(JSON.stringify({ receivedBody: received }));
+            });
+        });
+
+        const deps = makeAuthDeps([bodyProvider], storage);
+        const proxy = new ProxyServer({ port: 0, authDeps: deps, caManager });
+        const { port: proxyPort } = await proxy.start();
+
+        const result = await makePostRequest(proxyPort, '127.0.0.1', upstreamPort, 'field=value');
+        expect(result.status).toBe(200);
+
+        const parsed = JSON.parse(result.body) as { receivedBody: string };
+        const params = new URLSearchParams(parsed.receivedBody);
+        expect(params.get('field')).toBe('value');
+        expect(params.get('token')).toBe('xoxc-xyz');
 
         await proxy.stop();
     });

--- a/cli/tests/unit/proxy/proxy-server.test.ts
+++ b/cli/tests/unit/proxy/proxy-server.test.ts
@@ -1,0 +1,155 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as http from 'node:http';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ProxyServer } from '../../../src/proxy/proxy-server.js';
+import { CaManager } from '../../../src/proxy/ca-manager.js';
+import { MemoryStorage } from '../../../src/storage/memory-storage.js';
+import { ProviderRegistry } from '../../../src/providers/provider-registry.js';
+import { StrategyRegistry } from '../../../src/strategies/registry.js';
+import { ApiTokenStrategyFactory } from '../../../src/strategies/api-token.strategy.js';
+import { AuthManager } from '../../../src/auth-manager.js';
+import type { AuthDeps } from '../../../src/deps.js';
+import type { IBrowserAdapter } from '../../../src/core/interfaces/browser-adapter.js';
+import type { ProviderConfig, ApiKeyCredential } from '../../../src/core/types.js';
+import type { SigConfig } from '../../../src/config/schema.js';
+
+const testProvider: ProviderConfig = {
+    id: 'test-provider',
+    name: 'Test',
+    domains: ['127.0.0.1'],
+    strategy: 'api-token',
+    strategyConfig: { strategy: 'api-token', headerName: 'Authorization', headerPrefix: 'Bearer' },
+};
+
+function makeMinimalConfig(): SigConfig {
+    return {
+        mode: 'browserless',
+        providers: {},
+        storage: { credentialsDir: '~/.sig/credentials' },
+        browser: {
+            browserDataDir: '/tmp',
+            channel: 'chrome',
+            headlessTimeout: 30000,
+            visibleTimeout: 120000,
+            waitUntil: 'load',
+        },
+    } as unknown as SigConfig;
+}
+
+function makeAuthDeps(providers: ProviderConfig[] = [], storage = new MemoryStorage()): AuthDeps {
+    const strategyRegistry = new StrategyRegistry();
+    strategyRegistry.register(new ApiTokenStrategyFactory());
+    const providerRegistry = new ProviderRegistry(providers);
+    const authManager = new AuthManager({
+        storage,
+        strategyRegistry,
+        providerRegistry,
+        browserAdapterFactory: () => ({}) as IBrowserAdapter,
+        browserConfig: {
+            browserDataDir: '/tmp',
+            channel: 'chrome',
+            headlessTimeout: 30000,
+            visibleTimeout: 120000,
+            waitUntil: 'load',
+        },
+    });
+    return {
+        authManager,
+        storage,
+        providerRegistry,
+        strategyRegistry,
+        config: makeMinimalConfig(),
+        browserAvailable: false,
+    };
+}
+
+function makeRequest(
+    proxyPort: number,
+    targetHost: string,
+    targetPort: number,
+    path = '/',
+): Promise<{ status: number; headers: http.IncomingHttpHeaders; body: string }> {
+    return new Promise((resolve, reject) => {
+        const req = http.request(
+            {
+                hostname: '127.0.0.1',
+                port: proxyPort,
+                method: 'GET',
+                path: `http://${targetHost}:${targetPort}${path}`,
+                headers: { host: `${targetHost}:${targetPort}` },
+            },
+            (res) => {
+                let body = '';
+                res.on('data', (chunk: Buffer) => (body += chunk.toString()));
+                res.on('end', () =>
+                    resolve({ status: res.statusCode ?? 0, headers: res.headers, body }),
+                );
+            },
+        );
+        req.on('error', reject);
+        req.end();
+    });
+}
+
+describe('ProxyServer', () => {
+    let dir: string;
+    let caManager: CaManager;
+    let upstream: http.Server;
+    let upstreamPort: number;
+
+    beforeEach(async () => {
+        dir = await mkdtemp(join(tmpdir(), 'sigcli-proxy-test-'));
+        caManager = new CaManager(dir);
+
+        // Start a simple upstream HTTP server
+        upstream = http.createServer((req, res) => {
+            res.writeHead(200, { 'content-type': 'text/plain' });
+            res.end(JSON.stringify({ receivedHeaders: req.headers }));
+        });
+        await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+        upstreamPort = (upstream.address() as { port: number }).port;
+    });
+
+    afterEach(async () => {
+        await new Promise<void>((resolve) => upstream.close(() => resolve()));
+        await rm(dir, { recursive: true, force: true });
+    });
+
+    it('starts and listens on port 0', async () => {
+        const proxy = new ProxyServer({ port: 0, authDeps: makeAuthDeps(), caManager });
+        const { port } = await proxy.start();
+        expect(port).toBeGreaterThan(0);
+        await proxy.stop();
+    });
+
+    it('proxies plain HTTP request without provider (passthrough)', async () => {
+        const proxy = new ProxyServer({ port: 0, authDeps: makeAuthDeps(), caManager });
+        const { port: proxyPort } = await proxy.start();
+
+        const result = await makeRequest(proxyPort, '127.0.0.1', upstreamPort);
+        expect(result.status).toBe(200);
+
+        await proxy.stop();
+    });
+
+    it('injects auth headers when provider matches', async () => {
+        const storage = new MemoryStorage();
+        const credential: ApiKeyCredential = { type: 'api-key', key: 'test-token-xyz' };
+        await storage.set('test-provider', { credential, providerId: 'test-provider' });
+
+        const deps = makeAuthDeps([testProvider], storage);
+        const proxy = new ProxyServer({ port: 0, authDeps: deps, caManager });
+        const { port: proxyPort } = await proxy.start();
+
+        const result = await makeRequest(proxyPort, '127.0.0.1', upstreamPort);
+        expect(result.status).toBe(200);
+
+        const body = JSON.parse(result.body) as { receivedHeaders: Record<string, string> };
+        expect(body.receivedHeaders['authorization']).toBe('Bearer test-token-xyz');
+
+        await proxy.stop();
+    });
+});

--- a/cli/tests/unit/proxy/proxy-server.test.ts
+++ b/cli/tests/unit/proxy/proxy-server.test.ts
@@ -27,6 +27,9 @@ const testProvider: ProviderConfig = {
     domains: ['127.0.0.1'],
     strategy: 'api-token',
     strategyConfig: { strategy: 'api-token', headerName: 'Authorization', headerPrefix: 'Bearer' },
+    proxy: {
+        inject: [{ in: 'header', action: 'set', name: 'authorization', from: 'credential.key' }],
+    },
 };
 
 function makeMinimalConfig(): SigConfig {
@@ -187,7 +190,7 @@ describe('ProxyServer', () => {
         expect(result.status).toBe(200);
 
         const body = JSON.parse(result.body) as { receivedHeaders: Record<string, string> };
-        expect(body.receivedHeaders['authorization']).toBe('Bearer test-token-xyz');
+        expect(body.receivedHeaders['authorization']).toBe('test-token-xyz');
 
         await proxy.stop();
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,19 +104,19 @@ importers:
         version: 0.10.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(csstype@3.2.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@1.9.12)
       '@tanstack/react-router':
         specifier: latest
-        version: 1.168.22(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-router-devtools':
         specifier: latest
-        version: 1.166.13(@tanstack/react-router@1.168.22(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/router-core@1.168.15)(csstype@3.2.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.166.13(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/router-core@1.168.15)(csstype@3.2.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-router-ssr-query':
         specifier: latest
-        version: 1.166.11(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@tanstack/react-router@1.168.22(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/router-core@1.168.15)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.166.11(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/router-core@1.168.15)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-start':
         specifier: latest
-        version: 1.167.41(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.167.42(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/router-plugin':
         specifier: ^1.132.0
-        version: 1.167.22(@tanstack/react-router@1.168.22(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.167.22(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1065,84 +1065,72 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.16':
     resolution: {integrity: sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.16':
     resolution: {integrity: sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
@@ -1236,79 +1224,66 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -1415,28 +1390,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -1552,22 +1523,22 @@ packages:
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
 
-  '@tanstack/react-router@1.168.22':
-    resolution: {integrity: sha512-W2LyfkfJtDCf//jOjZeUBWwOVl8iDRVTECpGHa2M28MT3T5/VVnjgicYNHR/ax0Filk1iU67MRjcjHheTYvK1Q==}
+  '@tanstack/react-router@1.168.23':
+    resolution: {integrity: sha512-+GblieDnutG6oipJJPNtRJjrWF8QTZEG/l0532+BngFkVK48oHNOcvIkSoAFYftK1egAwM7KBxXsb0Ou+X6/MQ==}
     engines: {node: '>=20.19'}
     peerDependencies:
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
 
-  '@tanstack/react-start-client@1.166.39':
-    resolution: {integrity: sha512-NDao1nwwM4hXiVwQjVO8ZPlL9gZ0yeIl7w0PV+75jz+V9bhXr2nGhBuBw4zBuG7px4fEVmO5E8b7kpjWgCDJtA==}
+  '@tanstack/react-start-client@1.166.40':
+    resolution: {integrity: sha512-ynjRe8YjaPfcQNEaQ3nE2/zIZNCdyVGew0pHK5lCorqEy3z/YuiKlj5ZXPmel7XGw0XoKsDIH2eXnUtTbIwpjg==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
 
-  '@tanstack/react-start-rsc@0.0.20':
-    resolution: {integrity: sha512-KPsaq/asQxu/scMduMuQlwURIXwu+qZ7SO/8xbY/PQ/DJzfp9q1ZEHs9JN7dBEOHcme/YPeHta+UxBapB5Syyw==}
+  '@tanstack/react-start-rsc@0.0.21':
+    resolution: {integrity: sha512-Q7T8HIGgCIrbMkdep5bmh/uPRK/3OZQ11FODZoMOvyrgTho/MA4kuUFSREvz2LdlXYrz3WxhSSLJnAtpPKJn5w==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@vitejs/plugin-rsc': '>=0.5.20'
@@ -1577,15 +1548,15 @@ packages:
       '@vitejs/plugin-rsc':
         optional: true
 
-  '@tanstack/react-start-server@1.166.40':
-    resolution: {integrity: sha512-g5OU/eHmT1MleDbebdhNybpYgDu3QeNlemMCyXxEJNewOFM4iBlfoUBdMPhONJDlHQrOBXwMk/RUEFemY94yRw==}
+  '@tanstack/react-start-server@1.166.41':
+    resolution: {integrity: sha512-Z0kyOeraz5nHE7DYh4brYetYoXvh3wjNNI3fJZ0+OzGODfNUgZtEQg/f1g1f1kj64irgWIuWTVPi3rOwiPSzYw==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
 
-  '@tanstack/react-start@1.167.41':
-    resolution: {integrity: sha512-w51yu/VQHNecIgN3ku+EmCxPjVbBftbnucDZBnxns43zPAhL5T5bnaBi0Fx4yJ3sDAmiceWEJD2F6IUaXTlNFA==}
+  '@tanstack/react-start@1.167.42':
+    resolution: {integrity: sha512-zobCIyeChagJg/dwWOWYofseucV618++DOIT/HB6tfnKKKnCw15vO9jhkGD5c+SBUNLyG4km+Y4ynvTIkaseVg==}
     engines: {node: '>=22.12.0'}
     hasBin: true
     peerDependencies:
@@ -1869,49 +1840,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -3107,28 +3070,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -5569,9 +5528,9 @@ snapshots:
       '@tanstack/query-core': 5.99.0
       react: 19.2.5
 
-  '@tanstack/react-router-devtools@1.166.13(@tanstack/react-router@1.168.22(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/router-core@1.168.15)(csstype@3.2.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@tanstack/react-router-devtools@1.166.13(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/router-core@1.168.15)(csstype@3.2.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@tanstack/react-router': 1.168.22(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-router': 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/router-devtools-core': 1.167.3(@tanstack/router-core@1.168.15)(csstype@3.2.3)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -5580,18 +5539,18 @@ snapshots:
     transitivePeerDependencies:
       - csstype
 
-  '@tanstack/react-router-ssr-query@1.166.11(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@tanstack/react-router@1.168.22(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/router-core@1.168.15)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@tanstack/react-router-ssr-query@1.166.11(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/router-core@1.168.15)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@tanstack/query-core': 5.99.0
       '@tanstack/react-query': 5.99.0(react@19.2.5)
-      '@tanstack/react-router': 1.168.22(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-router': 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/router-ssr-query-core': 1.167.1(@tanstack/query-core@5.99.0)(@tanstack/router-core@1.168.15)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     transitivePeerDependencies:
       - '@tanstack/router-core'
 
-  '@tanstack/react-router@1.168.22(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@tanstack/history': 1.161.6
       '@tanstack/react-store': 0.9.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -5600,23 +5559,23 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@tanstack/react-start-client@1.166.39(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@tanstack/react-start-client@1.166.40(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@tanstack/react-router': 1.168.22(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-router': 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/router-core': 1.168.15
       '@tanstack/start-client-core': 1.167.17
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@tanstack/react-start-rsc@0.0.20(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tanstack/react-start-rsc@0.0.21(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@tanstack/react-router': 1.168.22(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/react-start-server': 1.166.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-router': 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-start-server': 1.166.41(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/router-core': 1.168.15
       '@tanstack/router-utils': 1.161.6
       '@tanstack/start-client-core': 1.167.17
       '@tanstack/start-fn-stubs': 1.161.6
-      '@tanstack/start-plugin-core': 1.167.35(@tanstack/react-router@1.168.22(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.15))(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@tanstack/start-plugin-core': 1.167.35(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.15))(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/start-server-core': 1.167.19(crossws@0.4.5(srvx@0.11.15))
       '@tanstack/start-storage-context': 1.166.29
       pathe: 2.0.3
@@ -5630,10 +5589,10 @@ snapshots:
       - vite-plugin-solid
       - webpack
 
-  '@tanstack/react-start-server@1.166.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@tanstack/react-start-server@1.166.41(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@tanstack/history': 1.161.6
-      '@tanstack/react-router': 1.168.22(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-router': 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/router-core': 1.168.15
       '@tanstack/start-client-core': 1.167.17
       '@tanstack/start-server-core': 1.167.19(crossws@0.4.5(srvx@0.11.15))
@@ -5642,15 +5601,15 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.167.41(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tanstack/react-start@1.167.42(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@tanstack/react-router': 1.168.22(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/react-start-client': 1.166.39(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/react-start-rsc': 0.0.20(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
-      '@tanstack/react-start-server': 1.166.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-router': 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-start-client': 1.166.40(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-start-rsc': 0.0.21(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@tanstack/react-start-server': 1.166.41(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/router-utils': 1.161.6
       '@tanstack/start-client-core': 1.167.17
-      '@tanstack/start-plugin-core': 1.167.35(@tanstack/react-router@1.168.22(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.15))(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@tanstack/start-plugin-core': 1.167.35(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.15))(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/start-server-core': 1.167.19(crossws@0.4.5(srvx@0.11.15))
       pathe: 2.0.3
       react: 19.2.5
@@ -5698,7 +5657,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.167.22(@tanstack/react-router@1.168.22(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tanstack/router-plugin@1.167.22(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
@@ -5714,7 +5673,7 @@ snapshots:
       unplugin: 2.3.11
       zod: 3.25.76
     optionalDependencies:
-      '@tanstack/react-router': 1.168.22(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-router': 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       vite: 8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
@@ -5747,7 +5706,7 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.161.6': {}
 
-  '@tanstack/start-plugin-core@1.167.35(@tanstack/react-router@1.168.22(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.15))(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tanstack/start-plugin-core@1.167.35(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.15))(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.0
@@ -5755,7 +5714,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.40
       '@tanstack/router-core': 1.168.15
       '@tanstack/router-generator': 1.166.32
-      '@tanstack/router-plugin': 1.167.22(@tanstack/react-router@1.168.22(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@tanstack/router-plugin': 1.167.22(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/router-utils': 1.161.6
       '@tanstack/start-client-core': 1.167.17
       '@tanstack/start-server-core': 1.167.19(crossws@0.4.5(srvx@0.11.15))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
 
   cli:
     dependencies:
+      '@peculiar/x509':
+        specifier: ^2.0.0
+        version: 2.0.0
       croner:
         specifier: ^10.0.1
         version: 10.0.1
@@ -63,6 +66,9 @@ importers:
       '@types/proper-lockfile':
         specifier: ^4.1.4
         version: 4.1.4
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
       vitest:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@20.19.39)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
@@ -959,6 +965,40 @@ packages:
 
   '@package-json/types@0.0.12':
     resolution: {integrity: sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==}
+
+  '@peculiar/asn1-cms@2.6.1':
+    resolution: {integrity: sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==}
+
+  '@peculiar/asn1-csr@2.6.1':
+    resolution: {integrity: sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w==}
+
+  '@peculiar/asn1-ecc@2.6.1':
+    resolution: {integrity: sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g==}
+
+  '@peculiar/asn1-pfx@2.6.1':
+    resolution: {integrity: sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw==}
+
+  '@peculiar/asn1-pkcs8@2.6.1':
+    resolution: {integrity: sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw==}
+
+  '@peculiar/asn1-pkcs9@2.6.1':
+    resolution: {integrity: sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw==}
+
+  '@peculiar/asn1-rsa@2.6.1':
+    resolution: {integrity: sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==}
+
+  '@peculiar/asn1-schema@2.6.0':
+    resolution: {integrity: sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==}
+
+  '@peculiar/asn1-x509-attr@2.6.1':
+    resolution: {integrity: sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ==}
+
+  '@peculiar/asn1-x509@2.6.1':
+    resolution: {integrity: sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==}
+
+  '@peculiar/x509@2.0.0':
+    resolution: {integrity: sha512-r10lkuy6BNfRmyYdRAfgu6dq0HOmyIV2OLhXWE3gDEPBdX1b8miztJVyX/UxWhLwemNyDP3CLZHpDxDwSY0xaA==}
+    engines: {node: '>=20.0.0'}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
@@ -2033,6 +2073,10 @@ packages:
 
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  asn1js@3.0.7:
+    resolution: {integrity: sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==}
+    engines: {node: '>=12.0.0'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -3482,6 +3526,13 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  pvtsutils@1.3.6:
+    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
+
+  pvutils@1.1.5:
+    resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
+    engines: {node: '>=16.0.0'}
+
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
@@ -3516,6 +3567,9 @@ packages:
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
+
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -3852,6 +3906,9 @@ packages:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
 
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -3859,6 +3916,10 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tsyringe@4.10.0:
+    resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
+    engines: {node: '>= 6.0.0'}
 
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
@@ -5049,6 +5110,95 @@ snapshots:
 
   '@package-json/types@0.0.12': {}
 
+  '@peculiar/asn1-cms@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      '@peculiar/asn1-x509-attr': 2.6.1
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-csr@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-ecc@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pfx@2.6.1':
+    dependencies:
+      '@peculiar/asn1-cms': 2.6.1
+      '@peculiar/asn1-pkcs8': 2.6.1
+      '@peculiar/asn1-rsa': 2.6.1
+      '@peculiar/asn1-schema': 2.6.0
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs8@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs9@2.6.1':
+    dependencies:
+      '@peculiar/asn1-cms': 2.6.1
+      '@peculiar/asn1-pfx': 2.6.1
+      '@peculiar/asn1-pkcs8': 2.6.1
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      '@peculiar/asn1-x509-attr': 2.6.1
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-rsa@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-schema@2.6.0':
+    dependencies:
+      asn1js: 3.0.7
+      pvtsutils: 1.3.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509-attr@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      asn1js: 3.0.7
+      pvtsutils: 1.3.6
+      tslib: 2.8.1
+
+  '@peculiar/x509@2.0.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.6.1
+      '@peculiar/asn1-csr': 2.6.1
+      '@peculiar/asn1-ecc': 2.6.1
+      '@peculiar/asn1-pkcs9': 2.6.1
+      '@peculiar/asn1-rsa': 2.6.1
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      pvtsutils: 1.3.6
+      tslib: 2.8.1
+      tsyringe: 4.10.0
+
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     optional: true
 
@@ -6043,6 +6193,12 @@ snapshots:
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
+
+  asn1js@3.0.7:
+    dependencies:
+      pvtsutils: 1.3.6
+      pvutils: 1.1.5
+      tslib: 2.8.1
 
   assertion-error@2.0.1: {}
 
@@ -7494,6 +7650,12 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  pvtsutils@1.3.6:
+    dependencies:
+      tslib: 2.8.1
+
+  pvutils@1.1.5: {}
+
   qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
@@ -7529,6 +7691,8 @@ snapshots:
       source-map: 0.6.1
       tiny-invariant: 1.3.3
       tslib: 2.8.1
+
+  reflect-metadata@0.2.2: {}
 
   require-directory@2.1.1: {}
 
@@ -7925,6 +8089,8 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
+  tslib@1.14.1: {}
+
   tslib@2.8.1: {}
 
   tsx@4.21.0:
@@ -7933,6 +8099,10 @@ snapshots:
       get-tsconfig: 4.14.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  tsyringe@4.10.0:
+    dependencies:
+      tslib: 1.14.1
 
   tw-animate-css@1.4.0: {}
 

--- a/skills/sigcli-auth/SKILL.md
+++ b/skills/sigcli-auth/SKILL.md
@@ -33,9 +33,11 @@ sigcli (`sig`) is a CLI tool that stores and manages authentication credentials 
 | `sig sync push\|pull [remote]`   | Sync credentials over SSH                        | Share credentials with headless machines        | 5-30s                            |
 | `sig watch add <provider>`       | Add provider to auto-refresh watch list          | Keep long-lived sessions alive                  | < 1s                             |
 | `sig watch remove <provider>`    | Remove from watch list                           | Stop auto-refresh                               | < 1s                             |
-| `sig watch list`                 | Show watched providers                           | Inspect watch config                            | < 1s                             |
-| `sig watch start`                | Start auto-refresh daemon                        | Run in background for session maintenance       | Continuous                       |
 | `sig watch set-interval <dur>`   | Set default watch interval                       | Tune refresh frequency                          | < 1s                             |
+| `sig proxy start [--port N]`     | Start MITM proxy daemon                          | Daemons/tools that read HTTP_PROXY env vars     | < 1s (daemon runs in background) |
+| `sig proxy stop`                 | Stop proxy daemon                                | Shut down proxy                                 | < 1s                             |
+| `sig proxy status`               | Show proxy running state and port                | Check if proxy is running                       | < 1s                             |
+| `sig proxy trust`                | Print CA cert path + OS trust instructions       | First-time proxy setup                          | < 1s                             |
 | `sig run [provider...] -- <cmd>` | Run command with credentials in env              | Scripts that need SIG\_<PROVIDER\>\_\* env vars | < 1s + child process             |
 
 ---
@@ -214,9 +216,38 @@ sig get <provider> --format json   # includes type, headerName, value, xHeaders
 
 ```bash
 sig watch add <provider>
-sig watch start --interval 30m   # refresh every 30 minutes
-sig watch start --once           # single cycle (for cron)
+sig watch set-interval 30m   # change default refresh interval
+# The watch loop runs automatically inside the proxy daemon:
+sig proxy start              # starts both MITM proxy + watch loop
 ```
+
+### Use MITM proxy for transparent credential injection
+
+Use `sig proxy` when you have tools that can't be wrapped with `sig run` — long-lived daemons, tools that fork process trees, or tools that only read proxy env vars.
+
+```bash
+# 1. Start the proxy (also runs the watch/refresh loop)
+sig proxy start
+
+# 2. Trust the CA cert (one-time per machine)
+sig proxy trust   # prints path + OS-specific instructions
+
+# 3. Point your tools at the proxy
+export HTTP_PROXY=http://127.0.0.1:7891
+export HTTPS_PROXY=http://127.0.0.1:7891
+
+# 4. Now any HTTP/HTTPS request gets credentials injected automatically
+curl https://jira.example.com/api/me   # no SIG_* env vars needed
+python long_running_agent.py           # daemon never sees credentials
+
+# Stop when done
+sig proxy stop
+```
+
+**When to use proxy vs sig run:**
+
+- `sig run` — simpler, wraps a single command, no CA trust required
+- `sig proxy` — for daemons, process trees, or tools that only respect proxy env vars
 
 ---
 
@@ -262,7 +293,7 @@ sig get <provider>          # reads + decrypts local credential file
 sig status [provider]       # reads credential files + decrypts + parses JWT
 sig providers               # reads config file
 sig remote list             # reads config file
-sig watch list              # reads config file
+sig proxy status            # reads PID/port state files
 ```
 
 ### Moderate -- network I/O
@@ -298,6 +329,6 @@ sig login <url>             # 30-120s; uses playwright-core
 
 6. **Credentials are encrypted at rest.** `~/.sig/credentials/` stores AES-256-GCM encrypted files. The encryption key is at `~/.sig/encryption.key`. Do not commit, copy, or transmit credential files or the encryption key.
 
-7. **`sig watch start` runs forever.** Only invoke it as a background daemon, not in interactive agent loops.
+7. **`sig proxy start` runs a background daemon.** Only invoke once; use `sig proxy stop` to shut it down. For credential refresh, the proxy runs the watch loop automatically — no need to run `sig watch start` separately.
 
 8. **Use `--verbose` to debug.** All internal logs go to stderr and are hidden by default. Add `--verbose` when diagnosing failures.

--- a/website/src/content/docs-zh.tsx
+++ b/website/src/content/docs-zh.tsx
@@ -397,8 +397,8 @@ sig watch set-interval 1h       # 更改默认间隔`}</CodeBlock>
                         sig proxy
                     </SectionHeading>
                     <P>
-                        运行本地 MITM HTTP/HTTPS 代理守护进程。代理工具将{' '}
-                        <Code>HTTP_PROXY</Code>/<Code>HTTPS_PROXY</Code> 指向代理后发起普通请求——
+                        运行本地 MITM HTTP/HTTPS 代理守护进程。代理工具将 <Code>HTTP_PROXY</Code>/
+                        <Code>HTTPS_PROXY</Code> 指向代理后发起普通请求——
                         凭证透明注入，代理工具永远不会看到令牌值。代理同时运行监视/刷新循环。
                     </P>
                     <CodeBlock lang="bash">{`sig proxy start                  # 启动守护进程（默认端口 7891）
@@ -413,8 +413,8 @@ export HTTPS_PROXY=http://127.0.0.1:7891
 curl https://jira.example.com/api/me   # 凭证自动注入`}</CodeBlock>
                     <P>
                         <strong>何时用代理 vs sig run：</strong>用 <Code>sig run</Code>{' '}
-                        包裹单个命令；用 <Code>sig proxy</Code> 处理长期守护进程、会派生进程树的工具，
-                        或只读取代理环境变量的工具。
+                        包裹单个命令；用 <Code>sig proxy</Code>{' '}
+                        处理长期守护进程、会派生进程树的工具， 或只读取代理环境变量的工具。
                     </P>
 
                     <SectionHeading id="cmd-completion" level={2}>

--- a/website/src/content/docs-zh.tsx
+++ b/website/src/content/docs-zh.tsx
@@ -57,6 +57,7 @@ export const pageContent = {
         tocItem('#cmd-remote', 'sig remote', { level: 1, parent: '#commands', prefix: '├ ' }),
         tocItem('#cmd-sync', 'sig sync', { level: 1, parent: '#commands', prefix: '├ ' }),
         tocItem('#cmd-watch', 'sig watch', { level: 1, parent: '#commands', prefix: '├ ' }),
+        tocItem('#cmd-proxy', 'sig proxy', { level: 1, parent: '#commands', prefix: '├ ' }),
         tocItem('#cmd-completion', 'sig completion', {
             level: 1,
             parent: '#commands',
@@ -384,17 +385,37 @@ sig sync push --force            # 冲突时覆盖`}</CodeBlock>
                         sig watch
                     </SectionHeading>
                     <P>
-                        按计划自动刷新凭证。将 <Code>sig watch start</Code>{' '}
-                        作为后台守护进程运行，以保持会话活跃。
+                        管理自动刷新监视列表。监视循环本身作为代理守护进程的一部分运行——使用{' '}
+                        <Code>sig proxy start</Code> 自动保持会话活跃。
                     </P>
                     <CodeBlock lang="bash">{`sig watch add my-jira           # 添加到监视列表
 sig watch add my-jira --auto-sync prod   # 刷新后自动同步
 sig watch remove my-jira        # 从监视列表移除
-sig watch list                   # 显示被监视的提供者
-sig watch start                  # 启动自动刷新守护进程
-sig watch start --interval 30m   # 每 30 分钟刷新一次
-sig watch start --once           # 单次循环后退出
-sig watch set-interval 1h        # 更改默认间隔`}</CodeBlock>
+sig watch set-interval 1h       # 更改默认间隔`}</CodeBlock>
+
+                    <SectionHeading id="cmd-proxy" level={2}>
+                        sig proxy
+                    </SectionHeading>
+                    <P>
+                        运行本地 MITM HTTP/HTTPS 代理守护进程。代理工具将{' '}
+                        <Code>HTTP_PROXY</Code>/<Code>HTTPS_PROXY</Code> 指向代理后发起普通请求——
+                        凭证透明注入，代理工具永远不会看到令牌值。代理同时运行监视/刷新循环。
+                    </P>
+                    <CodeBlock lang="bash">{`sig proxy start                  # 启动守护进程（默认端口 7891）
+sig proxy start --port 8080      # 使用自定义端口
+sig proxy stop                   # 停止守护进程
+sig proxy status                 # 显示运行状态、端口和环境变量提示
+sig proxy trust                  # 打印 CA 证书路径和操作系统信任说明
+
+# 用法：将任意工具指向代理
+export HTTP_PROXY=http://127.0.0.1:7891
+export HTTPS_PROXY=http://127.0.0.1:7891
+curl https://jira.example.com/api/me   # 凭证自动注入`}</CodeBlock>
+                    <P>
+                        <strong>何时用代理 vs sig run：</strong>用 <Code>sig run</Code>{' '}
+                        包裹单个命令；用 <Code>sig proxy</Code> 处理长期守护进程、会派生进程树的工具，
+                        或只读取代理环境变量的工具。
+                    </P>
 
                     <SectionHeading id="cmd-completion" level={2}>
                         sig completion
@@ -406,8 +427,8 @@ sig completion fish > ~/.config/fish/completions/sig.fish`}</CodeBlock>
             ),
             aside: (
                 <P>
-                    <Code>sig watch start</Code>{' '}
-                    会无限运行——只能作为后台进程或守护进程调用，切勿在交互式循环中使用。
+                    使用 <Code>sig proxy start</Code>{' '}
+                    将监视循环作为后台守护进程运行——它同时保持凭证新鲜并处理 HTTPS 拦截。
                 </P>
             ),
         },
@@ -423,6 +444,12 @@ sig completion fish > ~/.config/fish/completions/sig.fish`}</CodeBlock>
                         <Code>sig run</Code> 将 <Code>SIG_&lt;PROVIDER&gt;_*</Code>{' '}
                         变量注入子进程。使用 <Code>sig run my-jira -- env | grep SIG_MY_JIRA_</Code>{' '}
                         来探索某个提供者可用的具体变量。
+                    </P>
+                    <P>
+                        使用代理时（<Code>sig proxy start</Code>），设置{' '}
+                        <Code>HTTP_PROXY=http://127.0.0.1:&lt;port&gt;</Code> 和{' '}
+                        <Code>HTTPS_PROXY=http://127.0.0.1:&lt;port&gt;</Code>——凭证由代理注入，
+                        无需 <Code>SIG_*</Code> 环境变量。
                     </P>
                     <CodeBlock lang="bash">{`# 始终存在（以提供者 "my-jira" 为例）
 SIG_MY_JIRA_PROVIDER          # 提供者 ID："my-jira"
@@ -687,11 +714,17 @@ result = sig.request("https://jira.example.com/api/issues/123")`}</CodeBlock>
                     </P>
                     <P>
                         推荐模式是 <Code>sig run</Code>：代理启动一个子进程，凭证已在环境中。
-                        代理永远不会看到令牌值。
+                        代理永远不会看到令牌值。对于无法包裹的工具——长期守护进程、会派生进程的工具——
+                        请改用 <Code>sig proxy start</Code>。
                     </P>
                     <CodeBlock lang="bash">{`# 推荐：sig run 将凭证排除在代理上下文之外
 sig run my-jira -- python fetch_issues.py
 sig run my-jira -- node export_sprint.js
+
+# 备选：sig proxy，适用于守护进程或只读取代理环境变量的工具
+sig proxy start
+export HTTP_PROXY=http://127.0.0.1:7891 HTTPS_PROXY=http://127.0.0.1:7891
+# 现在任何遵循代理环境变量的工具都会自动注入凭证
 
 # 探索可用的 SIG_<PROVIDER>_* 变量
 sig run my-jira -- env | grep SIG_MY_JIRA_

--- a/website/src/content/docs.tsx
+++ b/website/src/content/docs.tsx
@@ -60,6 +60,7 @@ export const pageContent = {
         tocItem('#cmd-remote', 'sig remote', { level: 1, parent: '#commands', prefix: '├ ' }),
         tocItem('#cmd-sync', 'sig sync', { level: 1, parent: '#commands', prefix: '├ ' }),
         tocItem('#cmd-watch', 'sig watch', { level: 1, parent: '#commands', prefix: '├ ' }),
+        tocItem('#cmd-proxy', 'sig proxy', { level: 1, parent: '#commands', prefix: '├ ' }),
         tocItem('#cmd-completion', 'sig completion', {
             level: 1,
             parent: '#commands',
@@ -398,17 +399,40 @@ sig sync push --force            # overwrite on conflict`}</CodeBlock>
                         sig watch
                     </SectionHeading>
                     <P>
-                        Auto-refreshes credentials on a schedule. Run <Code>sig watch start</Code>{' '}
-                        as a background daemon to keep sessions alive.
+                        Manages the auto-refresh watch list. The watch loop itself runs as part of
+                        the proxy daemon — use <Code>sig proxy start</Code> to keep sessions alive
+                        automatically.
                     </P>
                     <CodeBlock lang="bash">{`sig watch add my-jira           # add to watch list
 sig watch add my-jira --auto-sync prod   # auto-sync after refresh
 sig watch remove my-jira        # remove from watch list
-sig watch list                   # show watched providers
-sig watch start                  # start auto-refresh daemon
-sig watch start --interval 30m   # refresh every 30 minutes
-sig watch start --once           # single cycle, then exit
-sig watch set-interval 1h        # change default interval`}</CodeBlock>
+sig watch set-interval 1h       # change default interval`}</CodeBlock>
+
+                    <SectionHeading id="cmd-proxy" level={2}>
+                        sig proxy
+                    </SectionHeading>
+                    <P>
+                        Runs a local MITM HTTP/HTTPS proxy daemon. Agents point{' '}
+                        <Code>HTTP_PROXY</Code>/<Code>HTTPS_PROXY</Code> at the proxy and make
+                        normal requests — credentials are injected transparently and the agent
+                        never sees token values. The proxy also runs the watch/refresh loop.
+                    </P>
+                    <CodeBlock lang="bash">{`sig proxy start                  # start daemon (default port 7891)
+sig proxy start --port 8080      # use custom port
+sig proxy stop                   # stop daemon
+sig proxy status                 # show running state, port, env var hints
+sig proxy trust                  # print CA cert path + OS trust instructions
+
+# Usage: point any tool at the proxy
+export HTTP_PROXY=http://127.0.0.1:7891
+export HTTPS_PROXY=http://127.0.0.1:7891
+curl https://jira.example.com/api/me   # credentials injected automatically`}</CodeBlock>
+                    <P>
+                        <strong>When to use proxy vs sig run:</strong> Use <Code>sig run</Code> for
+                        wrapping a single command. Use <Code>sig proxy</Code> for long-lived
+                        daemons, tools that fork process trees, or tools that only read proxy env
+                        vars.
+                    </P>
 
                     <SectionHeading id="cmd-completion" level={2}>
                         sig completion
@@ -420,8 +444,8 @@ sig completion fish > ~/.config/fish/completions/sig.fish`}</CodeBlock>
             ),
             aside: (
                 <P>
-                    <Code>sig watch start</Code> runs indefinitely — only invoke it as a background
-                    process or daemon, never in an interactive loop.
+                    Use <Code>sig proxy start</Code> to run the watch loop as a background daemon
+                    — it keeps credentials fresh and handles HTTPS interception simultaneously.
                 </P>
             ),
         },
@@ -438,6 +462,12 @@ sig completion fish > ~/.config/fish/completions/sig.fish`}</CodeBlock>
                         into the child process. Use{' '}
                         <Code>sig run my-jira -- env | grep SIG_MY_JIRA_</Code> to discover exactly
                         what's available for a provider.
+                    </P>
+                    <P>
+                        When using the proxy (<Code>sig proxy start</Code>), set{' '}
+                        <Code>HTTP_PROXY=http://127.0.0.1:&lt;port&gt;</Code> and{' '}
+                        <Code>HTTPS_PROXY=http://127.0.0.1:&lt;port&gt;</Code> — credentials are
+                        injected by the proxy and no <Code>SIG_*</Code> variables are needed.
                     </P>
                     <CodeBlock lang="bash">{`# Always present (example: provider "my-jira")
 SIG_MY_JIRA_PROVIDER          # provider ID: "my-jira"
@@ -717,11 +747,17 @@ result = sig.request("https://jira.example.com/api/issues/123")`}</CodeBlock>
                     <P>
                         The recommended pattern is <Code>sig run</Code>: the agent spawns a child
                         process with credentials already in the environment. The agent never sees
-                        token values.
+                        token values. For tools that can't be wrapped — long-lived daemons, tools
+                        that fork — use <Code>sig proxy start</Code> instead.
                     </P>
                     <CodeBlock lang="bash">{`# Recommended: sig run keeps credentials out of agent context
 sig run my-jira -- python fetch_issues.py
 sig run my-jira -- node export_sprint.js
+
+# Alternative: sig proxy for daemons / tools that only read proxy env vars
+sig proxy start
+export HTTP_PROXY=http://127.0.0.1:7891 HTTPS_PROXY=http://127.0.0.1:7891
+# now any tool that respects proxy env vars gets credentials injected
 
 # Discovery: find out what SIG_<PROVIDER>_* vars are available
 sig run my-jira -- env | grep SIG_MY_JIRA_

--- a/website/src/content/docs.tsx
+++ b/website/src/content/docs.tsx
@@ -414,8 +414,8 @@ sig watch set-interval 1h       # change default interval`}</CodeBlock>
                     <P>
                         Runs a local MITM HTTP/HTTPS proxy daemon. Agents point{' '}
                         <Code>HTTP_PROXY</Code>/<Code>HTTPS_PROXY</Code> at the proxy and make
-                        normal requests — credentials are injected transparently and the agent
-                        never sees token values. The proxy also runs the watch/refresh loop.
+                        normal requests — credentials are injected transparently and the agent never
+                        sees token values. The proxy also runs the watch/refresh loop.
                     </P>
                     <CodeBlock lang="bash">{`sig proxy start                  # start daemon (default port 7891)
 sig proxy start --port 8080      # use custom port
@@ -444,8 +444,8 @@ sig completion fish > ~/.config/fish/completions/sig.fish`}</CodeBlock>
             ),
             aside: (
                 <P>
-                    Use <Code>sig proxy start</Code> to run the watch loop as a background daemon
-                    — it keeps credentials fresh and handles HTTPS interception simultaneously.
+                    Use <Code>sig proxy start</Code> to run the watch loop as a background daemon —
+                    it keeps credentials fresh and handles HTTPS interception simultaneously.
                 </P>
             ),
         },

--- a/website/src/content/en.tsx
+++ b/website/src/content/en.tsx
@@ -91,6 +91,10 @@ export const pageContent = {
  │  curl, fetch,    │    │  ┌─────────────────┐  │    │  cookies, tokens,    │
  │  agents, CI      │<───┼──┤ SSH transport   │  │    │  x-headers,          │
  │                  │    │  │ sig sync push   │  │    │  localStorage        │
+ │  ┌────────────┐  │    │  └─────────────────┘  │    │                      │
+ │  │HTTP_PROXY= ├──┼──> │  ┌─────────────────┐  │    │                      │
+ │  │sig proxy   │  │    │  │ MITM proxy      │  │    │                      │
+ │  └────────────┘  │    │  │ sig proxy start │  │    │                      │
  │                  │    │  └─────────────────┘  │    │                      │
  └──────────────────┘    └───────────────────────┘    └──────────────────────┘
 `}</CodeBlock>
@@ -181,6 +185,14 @@ $ sig run my-jira -- node export_board.js`}</CodeBlock>
                         Features
                     </SectionHeading>
                     <List>
+                        <Li>
+                            <strong>MITM proxy</strong> — <Code>sig proxy start</Code> runs a local
+                            HTTPS proxy at <Code>127.0.0.1</Code>. Agents set{' '}
+                            <Code>HTTP_PROXY</Code>/<Code>HTTPS_PROXY</Code> and credentials are
+                            injected transparently — the agent never sees tokens. Ideal for
+                            long-lived daemons or tools that can't be wrapped with{' '}
+                            <Code>sig run</Code>.
+                        </Li>
                         <Li>
                             <strong>sig run</strong> — inject <Code>SIG_&lt;PROVIDER&gt;_*</Code>{' '}
                             credentials directly into any child process. Values are redacted from

--- a/website/src/content/zh.tsx
+++ b/website/src/content/zh.tsx
@@ -90,6 +90,10 @@ export const pageContent = {
  │  curl, fetch,    │    │  ┌─────────────────┐  │    │  cookies, tokens,    │
  │  agents, CI      │<───┼──┤ SSH transport   │  │    │  x-headers,          │
  │                  │    │  │ sig sync push   │  │    │  localStorage        │
+ │  ┌────────────┐  │    │  └─────────────────┘  │    │                      │
+ │  │HTTP_PROXY= ├──┼──> │  ┌─────────────────┐  │    │                      │
+ │  │sig proxy   │  │    │  │ MITM proxy      │  │    │                      │
+ │  └────────────┘  │    │  │ sig proxy start │  │    │                      │
  │                  │    │  └─────────────────┘  │    │                      │
  └──────────────────┘    └───────────────────────┘    └──────────────────────┘
 `}</CodeBlock>
@@ -177,6 +181,13 @@ $ sig run my-jira -- node export_board.js`}</CodeBlock>
                         功能特性
                     </SectionHeading>
                     <List>
+                        <Li>
+                            <strong>MITM 代理</strong> — <Code>sig proxy start</Code>{' '}
+                            在本地 <Code>127.0.0.1</Code> 启动 HTTPS 代理。代理设置{' '}
+                            <Code>HTTP_PROXY</Code>/<Code>HTTPS_PROXY</Code>，凭证透明注入——
+                            代理工具永远不会看到令牌。适用于无法用 <Code>sig run</Code>{' '}
+                            包裹的长期守护进程或工具。
+                        </Li>
                         <Li>
                             <strong>sig run</strong> — 将 <Code>SIG_&lt;PROVIDER&gt;_*</Code>{' '}
                             凭证直接注入任意子进程，输出中的凭证值自动脱敏。这是使用凭证的推荐方式。

--- a/website/src/content/zh.tsx
+++ b/website/src/content/zh.tsx
@@ -182,9 +182,9 @@ $ sig run my-jira -- node export_board.js`}</CodeBlock>
                     </SectionHeading>
                     <List>
                         <Li>
-                            <strong>MITM 代理</strong> — <Code>sig proxy start</Code>{' '}
-                            在本地 <Code>127.0.0.1</Code> 启动 HTTPS 代理。代理设置{' '}
-                            <Code>HTTP_PROXY</Code>/<Code>HTTPS_PROXY</Code>，凭证透明注入——
+                            <strong>MITM 代理</strong> — <Code>sig proxy start</Code> 在本地{' '}
+                            <Code>127.0.0.1</Code> 启动 HTTPS 代理。代理设置 <Code>HTTP_PROXY</Code>
+                            /<Code>HTTPS_PROXY</Code>，凭证透明注入——
                             代理工具永远不会看到令牌。适用于无法用 <Code>sig run</Code>{' '}
                             包裹的长期守护进程或工具。
                         </Li>


### PR DESCRIPTION
## Summary

- Add `sig proxy start|stop|status|trust` — a local MITM HTTP/HTTPS proxy daemon that intercepts agent requests and injects credentials transparently, so agents **never see real credentials**
- The proxy daemon also runs the credential watch/refresh loop, replacing `sig watch start`
- Closes the #1 architectural gap vs competitors (env var credential exposure)

## What changed

### New: `cli/src/proxy/`
- **`ca-manager.ts`** — Self-signed ECDSA P-256 CA + per-hostname leaf cert generation with in-memory cache
- **`proxy-server.ts`** — HTTP proxy with credential injection + HTTPS CONNECT with MITM TLS termination or transparent tunneling
- **`daemon.ts`** — Runs proxy server + watch refresh loop in a single background process
- **`proxy-state.ts`** — PID/port file management for daemon lifecycle

### New: `cli/src/cli/commands/proxy.ts`
- `sig proxy start [--port <n>]` — start daemon in background
- `sig proxy stop` — stop daemon
- `sig proxy status` — show running state, port, env vars to set
- `sig proxy trust` — print OS-specific CA trust instructions

### Modified
- **`watch.ts`** — Removed `list` and `start` subcommands (covered by proxy daemon)
- **`constants.ts`** — Added `Command.PROXY`, `ProxySubcommand`; removed `WatchSubcommand.LIST/START`
- **`main.ts`** — Wired proxy command, updated help text

### How it works
```
Agent (no credentials, just HTTP_PROXY set)
  │  CONNECT api.example.com:443
  ▼
sig proxy (127.0.0.1:<port>)
  1. providerRegistry.resolve(hostname) → provider
  2. authManager.getCredentials(provider.id) → credential
  3. applyToRequest() → inject real auth headers
  4. Generate leaf cert, MITM the TLS connection
  5. Forward to real upstream, stream response back
  ▼
api.example.com (sees real credential, agent never did)
```

## Test plan

- [x] 50 test files, 646 tests passing
- [x] E2E: `sig proxy start` → `curl --proxy` to authenticated API → verified credential injection works
- [x] E2E: transparent tunnel for unknown hosts (no MITM)
- [x] E2E: `sig proxy status` / `sig proxy stop` lifecycle
- [x] Watch loop runs inside daemon (auto-refreshes watched providers)