### PR TITLE
chore: add unrelease workflow

### DIFF
--- a/.github/workflows/unrelease.yml
+++ b/.github/workflows/unrelease.yml
@@ -1,0 +1,89 @@
+name: Unrelease
+
+on:
+    workflow_dispatch:
+        inputs:
+            package:
+                description: Package to unrelease
+                required: true
+                type: choice
+                options:
+                    - '@sigcli/cli'
+                    - '@sigcli/sdk'
+            version:
+                description: Version to unrelease (e.g. 1.1.1)
+                required: true
+                type: string
+            action:
+                description: Action to take
+                required: true
+                type: choice
+                options:
+                    - deprecate
+                    - unpublish
+                default: deprecate
+
+jobs:
+    unrelease:
+        name: Unrelease ${{ inputs.package }}@${{ inputs.version }} (${{ inputs.action }})
+        runs-on: ubuntu-latest
+
+        if: github.ref == 'refs/heads/main'
+
+        permissions:
+            contents: write
+
+        steps:
+            - name: Setup Node.js 22
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  registry-url: https://registry.npmjs.org
+
+            - name: Verify version exists
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+              run: |
+                  PKG="${{ inputs.package }}"
+                  VER="${{ inputs.version }}"
+                  if ! npm view "${PKG}@${VER}" version 2>/dev/null; then
+                    echo "::error::${PKG}@${VER} not found on npm."
+                    exit 1
+                  fi
+                  echo "Found ${PKG}@${VER} on npm."
+
+            - name: Deprecate version
+              if: inputs.action == 'deprecate'
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+              run: |
+                  PKG="${{ inputs.package }}"
+                  VER="${{ inputs.version }}"
+                  npm deprecate "${PKG}@${VER}" "This version has been deprecated. Please use a newer version."
+                  echo "## Deprecated \`${PKG}@${VER}\`" >> "$GITHUB_STEP_SUMMARY"
+
+            - name: Unpublish version
+              if: inputs.action == 'unpublish'
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+              run: |
+                  PKG="${{ inputs.package }}"
+                  VER="${{ inputs.version }}"
+                  npm unpublish "${PKG}@${VER}" --force
+                  echo "## Unpublished \`${PKG}@${VER}\`" >> "$GITHUB_STEP_SUMMARY"
+                  echo ""
+                  echo "::warning::npm will not allow re-publishing this exact version for 24 hours."
+
+            - name: Delete GitHub release
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  PKG="${{ inputs.package }}"
+                  VER="${{ inputs.version }}"
+                  TAG="${PKG//\//-}-v${VER}"
+                  if gh release view "${TAG}" --repo "${{ github.repository }}" 2>/dev/null; then
+                    gh release delete "${TAG}" --repo "${{ github.repository }}" --yes
+                    echo "Deleted GitHub release ${TAG}"
+                  else
+                    echo "No GitHub release found for ${TAG} (skipping)"
+                  fi

--- a/cli/src/cli/commands/proxy.ts
+++ b/cli/src/cli/commands/proxy.ts
@@ -1,4 +1,6 @@
 import { fork } from 'node:child_process';
