### PR TITLE
fix(ci): remove explicit pnpm version to resolve packageManager conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
 
             - name: Install pnpm
               uses: pnpm/action-setup@v4
-              with:
-                  version: 10
 
             - name: Setup Node.js
               uses: actions/setup-node@v4
@@ -53,8 +51,6 @@ jobs:
 
             - name: Install pnpm
               uses: pnpm/action-setup@v4
-              with:
-                  version: 10
 
             - name: Setup Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4
@@ -106,8 +102,6 @@ jobs:
             - name: Install pnpm
               if: steps.changes.outputs.changed == 'true'
               uses: pnpm/action-setup@v4
-              with:
-                  version: 10
 
             - name: Setup Node.js
               if: steps.changes.outputs.changed == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,6 @@ jobs:
 
             - name: Install pnpm
               uses: pnpm/action-setup@v4
-              with:
-                  version: 10
 
             - name: Setup Node.js 22
               uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Removes the explicit `version: 10` from `pnpm/action-setup@v4` in all CI/release workflows
- `pnpm/action-setup@v4` now reads the version from the `packageManager` field in `package.json`, avoiding the duplicate-version conflict that was failing CI

## Test plan
- [ ] CI passes on this PR (the fix itself is what unblocks CI)