### PR TITLE
fix: sig init browser menu, sig get redaction, proxy docs

### DIFF
--- a/cli/src/cli/commands/get.ts
+++ b/cli/src/cli/commands/get.ts
@@ -5,6 +5,7 @@ import { formatJson, formatCredentialHeaders } from '../formatters.js';
 import { ExitCode } from '../exit-codes.js';
 import { CredentialTypeName, HttpHeader, OutputFormat } from '../../core/constants.js';
 import { logAuditEvent, AuditAction, AuditStatus } from '../../audit/audit-log.js';
+import { extractSensitiveValues, redactOutput } from '../../utils/redact.js';
 
 const PRIMARY_HEADERS = [HttpHeader.COOKIE.toLowerCase(), HttpHeader.AUTHORIZATION.toLowerCase()];
 
@@ -91,11 +92,12 @@ export async function runGet(
     }
 
     const headers = deps.authManager.applyToRequest(providerId, credential);
+    const noRedaction = flags['no-redaction'] === true;
     await logAuditEvent({
         action: AuditAction.CREDENTIAL_ACCESS,
         status: AuditStatus.SUCCESS,
         provider: providerId,
-        metadata: { credentialType: credential.type },
+        metadata: { credentialType: credential.type, redacted: !noRedaction },
     });
     const entries = Object.entries(headers);
 
@@ -117,17 +119,36 @@ export async function runGet(
     }
 
     const format = (flags.format as string) ?? OutputFormat.JSON;