+import { openSync, closeSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { join, dirname } from 'node:path';
 import { readState, isRunning, clearState } from '../../proxy/proxy-state.js';
@@ -78,15 +80,44 @@ async function handleStart(
     }
 
     // Fork a detached background child
-    const entry = join(dirname(fileURLToPath(import.meta.url)), '../../../../bin/sig.js');
+    const entry = join(dirname(fileURLToPath(import.meta.url)), '../../../bin/sig.js');
+
+    const proxyDir = expandHome('~/.sig/proxy');
+    await mkdir(proxyDir, { recursive: true });
+    const logPath = join(proxyDir, 'proxy.log');
+    const logFd = openSync(logPath, 'a');
 
     const child = fork(entry, ['proxy', 'start', ...(port ? ['--port', String(port)] : [])], {
         detached: true,
-        stdio: 'ignore',
+        stdio: ['ignore', logFd, logFd, 'ipc'],
         env: { ...process.env, PROXY_DAEMON: '1' },
     });
 
+    // Wait briefly for daemon to write state files or exit with error
+    const started = await new Promise<boolean>((resolve) => {
+        const timeout = setTimeout(() => resolve(true), 2000);
+        child.on('exit', (code) => {
+            clearTimeout(timeout);
+            if (code !== 0) resolve(false);
+            else resolve(true);
+        });
+    });
+
     child.unref();
+    child.disconnect();
+    closeSync(logFd);
+
+    if (!started) {
+        process.stderr.write(`Proxy daemon failed to start. Check ${logPath} for details.\n`);
+        await logAuditEvent({
+            action: AuditAction.PROXY_START,
+            status: AuditStatus.FAILURE,
+            metadata: { port: port || 'auto', logPath },
+        });
+        process.exitCode = ExitCode.GENERAL_ERROR;
+        return;
+    }
+
     await logAuditEvent({
         action: AuditAction.PROXY_START,
         status: AuditStatus.SUCCESS,
@@ -132,17 +163,50 @@ async function handleStatus(): Promise<void> {
     const state = await readState();
     if (!state) {
         process.stdout.write('Proxy: not running\n');
-        return;
+    } else {
+        const running = await isRunning();
+        if (running) {
+            process.stdout.write(`Proxy: running  pid=${state.pid}  port=${state.port}\n`);
+            process.stdout.write(`  http_proxy=http://127.0.0.1:${state.port}\n`);
+            process.stdout.write(`  https_proxy=http://127.0.0.1:${state.port}\n`);
+        } else {
+            await clearState();
+            process.stdout.write('Proxy: not running (stale state cleared)\n');
+        }
     }
 
-    const running = await isRunning();
-    if (running) {
-        process.stdout.write(`Proxy: running  pid=${state.pid}  port=${state.port}\n`);
-        process.stdout.write(`  http_proxy=http://127.0.0.1:${state.port}\n`);
-        process.stdout.write(`  https_proxy=http://127.0.0.1:${state.port}\n`);
+    // Watch status
+    const { getWatchConfig } = await import('../../watch/watch-config.js');
+    const watchConfig = await getWatchConfig();
+    const watchProviders = watchConfig ? Object.keys(watchConfig.providers) : [];
+
+    process.stdout.write('\n');
+    if (watchProviders.length > 0) {
+        process.stdout.write(
+            `Watch: ${watchProviders.length} provider(s)  interval=${watchConfig!.interval}\n`,
+        );
+        for (const id of watchProviders) {
+            const opts = watchConfig!.providers[id];
+            const sync = opts.autoSync.length > 0 ? ` → sync: ${opts.autoSync.join(', ')}` : '';
+            process.stdout.write(`  ${id}${sync}\n`);
+        }
     } else {
-        await clearState();
-        process.stdout.write('Proxy: not running (stale state cleared)\n');
+        process.stdout.write('Watch: no providers configured\n');
+    }
+
+    // Sync/remote status
+    const { getRemotes } = await import('../../sync/remote-config.js');
+    const remotes = await getRemotes();
+
+    process.stdout.write('\n');
+    if (remotes.length > 0) {
+        process.stdout.write(`Remotes: ${remotes.length} configured\n`);
+        for (const r of remotes) {
+            const target = r.host ? `${r.user ? r.user + '@' : ''}${r.host}` : r.name;
+            process.stdout.write(`  ${r.name} (${r.type}) → ${target}\n`);
+        }
+    } else {
+        process.stdout.write('Remotes: none configured\n');
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` workflow to deprecate or unpublish npm packages
- Two actions: `deprecate` (mark version as deprecated, keeps it installable) or `unpublish` (remove from registry entirely)
- Also deletes the corresponding GitHub release
- Requires version input to prevent accidents

## Test plan
- [ ] Merge, then trigger via Actions tab to unpublish `@sigcli/cli@1.1.1`