### PR TITLE
fix(cli): fix proxy daemon startup and enhance status output

### DIFF
--- a/cli/src/cli/commands/proxy.ts
+++ b/cli/src/cli/commands/proxy.ts
@@ -1,4 +1,6 @@
 import { fork } from 'node:child_process';
+import { openSync, closeSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { join, dirname } from 'node:path';
 import { readState, isRunning, clearState } from '../../proxy/proxy-state.js';
@@ -78,15 +80,44 @@ async function handleStart(
     }
 
     // Fork a detached background child
-    const entry = join(dirname(fileURLToPath(import.meta.url)), '../../../../bin/sig.js');
+    const entry = join(dirname(fileURLToPath(import.meta.url)), '../../../bin/sig.js');
+
+    const proxyDir = expandHome('~/.sig/proxy');
+    await mkdir(proxyDir, { recursive: true });
+    const logPath = join(proxyDir, 'proxy.log');
+    const logFd = openSync(logPath, 'a');
 
     const child = fork(entry, ['proxy', 'start', ...(port ? ['--port', String(port)] : [])], {
         detached: true,
-        stdio: 'ignore',
+        stdio: ['ignore', logFd, logFd, 'ipc'],
         env: { ...process.env, PROXY_DAEMON: '1' },
     });
 
+    // Wait briefly for daemon to write state files or exit with error
+    const started = await new Promise<boolean>((resolve) => {
+        const timeout = setTimeout(() => resolve(true), 2000);
+        child.on('exit', (code) => {
+            clearTimeout(timeout);
+            if (code !== 0) resolve(false);
+            else resolve(true);
+        });
+    });
+
     child.unref();
+    child.disconnect();
+    closeSync(logFd);
+
+    if (!started) {
+        process.stderr.write(`Proxy daemon failed to start. Check ${logPath} for details.\n`);
+        await logAuditEvent({
+            action: AuditAction.PROXY_START,
+            status: AuditStatus.FAILURE,
+            metadata: { port: port || 'auto', logPath },
+        });
+        process.exitCode = ExitCode.GENERAL_ERROR;
+        return;
+    }
+
     await logAuditEvent({
         action: AuditAction.PROXY_START,
         status: AuditStatus.SUCCESS,
@@ -132,17 +163,50 @@ async function handleStatus(): Promise<void> {
     const state = await readState();
     if (!state) {
         process.stdout.write('Proxy: not running\n');
-        return;
+    } else {
+        const running = await isRunning();
+        if (running) {
+            process.stdout.write(`Proxy: running  pid=${state.pid}  port=${state.port}\n`);
+            process.stdout.write(`  http_proxy=http://127.0.0.1:${state.port}\n`);
+            process.stdout.write(`  https_proxy=http://127.0.0.1:${state.port}\n`);
+        } else {
+            await clearState();
+            process.stdout.write('Proxy: not running (stale state cleared)\n');
+        }
     }
 
-    const running = await isRunning();
-    if (running) {
-        process.stdout.write(`Proxy: running  pid=${state.pid}  port=${state.port}\n`);
-        process.stdout.write(`  http_proxy=http://127.0.0.1:${state.port}\n`);
-        process.stdout.write(`  https_proxy=http://127.0.0.1:${state.port}\n`);
+    // Watch status
+    const { getWatchConfig } = await import('../../watch/watch-config.js');
+    const watchConfig = await getWatchConfig();
+    const watchProviders = watchConfig ? Object.keys(watchConfig.providers) : [];
+
+    process.stdout.write('\n');
+    if (watchProviders.length > 0) {
+        process.stdout.write(
+            `Watch: ${watchProviders.length} provider(s)  interval=${watchConfig!.interval}\n`,
+        );
+        for (const id of watchProviders) {
+            const opts = watchConfig!.providers[id];
+            const sync = opts.autoSync.length > 0 ? ` → sync: ${opts.autoSync.join(', ')}` : '';
+            process.stdout.write(`  ${id}${sync}\n`);
+        }
     } else {
-        await clearState();
-        process.stdout.write('Proxy: not running (stale state cleared)\n');
+        process.stdout.write('Watch: no providers configured\n');
+    }
+
+    // Sync/remote status
+    const { getRemotes } = await import('../../sync/remote-config.js');
+    const remotes = await getRemotes();
+
+    process.stdout.write('\n');
+    if (remotes.length > 0) {
+        process.stdout.write(`Remotes: ${remotes.length} configured\n`);
+        for (const r of remotes) {
+            const target = r.host ? `${r.user ? r.user + '@' : ''}${r.host}` : r.name;
+            process.stdout.write(`  ${r.name} (${r.type}) → ${target}\n`);
+        }
+    } else {
+        process.stdout.write('Remotes: none configured\n');
     }
 }
 


### PR DESCRIPTION
## Summary
- **Fix silent proxy crash**: The fork entry path was `../../../../bin/sig.js` (4 levels up → monorepo root) instead of `../../../bin/sig.js` (3 levels up → `cli/` root). Combined with `stdio: 'ignore'`, the child process crashed silently while the parent printed "started".
- **Add daemon logging**: Redirect child stdout/stderr to `~/.sig/proxy/proxy.log` for debuggability, and add a 2-second startup check that reports failure if the child exits early.
- **Enhance `sig proxy status`**: Now also displays watch providers (with interval and auto-sync targets) and configured remotes.

## Test plan
- [x] `sig proxy start` — daemon stays running, `sig proxy status` shows pid/port
- [x] `sig proxy start --port 8080` — binds to specified port
- [x] `curl --proxy http://127.0.0.1:<port> http://httpbin.org/get` returns 200
- [x] `sig proxy status` — shows proxy, watch, and remotes sections
- [x] `~/.sig/proxy/proxy.log` contains daemon output
- [x] All 666 unit tests pass