+    if (noRedaction) {
+        process.stderr.write(
+            'Warning: Outputting raw credential values — do not expose to untrusted processes.\n',
+        );
+    }
+    const secrets = noRedaction ? [] : extractSensitiveValues(credential);
+    const redact = (text: string): string => (noRedaction ? text : redactOutput(text, secrets));
 
     switch (format) {
         case OutputFormat.JSON: {
             const credentialObj: Record<string, unknown> = {
                 type: credential.type,
                 headerName: primaryHeaderName,
-                value: primaryHeaderValue,
+                value: redact(primaryHeaderValue),
             };
-            if (Object.keys(xHeaders).length > 0) credentialObj.xHeaders = xHeaders;
+            if (Object.keys(xHeaders).length > 0) {
+                const redactedXHeaders: Record<string, string> = {};
+                for (const [k, v] of Object.entries(xHeaders)) {
+                    redactedXHeaders[k] = redact(v);
+                }
+                credentialObj.xHeaders = redactedXHeaders;
+            }
             const ls = getLocalStorage(credential);
-            if (ls) credentialObj.localStorage = ls;
+            if (ls) {
+                const redactedLs: Record<string, string> = {};
+                for (const [k, v] of Object.entries(ls)) {
+                    redactedLs[k] = redact(v);
+                }
+                credentialObj.localStorage = redactedLs;
+            }
             const output = {
                 provider: providerId,
                 credential: credentialObj,
@@ -136,18 +157,22 @@ export async function runGet(
             break;
         }
         case OutputFormat.HEADER: {
-            process.stdout.write(formatCredentialHeaders(headers) + '\n');
+            const redactedHeaders: Record<string, string> = {};
+            for (const [k, v] of Object.entries(headers)) {
+                redactedHeaders[k] = redact(v);
+            }
+            process.stdout.write(formatCredentialHeaders(redactedHeaders) + '\n');
             break;
         }
         case OutputFormat.VALUE: {
-            process.stdout.write(primaryHeaderValue + '\n');
+            process.stdout.write(redact(primaryHeaderValue) + '\n');
             for (const [name, value] of Object.entries(xHeaders)) {
-                process.stdout.write(`${name}=${value}\n`);
+                process.stdout.write(`${name}=${redact(value)}\n`);
             }
             const ls = getLocalStorage(credential);
             if (ls) {
                 for (const [name, value] of Object.entries(ls)) {
-                    process.stdout.write(`${name}=${value}\n`);
+                    process.stdout.write(`${name}=${redact(value)}\n`);
                 }
             }
             break;

--- a/cli/src/cli/commands/init.ts
+++ b/cli/src/cli/commands/init.ts
@@ -54,11 +54,11 @@ const STRATEGY_TEMPLATES: Record<string, StrategyTemplate> = {
 // ---------------------------------------------------------------------------
 
 function detectBrowserChannel(): string {
-    const channels = ['chrome', 'msedge', 'chromium'];
+    const channels = ['msedge', 'chrome', 'chromium'];
     for (const ch of channels) {
         if (findChannelBrowser(ch) !== null) return ch;
     }
-    return 'chrome';
+    return 'msedge';
 }
 
 // ---------------------------------------------------------------------------
@@ -174,7 +174,7 @@ export async function runInit(
     }
 
     // Detect defaults
-    const detectedChannel = remote ? 'chrome' : detectBrowserChannel();
+    const detectedChannel = remote ? 'msedge' : detectBrowserChannel();
     const defaultChannel = typeof flags.channel === 'string' ? flags.channel : detectedChannel;
     const defaultBrowserDataDir =
         typeof flags['browser-data-dir'] === 'string'
@@ -203,8 +203,28 @@ export async function runInit(
         try {
             process.stderr.write("\nWelcome to SigCLI! Let's set up your configuration.\n\n");
 
-            const channelAnswer = await rl.question(`Browser channel [${defaultChannel}]: `);
-            if (channelAnswer.trim()) channel = channelAnswer.trim();
+            const browserOptions = ['msedge', 'chrome', 'chromium'];
+            const browserStatus = browserOptions.map((ch) => ({
+                name: ch,
+                found: findChannelBrowser(ch) !== null,
+            }));
+            const defaultIndex = browserOptions.indexOf(defaultChannel);
+            const defaultMenuChoice = defaultIndex >= 0 ? String(defaultIndex + 1) : '1';
+            process.stderr.write('Available browsers:\n');
+            browserStatus.forEach((b, i) => {
+                const mark = b.found ? '✓ (detected)' : '✗ (not found)';
+                process.stderr.write(`  ${i + 1}. ${b.name} ${mark}\n`);
+            });
+            const channelAnswer = await rl.question(`Browser channel [${defaultMenuChoice}]: `);
+            const trimmed = channelAnswer.trim();
+            if (trimmed) {
+                const asNumber = parseInt(trimmed, 10);
+                if (!isNaN(asNumber) && asNumber >= 1 && asNumber <= browserOptions.length) {
+                    channel = browserOptions[asNumber - 1];
+                } else if (browserOptions.includes(trimmed)) {
+                    channel = trimmed;
+                }
+            }
 
             providers = await promptProviders(rl);
         } finally {

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -90,6 +90,7 @@ Authentication:
 Credentials:
   get <provider|url>           Retrieve credential headers
     --format json|header|value   Output format (default: json)
+    --no-redaction               Output raw (unredacted) credential values
   request <url>                Make an authenticated HTTP request
     --method <METHOD>            HTTP method (default: GET)
     --body <json>                Request body
@@ -140,7 +141,7 @@ Setup:
     --remote                     Headless machine setup (mode: browserless)
     --yes                        Accept defaults, skip prompts
     --force                      Overwrite existing config
-    --channel <name>             Browser channel (chrome|msedge|chromium)
+    --channel <name>             Browser channel (msedge|chrome|chromium)
   doctor                       Check environment, config, and encryption key
   completion <shell>           Generate shell completion script (bash|zsh|fish)
 

--- a/website/src/content/docs-zh.tsx
+++ b/website/src/content/docs-zh.tsx
@@ -417,9 +417,10 @@ curl https://jira.example.com/api/me   # 凭证自动注入`}</CodeBlock>
                         处理长期守护进程、会派生进程树的工具， 或只读取代理环境变量的工具。
                     </P>
                     <P>
-                        <strong>注入规则：</strong>对于需要在非标准位置（请求体字段、查询参数、自定义标头）
-                        注入凭证的 API，可在 Provider 配置中添加 <Code>proxy.inject</Code> 规则。
-                        代理和 <Code>sig request</Code> 会在标准凭证标头之后应用这些规则。
+                        <strong>注入规则：</strong>
+                        对于需要在非标准位置（请求体字段、查询参数、自定义标头） 注入凭证的
+                        API，可在 Provider 配置中添加 <Code>proxy.inject</Code> 规则。 代理和{' '}
+                        <Code>sig request</Code> 会在标准凭证标头之后应用这些规则。
                     </P>
                     <CodeBlock lang="yaml">{`# Example: inject xoxc token from localStorage as form body parameter
 providers:
@@ -434,13 +435,14 @@ providers:
                     <P>
                         <Code>from</Code> 字段对已存储凭证中的路径进行解析：{' '}
                         <Code>credential.cookies</Code>、<Code>credential.accessToken</Code>、{' '}
-                        <Code>credential.localStorage.&lt;key&gt;</Code>、<Code>credential.xHeaders.&lt;key&gt;</Code>。
-                        请求体注入支持 <Code>application/json</Code> 和{' '}
+                        <Code>credential.localStorage.&lt;key&gt;</Code>、
+                        <Code>credential.xHeaders.&lt;key&gt;</Code>。 请求体注入支持{' '}
+                        <Code>application/json</Code> 和{' '}
                         <Code>application/x-www-form-urlencoded</Code> 内容类型。
                     </P>
                     <P>
-                        <strong>自动刷新：</strong>代理守护进程会自动运行监视/刷新循环。
-                        在 <Code>config.yaml</Code> 中配置需要监视的 Provider：
+                        <strong>自动刷新：</strong>代理守护进程会自动运行监视/刷新循环。 在{' '}
+                        <Code>config.yaml</Code> 中配置需要监视的 Provider：
                     </P>
                     <CodeBlock lang="yaml">{`watch:
   interval: 5m           # check interval (default: 5m)
@@ -450,9 +452,9 @@ providers:
         - dev-server
     ms-teams:`}</CodeBlock>
                     <P>
-                        凭证会在过期前刷新。使用{' '}
-                        <Code>sig watch add &lt;provider&gt;</Code> 管理监视列表，或直接编辑配置文件。
-                        代理内置的监视循环无需单独运行 <Code>sig watch start</Code> 进程。
+                        凭证会在过期前刷新。使用 <Code>sig watch add &lt;provider&gt;</Code>{' '}
+                        管理监视列表，或直接编辑配置文件。 代理内置的监视循环无需单独运行{' '}
+                        <Code>sig watch start</Code> 进程。
                     </P>
                     <P>
                         <strong>信任 CA 证书：</strong>进行 HTTPS 拦截时，代理会生成本地 CA 证书。

--- a/website/src/content/docs-zh.tsx
+++ b/website/src/content/docs-zh.tsx
@@ -416,6 +416,60 @@ curl https://jira.example.com/api/me   # 凭证自动注入`}</CodeBlock>
                         包裹单个命令；用 <Code>sig proxy</Code>{' '}
                         处理长期守护进程、会派生进程树的工具， 或只读取代理环境变量的工具。
                     </P>
+                    <P>
+                        <strong>注入规则：</strong>对于需要在非标准位置（请求体字段、查询参数、自定义标头）
+                        注入凭证的 API，可在 Provider 配置中添加 <Code>proxy.inject</Code> 规则。
+                        代理和 <Code>sig request</Code> 会在标准凭证标头之后应用这些规则。
+                    </P>
+                    <CodeBlock lang="yaml">{`# Example: inject xoxc token from localStorage as form body parameter
+providers:
+  app-slack:
+    # ... domains, strategy, etc.
+    proxy:
+      inject:
+        - in: body           # header | body | query
+          action: set         # set | append | remove
+          name: token
+          from: credential.localStorage.xoxc-token`}</CodeBlock>
+                    <P>
+                        <Code>from</Code> 字段对已存储凭证中的路径进行解析：{' '}
+                        <Code>credential.cookies</Code>、<Code>credential.accessToken</Code>、{' '}
+                        <Code>credential.localStorage.&lt;key&gt;</Code>、<Code>credential.xHeaders.&lt;key&gt;</Code>。
+                        请求体注入支持 <Code>application/json</Code> 和{' '}
+                        <Code>application/x-www-form-urlencoded</Code> 内容类型。
+                    </P>
+                    <P>
+                        <strong>自动刷新：</strong>代理守护进程会自动运行监视/刷新循环。
+                        在 <Code>config.yaml</Code> 中配置需要监视的 Provider：
+                    </P>
+                    <CodeBlock lang="yaml">{`watch:
+  interval: 5m           # check interval (default: 5m)
+  providers:
+    sap-jira:
+      autoSync:            # optional: sync to remotes after refresh
+        - dev-server
+    ms-teams:`}</CodeBlock>
+                    <P>
+                        凭证会在过期前刷新。使用{' '}
+                        <Code>sig watch add &lt;provider&gt;</Code> 管理监视列表，或直接编辑配置文件。
+                        代理内置的监视循环无需单独运行 <Code>sig watch start</Code> 进程。
+                    </P>
+                    <P>
+                        <strong>信任 CA 证书：</strong>进行 HTTPS 拦截时，代理会生成本地 CA 证书。
+                        将其添加到系统信任存储：
+                    </P>
+                    <CodeBlock lang="bash">{`sig proxy trust                  # show CA cert path + instructions
+
+# macOS
+sudo security add-trusted-cert -d -r trustRoot \\
+  -k /Library/Keychains/System.keychain ~/.sig/proxy/ca.crt
+
+# Ubuntu/Debian
+sudo cp ~/.sig/proxy/ca.crt /usr/local/share/ca-certificates/sigcli-proxy.crt
+sudo update-ca-certificates
+
+# Per-command (no system trust)
+curl --cacert ~/.sig/proxy/ca.crt https://api.example.com`}</CodeBlock>
 
                     <SectionHeading id="cmd-completion" level={2}>
                         sig completion

--- a/website/src/content/docs.tsx
+++ b/website/src/content/docs.tsx
@@ -433,6 +433,62 @@ curl https://jira.example.com/api/me   # credentials injected automatically`}</C
                         daemons, tools that fork process trees, or tools that only read proxy env
                         vars.
                     </P>
+                    <P>
+                        <strong>Inject rules:</strong> For APIs that need credentials in non-standard locations
+                        (body fields, query parameters, custom headers), add <Code>proxy.inject</Code> rules
+                        to the provider config. The proxy and <Code>sig request</Code> apply these rules
+                        after standard credential headers.
+                    </P>
+                    <CodeBlock lang="yaml">{`# Example: inject xoxc token from localStorage as form body parameter
+providers:
+  app-slack:
+    # ... domains, strategy, etc.
+    proxy:
+      inject:
+        - in: body           # header | body | query
+          action: set         # set | append | remove
+          name: token
+          from: credential.localStorage.xoxc-token`}</CodeBlock>
+                    <P>
+                        The <Code>from</Code> field resolves paths against the stored credential:{' '}
+                        <Code>credential.cookies</Code>, <Code>credential.accessToken</Code>,{' '}
+                        <Code>credential.localStorage.&lt;key&gt;</Code>, <Code>credential.xHeaders.&lt;key&gt;</Code>.
+                        Body injection supports <Code>application/json</Code> and{' '}
+                        <Code>application/x-www-form-urlencoded</Code> content types.
+                    </P>
+                    <P>
+                        <strong>Auto-refresh:</strong> The proxy daemon runs the watch/refresh loop
+                        automatically. Configure which providers to watch in <Code>config.yaml</Code>:
+                    </P>
+                    <CodeBlock lang="yaml">{`watch:
+  interval: 5m           # check interval (default: 5m)
+  providers:
+    sap-jira:
+      autoSync:            # optional: sync to remotes after refresh
+        - dev-server
+    ms-teams:`}</CodeBlock>
+                    <P>
+                        Credentials are refreshed before they expire. Use{' '}
+                        <Code>sig watch add &lt;provider&gt;</Code> to manage the watch list, or edit
+                        the config directly. The proxy's built-in watch loop replaces the need for a
+                        separate <Code>sig watch start</Code> process.
+                    </P>
+                    <P>
+                        <strong>Trusting the CA:</strong> For HTTPS interception, the proxy generates a
+                        local CA certificate. Add it to your system trust store:
+                    </P>
+                    <CodeBlock lang="bash">{`sig proxy trust                  # show CA cert path + instructions
+
+# macOS
+sudo security add-trusted-cert -d -r trustRoot \\
+  -k /Library/Keychains/System.keychain ~/.sig/proxy/ca.crt
+
+# Ubuntu/Debian
+sudo cp ~/.sig/proxy/ca.crt /usr/local/share/ca-certificates/sigcli-proxy.crt
+sudo update-ca-certificates
+
+# Per-command (no system trust)
+curl --cacert ~/.sig/proxy/ca.crt https://api.example.com`}</CodeBlock>
 
                     <SectionHeading id="cmd-completion" level={2}>
                         sig completion

--- a/website/src/content/docs.tsx
+++ b/website/src/content/docs.tsx
@@ -434,10 +434,11 @@ curl https://jira.example.com/api/me   # credentials injected automatically`}</C
                         vars.
                     </P>
                     <P>
-                        <strong>Inject rules:</strong> For APIs that need credentials in non-standard locations
-                        (body fields, query parameters, custom headers), add <Code>proxy.inject</Code> rules
-                        to the provider config. The proxy and <Code>sig request</Code> apply these rules
-                        after standard credential headers.
+                        <strong>Inject rules:</strong> For APIs that need credentials in
+                        non-standard locations (body fields, query parameters, custom headers), add{' '}
+                        <Code>proxy.inject</Code> rules to the provider config. The proxy and{' '}
+                        <Code>sig request</Code> apply these rules after standard credential
+                        headers.
                     </P>
                     <CodeBlock lang="yaml">{`# Example: inject xoxc token from localStorage as form body parameter
 providers:
@@ -452,13 +453,15 @@ providers:
                     <P>
                         The <Code>from</Code> field resolves paths against the stored credential:{' '}
                         <Code>credential.cookies</Code>, <Code>credential.accessToken</Code>,{' '}
-                        <Code>credential.localStorage.&lt;key&gt;</Code>, <Code>credential.xHeaders.&lt;key&gt;</Code>.
-                        Body injection supports <Code>application/json</Code> and{' '}
+                        <Code>credential.localStorage.&lt;key&gt;</Code>,{' '}
+                        <Code>credential.xHeaders.&lt;key&gt;</Code>. Body injection supports{' '}
+                        <Code>application/json</Code> and{' '}
                         <Code>application/x-www-form-urlencoded</Code> content types.
                     </P>
                     <P>
                         <strong>Auto-refresh:</strong> The proxy daemon runs the watch/refresh loop
-                        automatically. Configure which providers to watch in <Code>config.yaml</Code>:
+                        automatically. Configure which providers to watch in{' '}
+                        <Code>config.yaml</Code>:
                     </P>
                     <CodeBlock lang="yaml">{`watch:
   interval: 5m           # check interval (default: 5m)
@@ -469,13 +472,13 @@ providers:
     ms-teams:`}</CodeBlock>
                     <P>
                         Credentials are refreshed before they expire. Use{' '}
-                        <Code>sig watch add &lt;provider&gt;</Code> to manage the watch list, or edit
-                        the config directly. The proxy's built-in watch loop replaces the need for a
-                        separate <Code>sig watch start</Code> process.
+                        <Code>sig watch add &lt;provider&gt;</Code> to manage the watch list, or
+                        edit the config directly. The proxy's built-in watch loop replaces the need
+                        for a separate <Code>sig watch start</Code> process.
                     </P>
                     <P>
-                        <strong>Trusting the CA:</strong> For HTTPS interception, the proxy generates a
-                        local CA certificate. Add it to your system trust store:
+                        <strong>Trusting the CA:</strong> For HTTPS interception, the proxy
+                        generates a local CA certificate. Add it to your system trust store:
                     </P>
                     <CodeBlock lang="bash">{`sig proxy trust                  # show CA cert path + instructions
 


### PR DESCRIPTION
## Summary
- **sig init**: Change default browser from `chrome` to `msedge`. Show numbered menu with availability status during interactive setup (e.g. `1. msedge ✓ (detected)`)
- **sig get**: Redact credential values by default across all output formats (json/header/value). Add `--no-redaction` flag to bypass with stderr warning
- **sig proxy docs**: Expand website docs with inject rules (body/header/query examples), auto-refresh (watch loop config), and CA trust instructions (macOS/Ubuntu/curl). Mirrored in Chinese docs

Also updated outside this repo:
- **sap-auth skill**: Added Slack `proxy.inject` body rule (`token=xoxc-...`) to config-template.yaml and SKILL.md

## Test plan
- [x] `pnpm --filter @sigcli/cli build` — passes
- [x] `pnpm --filter @sigcli/cli test` — 666/666 tests pass
- [ ] Run `sig init --force` in TTY — verify numbered browser menu with msedge default
- [ ] Run `sig get sap-jira` — verify output is redacted (`****`)
- [ ] Run `sig get sap-jira --no-redaction` — verify raw values with stderr warning
- [ ] Check website proxy docs section for inject rules, auto-refresh, trust subsections