### PR TITLE
docs: add security model and onboarding guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
 
             - name: Install pnpm
               uses: pnpm/action-setup@v4
-              with:
-                  version: 10
 
             - name: Setup Node.js
               uses: actions/setup-node@v4
@@ -53,8 +51,6 @@ jobs:
 
             - name: Install pnpm
               uses: pnpm/action-setup@v4
-              with:
-                  version: 10
 
             - name: Setup Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4
@@ -106,8 +102,6 @@ jobs:
             - name: Install pnpm
               if: steps.changes.outputs.changed == 'true'
               uses: pnpm/action-setup@v4
-              with:
-                  version: 10
 
             - name: Setup Node.js
               if: steps.changes.outputs.changed == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,6 @@ jobs:
 
             - name: Install pnpm
               uses: pnpm/action-setup@v4
-              with:
-                  version: 10
 
             - name: Setup Node.js 22
               uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ Credentials are injected as `SIG_<PROVIDER>_*` env vars and never appear in your
 
 | Command                          | Description                                                              |
 | -------------------------------- | ------------------------------------------------------------------------ |
+| `sig request <url>`              | Make an authenticated HTTP request (credentials stay internal)           |
 | `sig run [provider...] -- <cmd>` | **Run command with credentials injected as `SIG_<PROVIDER>_*` env vars** |
-| `sig request <url>`              | Make an authenticated HTTP request                                       |
 | `sig status [provider]`          | Show auth status                                                         |
-| `sig get <provider\|url>`        | Get raw credential headers                                               |
+| `sig get <provider\|url>`        | Retrieve credential headers (prints to stdout — see Security)            |
 
 **Provider management**
 
@@ -80,6 +80,23 @@ Credentials are injected as `SIG_<PROVIDER>_*` env vars and never appear in your
 | `sig proxy trust`            | Print CA cert path for trust setup |
 
 Run `sig --help` or `sig <command> --help` for full options.
+
+## Security
+
+Sigcli offers four ways to use credentials, ranked by isolation level:
+
+| Method        | How                                                            | Security               |
+| ------------- | -------------------------------------------------------------- | ---------------------- |
+| `sig proxy`   | MITM daemon on localhost; credentials never leave proxy memory | Highest                |
+| `sig request` | Direct authenticated HTTP; credentials in-process only         | High                   |
+| `sig run`     | Injects `SIG_*` env vars into child process; redacts output    | Moderate               |
+| `sig get`     | Prints credentials to stdout                                   | Low — use with caution |
+
+All credentials are encrypted at rest (AES-256-GCM). Every access is logged to `~/.sig/audit.log`.
+
+**For AI agents**, use `sig proxy` (best) or `sig run`. Never pipe `sig get` output into agent context.
+
+See the [full security documentation](https://sigcli.ai/docs/#security) for threat models and recommendations.
 
 ## Documentation
 

--- a/cli/src/cli/commands/get.ts
+++ b/cli/src/cli/commands/get.ts
@@ -27,7 +27,9 @@ export async function runGet(
 ): Promise<void> {
     const target = positionals[0];
     if (!target) {
-        process.stderr.write('Usage: sig get <provider|url>\n');
+        process.stderr.write(
+            'Usage: sig get <provider|url>\n\n⚠ Least secure method — credentials may appear in stdout, shell history, and pipes.\nValues are redacted by default. Use --no-redaction only when needed.\nPrefer "sig request" or "sig run" for automation.\n',
+        );
         process.exitCode = ExitCode.GENERAL_ERROR;
         return;
     }

--- a/cli/src/cli/commands/proxy.ts
+++ b/cli/src/cli/commands/proxy.ts
@@ -12,11 +12,15 @@ import { logAuditEvent, AuditAction, AuditStatus } from '../../audit/audit-log.j
 
 const USAGE = `Usage: sig proxy <subcommand>
 
+Most secure credential method — credentials never leave the proxy process.
+Runs a local MITM daemon on 127.0.0.1 that intercepts HTTPS and injects
+credentials transparently. Client apps just set HTTP_PROXY.
+
 Subcommands:
   start [--port 8080]    Start proxy daemon in background
   stop                   Stop proxy daemon
-  status                 Show proxy daemon status
-  trust                  Print CA certificate path (add to system trust)
+  status                 Show proxy status and env-var hints
+  trust                  Print CA certificate path for OS trust setup
 `;
 
 export async function runProxy(

--- a/cli/src/cli/commands/request.ts
+++ b/cli/src/cli/commands/request.ts
@@ -15,7 +15,7 @@ export async function runRequest(
     const url = positionals[0];
     if (!url) {
         process.stderr.write(
-            'Usage: sig request <url> [--method GET] [--header "Name: Value"] [--body \'{}\']\n',
+            'Usage: sig request <url> [--method GET] [--header "Name: Value"] [--body \'{}\']\n\nCredentials stay internal — never exposed to subprocesses, env vars, or shell history.\nMore secure than "sig run" or "sig get" for one-off API calls.\n',
         );
         process.exitCode = ExitCode.GENERAL_ERROR;
         return;

--- a/cli/src/cli/commands/run.ts
+++ b/cli/src/cli/commands/run.ts
@@ -29,7 +29,7 @@ export async function runRun(
 
     if (cmdArgs.length === 0) {
         process.stderr.write(
-            'Error: No command specified\nUsage: sig run [provider...] -- <cmd> [args]\n',
+            'Error: No command specified\nUsage: sig run [provider...] -- <cmd> [args]\n\nInjects SIG_<PROVIDER>_* env vars into the child process. Credential values\nare redacted from stdout/stderr. Note: env vars are readable via /proc on Linux\nand inherited by child processes. For stronger isolation, use "sig proxy".\n',
         );
         process.exitCode = ExitCode.GENERAL_ERROR;
         return;

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -87,22 +87,26 @@ Authentication:
     --force                      Skip stored/refresh check, go straight to browser
   logout [provider]            Clear credentials (all if none specified)
 
-Credentials:
-  get <provider|url>           Retrieve credential headers
-    --format json|header|value   Output format (default: json)
-    --no-redaction               Output raw (unredacted) credential values
-  request <url>                Make an authenticated HTTP request
+Credentials (most → least secure):
+  proxy start [--port 8080]    Start MITM proxy daemon (credentials never leave proxy process)
+  proxy stop                   Stop proxy daemon
+  proxy status                 Show proxy status and env-var hints
+  proxy trust                  Print CA cert path for OS trust setup
+  request <url>                Make authenticated HTTP request (credentials in-process only)
     --method <METHOD>            HTTP method (default: GET)
     --body <json>                Request body
     --header "Name: Value"       Custom header (repeatable)
     --format json|body|headers   Output format (default: json)
-  status [provider]            Show authentication status
-    --format json|yaml|env|table|plain  Output format
-  run [provider...] -- <cmd>   Run command with SIG_<PROVIDER>_* env vars injected
+  run [provider...] -- <cmd>   Run command with SIG_* env vars (redacted output)
     --expand-cookies             Expand individual cookies as SIG_COOKIE_<NAME>=value
     --mount <path>               Write credentials to file instead of env vars
     --mount-format env|json      File format for --mount (default: env)
     No providers: injects all valid credentials. Vars always prefixed: SIG_<PROVIDER>_*
+  get <provider|url>           Retrieve credential headers (⚠ prints to stdout)
+    --format json|header|value   Output format (default: json)
+    --no-redaction               Output raw (unredacted) credential values
+  status [provider]            Show authentication status
+    --format json|yaml|env|table|plain  Output format
 
 Provider management:
   providers                    List configured providers
@@ -130,12 +134,6 @@ Watch:
   watch remove <provider>      Remove provider from watch list
   watch set-interval <dur>     Set default check interval
 
-Proxy:
-  proxy start [--port 8080]    Start MITM proxy daemon in background
-  proxy stop                   Stop proxy daemon
-  proxy status                 Show proxy status and env-var hints
-  proxy trust                  Print CA cert path for OS trust setup
-
 Setup:
   init                         Create ~/.sig/config.yaml
     --remote                     Headless machine setup (mode: browserless)
@@ -144,6 +142,8 @@ Setup:
     --channel <name>             Browser channel (msedge|chrome|chromium)
   doctor                       Check environment, config, and encryption key
   completion <shell>           Generate shell completion script (bash|zsh|fish)
+
+Security: proxy ≥ request > run > get. Full docs at https://sigcli.ai/docs/#security
 
 Global options:
   --verbose                    Debug output to stderr

--- a/cli/tests/unit/cli/help-text.test.ts
+++ b/cli/tests/unit/cli/help-text.test.ts
@@ -35,10 +35,10 @@ describe('CLI help text grouping (#9)', () => {
         expect(output).toContain('Authentication:');
     });
 
-    it('help output contains "Credentials:" section header', async () => {
+    it('help output contains "Credentials" section header', async () => {
         await run(['help']);
         const output = stdoutChunks.join('');
-        expect(output).toContain('Credentials:');
+        expect(output).toContain('Credentials (most');
     });
 
     it('help output contains "Remote & sync:" section header', async () => {
@@ -126,15 +126,14 @@ describe('CLI help text grouping (#9)', () => {
         expect(output).toContain('Authentication:');
     });
 
-    it('sections appear in correct order: Auth > Credentials > Provider > Remote > Watch > Proxy > Setup > Global', async () => {
+    it('sections appear in correct order: Auth > Credentials > Provider > Remote > Watch > Setup > Global', async () => {
         await run(['help']);
         const output = stdoutChunks.join('');
         const authIdx = output.indexOf('Authentication:');
-        const credIdx = output.indexOf('Credentials:');
+        const credIdx = output.indexOf('Credentials (most');
         const providerIdx = output.indexOf('Provider management:');
         const remoteIdx = output.indexOf('Remote & sync:');
         const watchIdx = output.indexOf('Watch:');
-        const proxyIdx = output.indexOf('Proxy:');
         const setupIdx = output.indexOf('Setup:');
         const globalIdx = output.indexOf('Global options:');
 
@@ -143,8 +142,7 @@ describe('CLI help text grouping (#9)', () => {
         expect(providerIdx).toBeGreaterThan(credIdx);
         expect(remoteIdx).toBeGreaterThan(providerIdx);
         expect(watchIdx).toBeGreaterThan(remoteIdx);
-        expect(proxyIdx).toBeGreaterThan(watchIdx);
-        expect(setupIdx).toBeGreaterThan(proxyIdx);
+        expect(setupIdx).toBeGreaterThan(watchIdx);
         expect(globalIdx).toBeGreaterThan(setupIdx);
     });
 });

--- a/website/src/content/docs-zh.tsx
+++ b/website/src/content/docs-zh.tsx
@@ -248,9 +248,8 @@ sig proxy stop`}</CodeBlock>
                         试试: sig request
                     </SectionHeading>
                     <P>
-                        对于一次性 API 调用，<Code>sig request</Code>{' '}
-                        直接发起认证的 HTTP 请求。凭证保持在 CLI
-                        进程内部，不会暴露到子进程或 shell 历史记录中。
+                        对于一次性 API 调用，<Code>sig request</Code> 直接发起认证的 HTTP
+                        请求。凭证保持在 CLI 进程内部，不会暴露到子进程或 shell 历史记录中。
                     </P>
                     <CodeBlock lang="bash">{`# 简单 GET 请求
 sig request https://jira.example.com/rest/api/2/myself
@@ -264,9 +263,7 @@ sig request https://api.example.com/me --format body`}</CodeBlock>
                     <SectionHeading id="onboard-choosing" level={2}>
                         选择方法
                     </SectionHeading>
-                    <P>
-                        根据你的使用场景选择合适的方法。如有疑问，优先选择更安全的方式。
-                    </P>
+                    <P>根据你的使用场景选择合适的方法。如有疑问，优先选择更安全的方式。</P>
                     <div
                         style={{
                             width: '100%',
@@ -740,22 +737,22 @@ sig request https://api.example.com/me --format body`}</CodeBlock>
                     <CodeBlock lang="bash">{`sig proxy start
 export HTTP_PROXY=http://127.0.0.1:7891 HTTPS_PROXY=http://127.0.0.1:7891`}</CodeBlock>
                     <P>
-                        <strong>适用场景：</strong>AI
-                        代理、CI/CD 流水线、长期运行的守护进程、任何支持 HTTP_PROXY 的工具。
+                        <strong>适用场景：</strong>AI 代理、CI/CD
+                        流水线、长期运行的守护进程、任何支持 HTTP_PROXY 的工具。
                     </P>
 
                     <SectionHeading id="security-request" level={3}>
                         sig request — 凭证保持在内部
                     </SectionHeading>
                     <P>
-                        <Code>sig request</Code>{' '}
-                        将凭证加载到进程内存中，发起一次 HTTP 请求，然后丢弃。凭证永远不会写入环境变量、文件或标准输出。
+                        <Code>sig request</Code> 将凭证加载到进程内存中，发起一次 HTTP
+                        请求，然后丢弃。凭证永远不会写入环境变量、文件或标准输出。
                         暴露窗口约为每次请求 100ms。
                     </P>
                     <CodeBlock lang="bash">{`sig request https://api.example.com/me --format body`}</CodeBlock>
                     <P>
-                        <strong>适用场景：</strong>一次性 API 调用、shell
-                        脚本、需要单个 HTTP 响应的流水线步骤。
+                        <strong>适用场景：</strong>一次性 API 调用、shell 脚本、需要单个 HTTP
+                        响应的流水线步骤。
                     </P>
 
                     <SectionHeading id="security-run" level={3}>
@@ -763,8 +760,9 @@ export HTTP_PROXY=http://127.0.0.1:7891 HTTPS_PROXY=http://127.0.0.1:7891`}</Cod
                     </SectionHeading>
                     <P>
                         <Code>sig run</Code> 将 <Code>SIG_&lt;PROVIDER&gt;_*</Code>{' '}
-                        环境变量注入子进程。这对于从环境变量读取配置的工具很方便，但在 Linux 上环境变量可以通过{' '}
-                        <Code>/proc</Code> 读取，并且会被所有子进程继承。子进程的输出会自动脱敏（凭证值替换为{' '}
+                        环境变量注入子进程。这对于从环境变量读取配置的工具很方便，但在 Linux
+                        上环境变量可以通过 <Code>/proc</Code>{' '}
+                        读取，并且会被所有子进程继承。子进程的输出会自动脱敏（凭证值替换为{' '}
                         <Code>****</Code>），但脱敏是尽力而为的。
                     </P>
                     <CodeBlock lang="bash">{`sig run my-jira -- curl https://jira.example.com/api/me`}</CodeBlock>
@@ -777,19 +775,19 @@ export HTTP_PROXY=http://127.0.0.1:7891 HTTPS_PROXY=http://127.0.0.1:7891`}</Cod
                         sig get — 凭证输出到标准输出
                     </SectionHeading>
                     <P>
-                        <Code>sig get</Code>{' '}
-                        将凭证头输出到标准输出。默认情况下值会被脱敏（<Code>****</Code>），但{' '}
-                        <Code>--no-redaction</Code>{' '}
-                        会显示原始令牌。原始值在终端回滚、shell 历史记录（<Code>~/.bash_history</Code>、
-                        <Code>~/.zsh_history</Code>）和管道命令中可见。
+                        <Code>sig get</Code> 将凭证头输出到标准输出。默认情况下值会被脱敏（
+                        <Code>****</Code>），但 <Code>--no-redaction</Code>{' '}
+                        会显示原始令牌。原始值在终端回滚、shell 历史记录（
+                        <Code>~/.bash_history</Code>、<Code>~/.zsh_history</Code>
+                        ）和管道命令中可见。
                     </P>
                     <CodeBlock lang="bash">{`# 默认脱敏
 sig get my-jira
 # 原始值（谨慎使用）
 sig get my-jira --no-redaction`}</CodeBlock>
                     <P>
-                        <strong>适用场景：</strong>调试凭证格式、手动 API
-                        测试。切勿将原始输出传入 AI 代理上下文或日志。
+                        <strong>适用场景：</strong>调试凭证格式、手动 API 测试。切勿将原始输出传入
+                        AI 代理上下文或日志。
                     </P>
 
                     <SectionHeading id="security-shared" level={2}>
@@ -803,12 +801,14 @@ sig get my-jira --no-redaction`}</CodeBlock>
                             <Code>~/.sig/encryption.key</Code>（权限 0o400，仅所有者可读）。
                         </Li>
                         <Li>
-                            <strong>审计日志</strong> — 每次凭证访问、登录、登出、同步以及代理启动/停止都记录在{' '}
+                            <strong>审计日志</strong> —
+                            每次凭证访问、登录、登出、同步以及代理启动/停止都记录在{' '}
                             <Code>~/.sig/audit.log</Code> 中（JSON Lines 格式）。
                         </Li>
                         <Li>
-                            <strong>基于 Result 的错误处理</strong> —
-                            认证失败返回类型化错误（<Code>{'Result<T, AuthError>'}</Code>），永远不会抛出异常。错误信息中不会暴露凭证。
+                            <strong>基于 Result 的错误处理</strong> — 认证失败返回类型化错误（
+                            <Code>{'Result<T, AuthError>'}</Code>
+                            ），永远不会抛出异常。错误信息中不会暴露凭证。
                         </Li>
                         <Li>
                             <strong>自动刷新</strong> —
@@ -819,8 +819,8 @@ sig get my-jira --no-redaction`}</CodeBlock>
             ),
             aside: (
                 <P>
-                    对于 AI 代理，优先使用 <Code>sig proxy</Code> 或 <Code>sig run</Code>。
-                    切勿将 <Code>sig get</Code> 的输出传入代理上下文。
+                    对于 AI 代理，优先使用 <Code>sig proxy</Code> 或 <Code>sig run</Code>。 切勿将{' '}
+                    <Code>sig get</Code> 的输出传入代理上下文。
                 </P>
             ),
         },

--- a/website/src/content/docs-zh.tsx
+++ b/website/src/content/docs-zh.tsx
@@ -40,6 +40,52 @@ export const pageContent = {
         tocItem('#first-run', '首次 sig run', {
             level: 1,
             parent: '#getting-started',
+            prefix: '├ ',
+        }),
+        tocItem('#onboard-proxy', '试试: sig proxy', {
+            level: 1,
+            parent: '#getting-started',
+            prefix: '├ ',
+        }),
+        tocItem('#onboard-request', '试试: sig request', {
+            level: 1,
+            parent: '#getting-started',
+            prefix: '├ ',
+        }),
+        tocItem('#onboard-choosing', '选择方法', {
+            level: 1,
+            parent: '#getting-started',
+            prefix: '└ ',
+        }),
+        tocItem('#security', '安全模型'),
+        tocItem('#security-hierarchy', '凭证访问方式', {
+            level: 1,
+            parent: '#security',
+            prefix: '├ ',
+        }),
+        tocItem('#security-proxy', 'sig proxy', {
+            level: 2,
+            parent: '#security',
+            prefix: '│  ├ ',
+        }),
+        tocItem('#security-request', 'sig request', {
+            level: 2,
+            parent: '#security',
+            prefix: '│  ├ ',
+        }),
+        tocItem('#security-run', 'sig run', {
+            level: 2,
+            parent: '#security',
+            prefix: '│  ├ ',
+        }),
+        tocItem('#security-get', 'sig get', {
+            level: 2,
+            parent: '#security',
+            prefix: '│  └ ',
+        }),
+        tocItem('#security-shared', '共享安全特性', {
+            level: 1,
+            parent: '#security',
             prefix: '└ ',
         }),
         tocItem('#commands', '命令参考'),
@@ -167,6 +213,614 @@ sig run my-jira -- python fetch_issues.py`}</CodeBlock>
                 <P>
                     凭证以密封 JSON 文件的形式存储在 <Code>~/.sig/credentials/</Code>{' '}
                     中。默认情况下，不会有任何内容进入你的代码仓库、shell 历史记录或环境变量。
+                </P>
+            ),
+        },
+
+        /* ── 快速上手（续）── */
+        {
+            content: (
+                <>
+                    <SectionHeading id="onboard-proxy" level={2}>
+                        试试: sig proxy
+                    </SectionHeading>
+                    <P>
+                        代理是<strong>最安全</strong>的凭证使用方式。它在本地运行一个 MITM
+                        守护进程，拦截 HTTPS 流量并透明注入凭证——你的工具永远不会看到令牌。
+                    </P>
+                    <CodeBlock lang="bash">{`# 启动代理守护进程
+sig proxy start
+
+# 信任 CA 证书（首次使用时）
+sig proxy trust    # 打印 CA 证书路径——添加到系统信任存储
+
+# 设置代理环境变量
+export HTTP_PROXY=http://127.0.0.1:7891
+export HTTPS_PROXY=http://127.0.0.1:7891
+
+# 任何 HTTP 客户端都会自动获得凭证注入
+curl https://jira.example.com/rest/api/2/myself
+
+# 完成后
+sig proxy stop`}</CodeBlock>
+
+                    <SectionHeading id="onboard-request" level={2}>
+                        试试: sig request
+                    </SectionHeading>
+                    <P>
+                        对于一次性 API 调用，<Code>sig request</Code>{' '}
+                        直接发起认证的 HTTP 请求。凭证保持在 CLI
+                        进程内部，不会暴露到子进程或 shell 历史记录中。
+                    </P>
+                    <CodeBlock lang="bash">{`# 简单 GET 请求
+sig request https://jira.example.com/rest/api/2/myself
+
+# POST 请求
+sig request https://api.example.com/data --method POST --body '{"key": "value"}'
+
+# 只获取响应体
+sig request https://api.example.com/me --format body`}</CodeBlock>
+
+                    <SectionHeading id="onboard-choosing" level={2}>
+                        选择方法
+                    </SectionHeading>
+                    <P>
+                        根据你的使用场景选择合适的方法。如有疑问，优先选择更安全的方式。
+                    </P>
+                    <div
+                        style={{
+                            width: '100%',
+                            overflowX: 'auto',
+                            padding: '8px 0',
+                        }}
+                    >
+                        <table
+                            style={{
+                                width: '100%',
+                                borderCollapse: 'collapse',
+                                fontFamily: 'var(--font-primary)',
+                                fontSize: 'var(--type-table-size)',
+                            }}
+                        >
+                            <thead>
+                                <tr>
+                                    <th
+                                        style={{
+                                            textAlign: 'left',
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            fontWeight: 600,
+                                            color: 'var(--text-primary)',
+                                        }}
+                                    >
+                                        使用场景
+                                    </th>
+                                    <th
+                                        style={{
+                                            textAlign: 'left',
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            fontWeight: 600,
+                                            color: 'var(--text-primary)',
+                                        }}
+                                    >
+                                        推荐方法
+                                    </th>
+                                    <th
+                                        style={{
+                                            textAlign: 'left',
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            fontWeight: 600,
+                                            color: 'var(--text-primary)',
+                                        }}
+                                    >
+                                        原因
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        长期运行的守护进程或 AI 代理
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            color: 'var(--text-secondary)',
+                                            fontFamily: 'var(--font-code)',
+                                        }}
+                                    >
+                                        sig proxy
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        凭证永远不会离开代理进程
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        一次性 API 调用或脚本
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            color: 'var(--text-secondary)',
+                                            fontFamily: 'var(--font-code)',
+                                        }}
+                                    >
+                                        sig request
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        凭证仅在进程内，不涉及磁盘或环境变量
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        包装需要读取环境变量的工具
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            color: 'var(--text-secondary)',
+                                            fontFamily: 'var(--font-code)',
+                                        }}
+                                    >
+                                        sig run
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        注入 SIG_* 环境变量，自动脱敏输出
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        调试凭证值
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            color: 'var(--text-secondary)',
+                                            fontFamily: 'var(--font-code)',
+                                        }}
+                                    >
+                                        sig get
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        输出到标准输出——谨慎使用
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </>
+            ),
+        },
+
+        /* ── 安全模型 ── */
+        {
+            content: (
+                <>
+                    <SectionHeading id="security" level={1}>
+                        安全模型
+                    </SectionHeading>
+                    <P>
+                        Sigcli 提供四种凭证访问方式，每种在安全性和便捷性之间有不同的权衡。
+                        按安全级别从高到低排列：
+                    </P>
+
+                    <SectionHeading id="security-hierarchy" level={2}>
+                        凭证访问方式
+                    </SectionHeading>
+                    <div
+                        style={{
+                            width: '100%',
+                            overflowX: 'auto',
+                            padding: '8px 0',
+                        }}
+                    >
+                        <table
+                            style={{
+                                width: '100%',
+                                borderCollapse: 'collapse',
+                                fontFamily: 'var(--font-primary)',
+                                fontSize: 'var(--type-table-size)',
+                            }}
+                        >
+                            <thead>
+                                <tr>
+                                    <th
+                                        style={{
+                                            textAlign: 'left',
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            fontWeight: 600,
+                                            color: 'var(--text-primary)',
+                                        }}
+                                    >
+                                        方法
+                                    </th>
+                                    <th
+                                        style={{
+                                            textAlign: 'left',
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            fontWeight: 600,
+                                            color: 'var(--text-primary)',
+                                        }}
+                                    >
+                                        凭证暴露
+                                    </th>
+                                    <th
+                                        style={{
+                                            textAlign: 'left',
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            fontWeight: 600,
+                                            color: 'var(--text-primary)',
+                                        }}
+                                    >
+                                        内存生命周期
+                                    </th>
+                                    <th
+                                        style={{
+                                            textAlign: 'left',
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            fontWeight: 600,
+                                            color: 'var(--text-primary)',
+                                        }}
+                                    >
+                                        可见于
+                                    </th>
+                                    <th
+                                        style={{
+                                            textAlign: 'left',
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            fontWeight: 600,
+                                            color: 'var(--text-primary)',
+                                        }}
+                                    >
+                                        安全级别
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            fontFamily: 'var(--font-code)',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        sig proxy
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        永远不会离开代理进程
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        代理守护进程生命周期
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        无外部可见
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        ●●●●● 最高
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            fontFamily: 'var(--font-code)',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        sig request
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        仅在进程内存中
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        每次请求约 100ms
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        无外部可见
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        ●●●●○ 高
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            fontFamily: 'var(--font-code)',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        sig run
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        子进程环境变量
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        子进程生命周期
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        /proc/PID/environ、子进程
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            borderBottom: '1px solid var(--page-border)',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        ●●●○○ 中等
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            fontFamily: 'var(--font-code)',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        sig get
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        输出到标准输出
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        N/A（被 shell 捕获）
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        终端、shell 历史、管道
+                                    </td>
+                                    <td
+                                        style={{
+                                            padding: '8px 12px',
+                                            color: 'var(--text-secondary)',
+                                        }}
+                                    >
+                                        ●●○○○ 低
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <SectionHeading id="security-proxy" level={3}>
+                        sig proxy — 凭证永远不会离开进程
+                    </SectionHeading>
+                    <P>
+                        MITM 代理守护进程运行在本地（127.0.0.1）。客户端应用设置 HTTP_PROXY
+                        并正常发起请求。代理拦截 HTTPS 连接，将凭证作为 HTTP
+                        头注入，然后转发到上游服务器。
+                    </P>
+                    <P>
+                        凭证从存储中解密后仅保存在代理进程的内存中。客户端应用、子进程和环境变量都不会包含令牌。TLS
+                        拦截使用为每个主机名生成的 ECDSA P-256 证书。
+                    </P>
+                    <CodeBlock lang="bash">{`sig proxy start
+export HTTP_PROXY=http://127.0.0.1:7891 HTTPS_PROXY=http://127.0.0.1:7891`}</CodeBlock>
+                    <P>
+                        <strong>适用场景：</strong>AI
+                        代理、CI/CD 流水线、长期运行的守护进程、任何支持 HTTP_PROXY 的工具。
+                    </P>
+
+                    <SectionHeading id="security-request" level={3}>
+                        sig request — 凭证保持在内部
+                    </SectionHeading>
+                    <P>
+                        <Code>sig request</Code>{' '}
+                        将凭证加载到进程内存中，发起一次 HTTP 请求，然后丢弃。凭证永远不会写入环境变量、文件或标准输出。
+                        暴露窗口约为每次请求 100ms。
+                    </P>
+                    <CodeBlock lang="bash">{`sig request https://api.example.com/me --format body`}</CodeBlock>
+                    <P>
+                        <strong>适用场景：</strong>一次性 API 调用、shell
+                        脚本、需要单个 HTTP 响应的流水线步骤。
+                    </P>
+
+                    <SectionHeading id="security-run" level={3}>
+                        sig run — 凭证在环境变量中
+                    </SectionHeading>
+                    <P>
+                        <Code>sig run</Code> 将 <Code>SIG_&lt;PROVIDER&gt;_*</Code>{' '}
+                        环境变量注入子进程。这对于从环境变量读取配置的工具很方便，但在 Linux 上环境变量可以通过{' '}
+                        <Code>/proc</Code> 读取，并且会被所有子进程继承。子进程的输出会自动脱敏（凭证值替换为{' '}
+                        <Code>****</Code>），但脱敏是尽力而为的。
+                    </P>
+                    <CodeBlock lang="bash">{`sig run my-jira -- curl https://jira.example.com/api/me`}</CodeBlock>
+                    <P>
+                        <strong>适用场景：</strong>包装读取 SIG_*
+                        环境变量的工具、本地开发、快速脚本编写。
+                    </P>
+
+                    <SectionHeading id="security-get" level={3}>
+                        sig get — 凭证输出到标准输出
+                    </SectionHeading>
+                    <P>
+                        <Code>sig get</Code>{' '}
+                        将凭证头输出到标准输出。默认情况下值会被脱敏（<Code>****</Code>），但{' '}
+                        <Code>--no-redaction</Code>{' '}
+                        会显示原始令牌。原始值在终端回滚、shell 历史记录（<Code>~/.bash_history</Code>、
+                        <Code>~/.zsh_history</Code>）和管道命令中可见。
+                    </P>
+                    <CodeBlock lang="bash">{`# 默认脱敏
+sig get my-jira
+# 原始值（谨慎使用）
+sig get my-jira --no-redaction`}</CodeBlock>
+                    <P>
+                        <strong>适用场景：</strong>调试凭证格式、手动 API
+                        测试。切勿将原始输出传入 AI 代理上下文或日志。
+                    </P>
+
+                    <SectionHeading id="security-shared" level={2}>
+                        共享安全特性
+                    </SectionHeading>
+                    <P>所有四种方式共享以下安全保护：</P>
+                    <List>
+                        <Li>
+                            <strong>AES-256-GCM 静态加密</strong> — <Code>~/.sig/credentials/</Code>{' '}
+                            中的所有凭证文件都经过加密。加密密钥存储在{' '}
+                            <Code>~/.sig/encryption.key</Code>（权限 0o400，仅所有者可读）。
+                        </Li>
+                        <Li>
+                            <strong>审计日志</strong> — 每次凭证访问、登录、登出、同步以及代理启动/停止都记录在{' '}
+                            <Code>~/.sig/audit.log</Code> 中（JSON Lines 格式）。
+                        </Li>
+                        <Li>
+                            <strong>基于 Result 的错误处理</strong> —
+                            认证失败返回类型化错误（<Code>{'Result<T, AuthError>'}</Code>），永远不会抛出异常。错误信息中不会暴露凭证。
+                        </Li>
+                        <Li>
+                            <strong>自动刷新</strong> —
+                            过期凭证在使用前会透明地刷新。不会有过期令牌通过错误路径泄露。
+                        </Li>
+                    </List>
+                </>
+            ),
+            aside: (
+                <P>
+                    对于 AI 代理，优先使用 <Code>sig proxy</Code> 或 <Code>sig run</Code>。
+                    切勿将 <Code>sig get</Code> 的输出传入代理上下文。
                 </P>
             ),
         },

--- a/website/src/content/docs.tsx
+++ b/website/src/content/docs.tsx
@@ -43,8 +43,18 @@ export const pageContent = {
         tocItem('#first-run', 'First sig run', {
             level: 1,
             parent: '#getting-started',
-            prefix: '└ ',
+            prefix: '├ ',
         }),
+        tocItem('#onboard-proxy', 'Try: sig proxy', { level: 1, parent: '#getting-started', prefix: '├ ' }),
+        tocItem('#onboard-request', 'Try: sig request', { level: 1, parent: '#getting-started', prefix: '├ ' }),
+        tocItem('#onboard-choosing', 'Choosing a method', { level: 1, parent: '#getting-started', prefix: '└ ' }),
+        tocItem('#security', 'Security Model'),
+        tocItem('#security-hierarchy', 'Credential access methods', { level: 1, parent: '#security', prefix: '├ ' }),
+        tocItem('#security-proxy', 'sig proxy', { level: 2, parent: '#security', prefix: '│  ├ ' }),
+        tocItem('#security-request', 'sig request', { level: 2, parent: '#security', prefix: '│  ├ ' }),
+        tocItem('#security-run', 'sig run', { level: 2, parent: '#security', prefix: '│  ├ ' }),
+        tocItem('#security-get', 'sig get', { level: 2, parent: '#security', prefix: '│  └ ' }),
+        tocItem('#security-shared', 'Shared protections', { level: 1, parent: '#security', prefix: '└ ' }),
         tocItem('#commands', 'Commands'),
         tocItem('#cmd-init', 'sig init', { level: 1, parent: '#commands', prefix: '├ ' }),
         tocItem('#cmd-doctor', 'sig doctor', { level: 1, parent: '#commands', prefix: '├ ' }),
@@ -167,6 +177,87 @@ sig run my-jira -- curl https://jira.example.com/api/me
 
 # Run a Python script
 sig run my-jira -- python fetch_issues.py`}</CodeBlock>
+
+                    <SectionHeading id="onboard-proxy" level={2}>Try: sig proxy</SectionHeading>
+                    <P>
+                        The proxy is the <strong>most secure</strong> way to use credentials. It runs a local MITM daemon
+                        that intercepts HTTPS traffic and injects credentials transparently — your tools never see the tokens.
+                    </P>
+                    <CodeBlock lang="bash">{`# Start the proxy daemon
+sig proxy start
+
+# Trust the CA certificate (first time only)
+sig proxy trust    # prints the CA cert path — add it to your OS trust store
+
+# Set the proxy env vars
+export HTTP_PROXY=http://127.0.0.1:7891
+export HTTPS_PROXY=http://127.0.0.1:7891
+
+# Now any HTTP client automatically gets credentials injected
+curl https://jira.example.com/rest/api/2/myself
+
+# When done
+sig proxy stop`}</CodeBlock>
+
+                    <SectionHeading id="onboard-request" level={2}>Try: sig request</SectionHeading>
+                    <P>
+                        For one-off API calls, <Code>sig request</Code> makes an authenticated HTTP request directly.
+                        Credentials stay inside the CLI process and are never exposed to subprocesses or shell history.
+                    </P>
+                    <CodeBlock lang="bash">{`# Simple GET request
+sig request https://jira.example.com/rest/api/2/myself
+
+# POST with body
+sig request https://api.example.com/data --method POST --body '{"key": "value"}'
+
+# Just the response body
+sig request https://api.example.com/me --format body`}</CodeBlock>
+
+                    <SectionHeading id="onboard-choosing" level={2}>Choosing a method</SectionHeading>
+                    <P>
+                        Pick the method that matches your use case. When in doubt, prefer higher security.
+                    </P>
+                    <div className="w-full max-w-full overflow-x-auto" style={{ padding: '8px 0' }}>
+                        <table
+                            className="w-full"
+                            style={{ borderSpacing: 0, borderCollapse: 'collapse' }}
+                        >
+                            <thead>
+                                <tr>
+                                    {['Use Case', 'Recommended', 'Why'].map((h) => (
+                                        <th
+                                            key={h}
+                                            className="text-left"
+                                            style={{
+                                                padding: '4px 12px 4px 0',
+                                                fontSize: 'var(--type-table-size)',
+                                                fontFamily: 'var(--font-primary)',
+                                                fontWeight: 400,
+                                                color: 'var(--text-muted)',
+                                                borderBottom: '1px solid var(--page-border)',
+                                            }}
+                                        >
+                                            {h}
+                                        </th>
+                                    ))}
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {[
+                                    ['Long-lived daemon or AI agent', 'sig proxy', 'Credentials never leave proxy process'],
+                                    ['One-off API call or script', 'sig request', 'Credentials in-process only, never on disk/env'],
+                                    ['Wrapping a tool that reads env vars', 'sig run', 'Injects SIG_* env vars, redacts output'],
+                                    ['Debugging credential values', 'sig get', 'Prints to stdout — use with caution'],
+                                ].map(([useCase, recommended, why]) => (
+                                    <tr key={useCase}>
+                                        <td style={{ padding: '4px 12px 4px 0', fontSize: 'var(--type-table-size)', fontFamily: 'var(--font-primary)', fontWeight: 475, color: 'var(--text-primary)', borderBottom: '1px solid var(--page-border)' }}>{useCase}</td>
+                                        <td style={{ padding: '4px 12px 4px 0', fontSize: 'var(--type-table-size)', fontFamily: 'var(--font-code)', fontWeight: 475, color: 'var(--text-primary)', borderBottom: '1px solid var(--page-border)', whiteSpace: 'nowrap' }}>{recommended}</td>
+                                        <td style={{ padding: '4px 12px 4px 0', fontSize: 'var(--type-table-size)', fontFamily: 'var(--font-primary)', fontWeight: 475, color: 'var(--text-primary)', borderBottom: '1px solid var(--page-border)' }}>{why}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
                 </>
             ),
             aside: (
@@ -174,6 +265,118 @@ sig run my-jira -- python fetch_issues.py`}</CodeBlock>
                     Credentials are stored in <Code>~/.sig/credentials/</Code> as sealed JSON files.
                     Nothing goes into your repo, shell history, or environment by default.
                 </P>
+            ),
+        },
+
+        /* ── Security Model ── */
+        {
+            content: (
+                <>
+                    <SectionHeading id="security" level={1}>Security Model</SectionHeading>
+                    <P>
+                        Sigcli offers four ways to access credentials. Each makes a different tradeoff
+                        between security and convenience. Listed from most to least secure:
+                    </P>
+
+                    <SectionHeading id="security-hierarchy" level={2}>Credential access methods</SectionHeading>
+                    <div className="w-full max-w-full overflow-x-auto" style={{ padding: '8px 0' }}>
+                        <table
+                            className="w-full"
+                            style={{ borderSpacing: 0, borderCollapse: 'collapse' }}
+                        >
+                            <thead>
+                                <tr>
+                                    {['Method', 'Credential Exposure', 'Lifetime', 'Visible To', 'Security'].map((h) => (
+                                        <th
+                                            key={h}
+                                            className="text-left"
+                                            style={{
+                                                padding: '4px 12px 4px 0',
+                                                fontSize: 'var(--type-table-size)',
+                                                fontFamily: 'var(--font-primary)',
+                                                fontWeight: 400,
+                                                color: 'var(--text-muted)',
+                                                borderBottom: '1px solid var(--page-border)',
+                                            }}
+                                        >
+                                            {h}
+                                        </th>
+                                    ))}
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {[
+                                    ['sig proxy', 'Never leaves proxy process', 'Proxy daemon lifetime', 'Nothing external', '●●●●● Highest'],
+                                    ['sig request', 'In-process memory only', '~100ms per request', 'Nothing external', '●●●●○ High'],
+                                    ['sig run', 'Child process env vars', 'Child process lifetime', '/proc/PID/environ, child processes', '●●●○○ Moderate'],
+                                    ['sig get', 'Printed to stdout', 'Captured by shell', 'Terminal, shell history, pipes', '●●○○○ Low'],
+                                ].map(([method, exposure, lifetime, visibleTo, security]) => (
+                                    <tr key={method}>
+                                        <td style={{ padding: '4px 12px 4px 0', fontSize: 'var(--type-table-size)', fontFamily: 'var(--font-code)', fontWeight: 475, color: 'var(--text-primary)', borderBottom: '1px solid var(--page-border)', whiteSpace: 'nowrap' }}>{method}</td>
+                                        <td style={{ padding: '4px 12px 4px 0', fontSize: 'var(--type-table-size)', fontFamily: 'var(--font-primary)', fontWeight: 475, color: 'var(--text-primary)', borderBottom: '1px solid var(--page-border)' }}>{exposure}</td>
+                                        <td style={{ padding: '4px 12px 4px 0', fontSize: 'var(--type-table-size)', fontFamily: 'var(--font-primary)', fontWeight: 475, color: 'var(--text-primary)', borderBottom: '1px solid var(--page-border)', whiteSpace: 'nowrap' }}>{lifetime}</td>
+                                        <td style={{ padding: '4px 12px 4px 0', fontSize: 'var(--type-table-size)', fontFamily: 'var(--font-primary)', fontWeight: 475, color: 'var(--text-primary)', borderBottom: '1px solid var(--page-border)' }}>{visibleTo}</td>
+                                        <td style={{ padding: '4px 12px 4px 0', fontSize: 'var(--type-table-size)', fontFamily: 'var(--font-code)', fontWeight: 475, color: 'var(--text-primary)', borderBottom: '1px solid var(--page-border)', whiteSpace: 'nowrap' }}>{security}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <SectionHeading id="security-proxy" level={2}>sig proxy — credentials never leave the process</SectionHeading>
+                    <P>
+                        The MITM proxy daemon runs on localhost (127.0.0.1). Client apps set HTTP_PROXY and make normal requests. The proxy intercepts HTTPS connections, injects credentials as HTTP headers, and forwards to the upstream server.
+                    </P>
+                    <P>
+                        Credentials are decrypted from storage and held only in the proxy process memory. Client applications, subprocesses, and env vars never contain tokens. TLS interception uses ECDSA P-256 certificates generated per hostname.
+                    </P>
+                    <CodeBlock lang="bash">{`sig proxy start && export HTTP_PROXY=http://127.0.0.1:7891 HTTPS_PROXY=http://127.0.0.1:7891`}</CodeBlock>
+                    <P><strong>Use when:</strong> AI agents, CI/CD pipelines, long-running daemons, any tool that supports HTTP_PROXY.</P>
+
+                    <SectionHeading id="security-request" level={2}>sig request — credentials stay internal</SectionHeading>
+                    <P>
+                        <Code>sig request</Code> loads credentials into process memory, makes a single HTTP request, and discards them. Credentials are never written to env vars, files, or stdout. The exposure window is ~100ms per request.
+                    </P>
+                    <CodeBlock lang="bash">{`sig request https://api.example.com/me --format body`}</CodeBlock>
+                    <P><strong>Use when:</strong> One-off API calls, shell scripts, pipeline steps that need a single HTTP response.</P>
+
+                    <SectionHeading id="security-run" level={2}>sig run — credentials in env vars</SectionHeading>
+                    <P>
+                        <Code>sig run</Code> injects <Code>SIG_&lt;PROVIDER&gt;_*</Code> env vars into the child process. This is convenient for tools that read configuration from environment variables, but env vars are readable via <Code>/proc</Code> on Linux and inherited by all child processes. Output from the child is redacted (credential values replaced with <Code>****</Code>) but redaction is best-effort.
+                    </P>
+                    <CodeBlock lang="bash">{`sig run my-jira -- bash -c 'curl -H "Cookie: $SIG_MY_JIRA_COOKIE" https://jira.example.com/api/me'`}</CodeBlock>
+                    <P><strong>Use when:</strong> Wrapping tools that read SIG_* env vars, local development, quick scripting.</P>
+
+                    <SectionHeading id="security-get" level={2}>sig get — credentials printed to stdout</SectionHeading>
+                    <P>
+                        <Code>sig get</Code> outputs credential headers to stdout. By default, values are redacted (<Code>****</Code>), but <Code>--no-redaction</Code> reveals raw tokens. Even redacted output shows credential structure. Raw values are visible in terminal scrollback, shell history (<Code>~/.bash_history</Code>, <Code>~/.zsh_history</Code>), and piped commands.
+                    </P>
+                    <CodeBlock lang="bash">{`# Redacted by default
+sig get my-jira
+# Raw values (use with caution)
+sig get my-jira --no-redaction`}</CodeBlock>
+                    <P><strong>Use when:</strong> Debugging credential format, manual API testing. Never pipe raw output into AI agent context or logs.</P>
+
+                    <SectionHeading id="security-shared" level={2}>Shared protections</SectionHeading>
+                    <P>All four methods share these protections:</P>
+                    <List>
+                        <Li>
+                            <strong>AES-256-GCM encryption at rest</strong> — all credential files in{' '}
+                            <Code>~/.sig/credentials/</Code> are encrypted. The encryption key lives at{' '}
+                            <Code>~/.sig/encryption.key</Code> (mode 0o400, owner-read only).
+                        </Li>
+                        <Li>
+                            <strong>Audit logging</strong> — every credential access, login, logout, sync, and proxy start/stop is logged to{' '}
+                            <Code>~/.sig/audit.log</Code> as JSON Lines.
+                        </Li>
+                        <Li>
+                            <strong>Result-based error handling</strong> — authentication failures return typed errors (<Code>{'Result<T, AuthError>'}</Code>), never throw exceptions. Credentials are never exposed in error messages.
+                        </Li>
+                        <Li>
+                            <strong>Automatic refresh</strong> — expired credentials are refreshed transparently before use. No stale tokens leak through error paths.
+                        </Li>
+                    </List>
+                </>
             ),
         },
 

--- a/website/src/content/docs.tsx
+++ b/website/src/content/docs.tsx
@@ -45,16 +45,40 @@ export const pageContent = {
             parent: '#getting-started',
             prefix: '├ ',
         }),
-        tocItem('#onboard-proxy', 'Try: sig proxy', { level: 1, parent: '#getting-started', prefix: '├ ' }),
-        tocItem('#onboard-request', 'Try: sig request', { level: 1, parent: '#getting-started', prefix: '├ ' }),
-        tocItem('#onboard-choosing', 'Choosing a method', { level: 1, parent: '#getting-started', prefix: '└ ' }),
+        tocItem('#onboard-proxy', 'Try: sig proxy', {
+            level: 1,
+            parent: '#getting-started',
+            prefix: '├ ',
+        }),
+        tocItem('#onboard-request', 'Try: sig request', {
+            level: 1,
+            parent: '#getting-started',
+            prefix: '├ ',
+        }),
+        tocItem('#onboard-choosing', 'Choosing a method', {
+            level: 1,
+            parent: '#getting-started',
+            prefix: '└ ',
+        }),
         tocItem('#security', 'Security Model'),
-        tocItem('#security-hierarchy', 'Credential access methods', { level: 1, parent: '#security', prefix: '├ ' }),
+        tocItem('#security-hierarchy', 'Credential access methods', {
+            level: 1,
+            parent: '#security',
+            prefix: '├ ',
+        }),
         tocItem('#security-proxy', 'sig proxy', { level: 2, parent: '#security', prefix: '│  ├ ' }),
-        tocItem('#security-request', 'sig request', { level: 2, parent: '#security', prefix: '│  ├ ' }),
+        tocItem('#security-request', 'sig request', {
+            level: 2,
+            parent: '#security',
+            prefix: '│  ├ ',
+        }),
         tocItem('#security-run', 'sig run', { level: 2, parent: '#security', prefix: '│  ├ ' }),
         tocItem('#security-get', 'sig get', { level: 2, parent: '#security', prefix: '│  └ ' }),
-        tocItem('#security-shared', 'Shared protections', { level: 1, parent: '#security', prefix: '└ ' }),
+        tocItem('#security-shared', 'Shared protections', {
+            level: 1,
+            parent: '#security',
+            prefix: '└ ',
+        }),
         tocItem('#commands', 'Commands'),
         tocItem('#cmd-init', 'sig init', { level: 1, parent: '#commands', prefix: '├ ' }),
         tocItem('#cmd-doctor', 'sig doctor', { level: 1, parent: '#commands', prefix: '├ ' }),
@@ -178,10 +202,13 @@ sig run my-jira -- curl https://jira.example.com/api/me
 # Run a Python script
 sig run my-jira -- python fetch_issues.py`}</CodeBlock>
 
-                    <SectionHeading id="onboard-proxy" level={2}>Try: sig proxy</SectionHeading>
+                    <SectionHeading id="onboard-proxy" level={2}>
+                        Try: sig proxy
+                    </SectionHeading>
                     <P>
-                        The proxy is the <strong>most secure</strong> way to use credentials. It runs a local MITM daemon
-                        that intercepts HTTPS traffic and injects credentials transparently — your tools never see the tokens.
+                        The proxy is the <strong>most secure</strong> way to use credentials. It
+                        runs a local MITM daemon that intercepts HTTPS traffic and injects
+                        credentials transparently — your tools never see the tokens.
                     </P>
                     <CodeBlock lang="bash">{`# Start the proxy daemon
 sig proxy start
@@ -199,10 +226,13 @@ curl https://jira.example.com/rest/api/2/myself
 # When done
 sig proxy stop`}</CodeBlock>
 
-                    <SectionHeading id="onboard-request" level={2}>Try: sig request</SectionHeading>
+                    <SectionHeading id="onboard-request" level={2}>
+                        Try: sig request
+                    </SectionHeading>
                     <P>
-                        For one-off API calls, <Code>sig request</Code> makes an authenticated HTTP request directly.
-                        Credentials stay inside the CLI process and are never exposed to subprocesses or shell history.
+                        For one-off API calls, <Code>sig request</Code> makes an authenticated HTTP
+                        request directly. Credentials stay inside the CLI process and are never
+                        exposed to subprocesses or shell history.
                     </P>
                     <CodeBlock lang="bash">{`# Simple GET request
 sig request https://jira.example.com/rest/api/2/myself
@@ -213,9 +243,12 @@ sig request https://api.example.com/data --method POST --body '{"key": "value"}'
 # Just the response body
 sig request https://api.example.com/me --format body`}</CodeBlock>
 
-                    <SectionHeading id="onboard-choosing" level={2}>Choosing a method</SectionHeading>
+                    <SectionHeading id="onboard-choosing" level={2}>
+                        Choosing a method
+                    </SectionHeading>
                     <P>
-                        Pick the method that matches your use case. When in doubt, prefer higher security.
+                        Pick the method that matches your use case. When in doubt, prefer higher
+                        security.
                     </P>
                     <div className="w-full max-w-full overflow-x-auto" style={{ padding: '8px 0' }}>
                         <table
@@ -244,15 +277,65 @@ sig request https://api.example.com/me --format body`}</CodeBlock>
                             </thead>
                             <tbody>
                                 {[
-                                    ['Long-lived daemon or AI agent', 'sig proxy', 'Credentials never leave proxy process'],
-                                    ['One-off API call or script', 'sig request', 'Credentials in-process only, never on disk/env'],
-                                    ['Wrapping a tool that reads env vars', 'sig run', 'Injects SIG_* env vars, redacts output'],
-                                    ['Debugging credential values', 'sig get', 'Prints to stdout — use with caution'],
+                                    [
+                                        'Long-lived daemon or AI agent',
+                                        'sig proxy',
+                                        'Credentials never leave proxy process',
+                                    ],
+                                    [
+                                        'One-off API call or script',
+                                        'sig request',
+                                        'Credentials in-process only, never on disk/env',
+                                    ],
+                                    [
+                                        'Wrapping a tool that reads env vars',
+                                        'sig run',
+                                        'Injects SIG_* env vars, redacts output',
+                                    ],
+                                    [
+                                        'Debugging credential values',
+                                        'sig get',
+                                        'Prints to stdout — use with caution',
+                                    ],
                                 ].map(([useCase, recommended, why]) => (
                                     <tr key={useCase}>
-                                        <td style={{ padding: '4px 12px 4px 0', fontSize: 'var(--type-table-size)', fontFamily: 'var(--font-primary)', fontWeight: 475, color: 'var(--text-primary)', borderBottom: '1px solid var(--page-border)' }}>{useCase}</td>
-                                        <td style={{ padding: '4px 12px 4px 0', fontSize: 'var(--type-table-size)', fontFamily: 'var(--font-code)', fontWeight: 475, color: 'var(--text-primary)', borderBottom: '1px solid var(--page-border)', whiteSpace: 'nowrap' }}>{recommended}</td>
-                                        <td style={{ padding: '4px 12px 4px 0', fontSize: 'var(--type-table-size)', fontFamily: 'var(--font-primary)', fontWeight: 475, color: 'var(--text-primary)', borderBottom: '1px solid var(--page-border)' }}>{why}</td>
+                                        <td
+                                            style={{
+                                                padding: '4px 12px 4px 0',
+                                                fontSize: 'var(--type-table-size)',
+                                                fontFamily: 'var(--font-primary)',
+                                                fontWeight: 475,
+                                                color: 'var(--text-primary)',
+                                                borderBottom: '1px solid var(--page-border)',
+                                            }}
+                                        >
+                                            {useCase}
+                                        </td>
+                                        <td
+                                            style={{
+                                                padding: '4px 12px 4px 0',
+                                                fontSize: 'var(--type-table-size)',
+                                                fontFamily: 'var(--font-code)',
+                                                fontWeight: 475,
+                                                color: 'var(--text-primary)',
+                                                borderBottom: '1px solid var(--page-border)',
+                                                whiteSpace: 'nowrap',
+                                            }}
+                                        >
+                                            {recommended}
+                                        </td>
+                                        <td
+                                            style={{
+                                                padding: '4px 12px 4px 0',
+                                                fontSize: 'var(--type-table-size)',
+                                                fontFamily: 'var(--font-primary)',
+                                                fontWeight: 475,
+                                                color: 'var(--text-primary)',
+                                                borderBottom: '1px solid var(--page-border)',
+                                            }}
+                                        >
+                                            {why}
+                                        </td>
                                     </tr>
                                 ))}
                             </tbody>
@@ -272,13 +355,17 @@ sig request https://api.example.com/me --format body`}</CodeBlock>
         {
             content: (
                 <>
-                    <SectionHeading id="security" level={1}>Security Model</SectionHeading>
+                    <SectionHeading id="security" level={1}>
+                        Security Model
+                    </SectionHeading>
                     <P>
-                        Sigcli offers four ways to access credentials. Each makes a different tradeoff
-                        between security and convenience. Listed from most to least secure:
+                        Sigcli offers four ways to access credentials. Each makes a different
+                        tradeoff between security and convenience. Listed from most to least secure:
                     </P>
 
-                    <SectionHeading id="security-hierarchy" level={2}>Credential access methods</SectionHeading>
+                    <SectionHeading id="security-hierarchy" level={2}>
+                        Credential access methods
+                    </SectionHeading>
                     <div className="w-full max-w-full overflow-x-auto" style={{ padding: '8px 0' }}>
                         <table
                             className="w-full"
@@ -286,7 +373,13 @@ sig request https://api.example.com/me --format body`}</CodeBlock>
                         >
                             <thead>
                                 <tr>
-                                    {['Method', 'Credential Exposure', 'Lifetime', 'Visible To', 'Security'].map((h) => (
+                                    {[
+                                        'Method',
+                                        'Credential Exposure',
+                                        'Lifetime',
+                                        'Visible To',
+                                        'Security',
+                                    ].map((h) => (
                                         <th
                                             key={h}
                                             className="text-left"
@@ -306,74 +399,200 @@ sig request https://api.example.com/me --format body`}</CodeBlock>
                             </thead>
                             <tbody>
                                 {[
-                                    ['sig proxy', 'Never leaves proxy process', 'Proxy daemon lifetime', 'Nothing external', '●●●●● Highest'],
-                                    ['sig request', 'In-process memory only', '~100ms per request', 'Nothing external', '●●●●○ High'],
-                                    ['sig run', 'Child process env vars', 'Child process lifetime', '/proc/PID/environ, child processes', '●●●○○ Moderate'],
-                                    ['sig get', 'Printed to stdout', 'Captured by shell', 'Terminal, shell history, pipes', '●●○○○ Low'],
+                                    [
+                                        'sig proxy',
+                                        'Never leaves proxy process',
+                                        'Proxy daemon lifetime',
+                                        'Nothing external',
+                                        '●●●●● Highest',
+                                    ],
+                                    [
+                                        'sig request',
+                                        'In-process memory only',
+                                        '~100ms per request',
+                                        'Nothing external',
+                                        '●●●●○ High',
+                                    ],
+                                    [
+                                        'sig run',
+                                        'Child process env vars',
+                                        'Child process lifetime',
+                                        '/proc/PID/environ, child processes',
+                                        '●●●○○ Moderate',
+                                    ],
+                                    [
+                                        'sig get',
+                                        'Printed to stdout',
+                                        'Captured by shell',
+                                        'Terminal, shell history, pipes',
+                                        '●●○○○ Low',
+                                    ],
                                 ].map(([method, exposure, lifetime, visibleTo, security]) => (
                                     <tr key={method}>
-                                        <td style={{ padding: '4px 12px 4px 0', fontSize: 'var(--type-table-size)', fontFamily: 'var(--font-code)', fontWeight: 475, color: 'var(--text-primary)', borderBottom: '1px solid var(--page-border)', whiteSpace: 'nowrap' }}>{method}</td>
-                                        <td style={{ padding: '4px 12px 4px 0', fontSize: 'var(--type-table-size)', fontFamily: 'var(--font-primary)', fontWeight: 475, color: 'var(--text-primary)', borderBottom: '1px solid var(--page-border)' }}>{exposure}</td>
-                                        <td style={{ padding: '4px 12px 4px 0', fontSize: 'var(--type-table-size)', fontFamily: 'var(--font-primary)', fontWeight: 475, color: 'var(--text-primary)', borderBottom: '1px solid var(--page-border)', whiteSpace: 'nowrap' }}>{lifetime}</td>
-                                        <td style={{ padding: '4px 12px 4px 0', fontSize: 'var(--type-table-size)', fontFamily: 'var(--font-primary)', fontWeight: 475, color: 'var(--text-primary)', borderBottom: '1px solid var(--page-border)' }}>{visibleTo}</td>
-                                        <td style={{ padding: '4px 12px 4px 0', fontSize: 'var(--type-table-size)', fontFamily: 'var(--font-code)', fontWeight: 475, color: 'var(--text-primary)', borderBottom: '1px solid var(--page-border)', whiteSpace: 'nowrap' }}>{security}</td>
+                                        <td
+                                            style={{
+                                                padding: '4px 12px 4px 0',
+                                                fontSize: 'var(--type-table-size)',
+                                                fontFamily: 'var(--font-code)',
+                                                fontWeight: 475,
+                                                color: 'var(--text-primary)',
+                                                borderBottom: '1px solid var(--page-border)',
+                                                whiteSpace: 'nowrap',
+                                            }}
+                                        >
+                                            {method}
+                                        </td>
+                                        <td
+                                            style={{
+                                                padding: '4px 12px 4px 0',
+                                                fontSize: 'var(--type-table-size)',
+                                                fontFamily: 'var(--font-primary)',
+                                                fontWeight: 475,
+                                                color: 'var(--text-primary)',
+                                                borderBottom: '1px solid var(--page-border)',
+                                            }}
+                                        >
+                                            {exposure}
+                                        </td>
+                                        <td
+                                            style={{
+                                                padding: '4px 12px 4px 0',
+                                                fontSize: 'var(--type-table-size)',
+                                                fontFamily: 'var(--font-primary)',
+                                                fontWeight: 475,
+                                                color: 'var(--text-primary)',
+                                                borderBottom: '1px solid var(--page-border)',
+                                                whiteSpace: 'nowrap',
+                                            }}
+                                        >
+                                            {lifetime}
+                                        </td>
+                                        <td
+                                            style={{
+                                                padding: '4px 12px 4px 0',
+                                                fontSize: 'var(--type-table-size)',
+                                                fontFamily: 'var(--font-primary)',
+                                                fontWeight: 475,
+                                                color: 'var(--text-primary)',
+                                                borderBottom: '1px solid var(--page-border)',
+                                            }}
+                                        >
+                                            {visibleTo}
+                                        </td>
+                                        <td
+                                            style={{
+                                                padding: '4px 12px 4px 0',
+                                                fontSize: 'var(--type-table-size)',
+                                                fontFamily: 'var(--font-code)',
+                                                fontWeight: 475,
+                                                color: 'var(--text-primary)',
+                                                borderBottom: '1px solid var(--page-border)',
+                                                whiteSpace: 'nowrap',
+                                            }}
+                                        >
+                                            {security}
+                                        </td>
                                     </tr>
                                 ))}
                             </tbody>
                         </table>
                     </div>
 
-                    <SectionHeading id="security-proxy" level={2}>sig proxy — credentials never leave the process</SectionHeading>
+                    <SectionHeading id="security-proxy" level={2}>
+                        sig proxy — credentials never leave the process
+                    </SectionHeading>
                     <P>
-                        The MITM proxy daemon runs on localhost (127.0.0.1). Client apps set HTTP_PROXY and make normal requests. The proxy intercepts HTTPS connections, injects credentials as HTTP headers, and forwards to the upstream server.
+                        The MITM proxy daemon runs on localhost (127.0.0.1). Client apps set
+                        HTTP_PROXY and make normal requests. The proxy intercepts HTTPS connections,
+                        injects credentials as HTTP headers, and forwards to the upstream server.
                     </P>
                     <P>
-                        Credentials are decrypted from storage and held only in the proxy process memory. Client applications, subprocesses, and env vars never contain tokens. TLS interception uses ECDSA P-256 certificates generated per hostname.
+                        Credentials are decrypted from storage and held only in the proxy process
+                        memory. Client applications, subprocesses, and env vars never contain
+                        tokens. TLS interception uses ECDSA P-256 certificates generated per
+                        hostname.
                     </P>
                     <CodeBlock lang="bash">{`sig proxy start && export HTTP_PROXY=http://127.0.0.1:7891 HTTPS_PROXY=http://127.0.0.1:7891`}</CodeBlock>
-                    <P><strong>Use when:</strong> AI agents, CI/CD pipelines, long-running daemons, any tool that supports HTTP_PROXY.</P>
-
-                    <SectionHeading id="security-request" level={2}>sig request — credentials stay internal</SectionHeading>
                     <P>
-                        <Code>sig request</Code> loads credentials into process memory, makes a single HTTP request, and discards them. Credentials are never written to env vars, files, or stdout. The exposure window is ~100ms per request.
+                        <strong>Use when:</strong> AI agents, CI/CD pipelines, long-running daemons,
+                        any tool that supports HTTP_PROXY.
+                    </P>
+
+                    <SectionHeading id="security-request" level={2}>
+                        sig request — credentials stay internal
+                    </SectionHeading>
+                    <P>
+                        <Code>sig request</Code> loads credentials into process memory, makes a
+                        single HTTP request, and discards them. Credentials are never written to env
+                        vars, files, or stdout. The exposure window is ~100ms per request.
                     </P>
                     <CodeBlock lang="bash">{`sig request https://api.example.com/me --format body`}</CodeBlock>
-                    <P><strong>Use when:</strong> One-off API calls, shell scripts, pipeline steps that need a single HTTP response.</P>
-
-                    <SectionHeading id="security-run" level={2}>sig run — credentials in env vars</SectionHeading>
                     <P>
-                        <Code>sig run</Code> injects <Code>SIG_&lt;PROVIDER&gt;_*</Code> env vars into the child process. This is convenient for tools that read configuration from environment variables, but env vars are readable via <Code>/proc</Code> on Linux and inherited by all child processes. Output from the child is redacted (credential values replaced with <Code>****</Code>) but redaction is best-effort.
+                        <strong>Use when:</strong> One-off API calls, shell scripts, pipeline steps
+                        that need a single HTTP response.
+                    </P>
+
+                    <SectionHeading id="security-run" level={2}>
+                        sig run — credentials in env vars
+                    </SectionHeading>
+                    <P>
+                        <Code>sig run</Code> injects <Code>SIG_&lt;PROVIDER&gt;_*</Code> env vars
+                        into the child process. This is convenient for tools that read configuration
+                        from environment variables, but env vars are readable via <Code>/proc</Code>{' '}
+                        on Linux and inherited by all child processes. Output from the child is
+                        redacted (credential values replaced with <Code>****</Code>) but redaction
+                        is best-effort.
                     </P>
                     <CodeBlock lang="bash">{`sig run my-jira -- bash -c 'curl -H "Cookie: $SIG_MY_JIRA_COOKIE" https://jira.example.com/api/me'`}</CodeBlock>
-                    <P><strong>Use when:</strong> Wrapping tools that read SIG_* env vars, local development, quick scripting.</P>
-
-                    <SectionHeading id="security-get" level={2}>sig get — credentials printed to stdout</SectionHeading>
                     <P>
-                        <Code>sig get</Code> outputs credential headers to stdout. By default, values are redacted (<Code>****</Code>), but <Code>--no-redaction</Code> reveals raw tokens. Even redacted output shows credential structure. Raw values are visible in terminal scrollback, shell history (<Code>~/.bash_history</Code>, <Code>~/.zsh_history</Code>), and piped commands.
+                        <strong>Use when:</strong> Wrapping tools that read SIG_* env vars, local
+                        development, quick scripting.
+                    </P>
+
+                    <SectionHeading id="security-get" level={2}>
+                        sig get — credentials printed to stdout
+                    </SectionHeading>
+                    <P>
+                        <Code>sig get</Code> outputs credential headers to stdout. By default,
+                        values are redacted (<Code>****</Code>), but <Code>--no-redaction</Code>{' '}
+                        reveals raw tokens. Even redacted output shows credential structure. Raw
+                        values are visible in terminal scrollback, shell history (
+                        <Code>~/.bash_history</Code>, <Code>~/.zsh_history</Code>), and piped
+                        commands.
                     </P>
                     <CodeBlock lang="bash">{`# Redacted by default
 sig get my-jira
 # Raw values (use with caution)
 sig get my-jira --no-redaction`}</CodeBlock>
-                    <P><strong>Use when:</strong> Debugging credential format, manual API testing. Never pipe raw output into AI agent context or logs.</P>
+                    <P>
+                        <strong>Use when:</strong> Debugging credential format, manual API testing.
+                        Never pipe raw output into AI agent context or logs.
+                    </P>
 
-                    <SectionHeading id="security-shared" level={2}>Shared protections</SectionHeading>
+                    <SectionHeading id="security-shared" level={2}>
+                        Shared protections
+                    </SectionHeading>
                     <P>All four methods share these protections:</P>
                     <List>
                         <Li>
-                            <strong>AES-256-GCM encryption at rest</strong> — all credential files in{' '}
-                            <Code>~/.sig/credentials/</Code> are encrypted. The encryption key lives at{' '}
-                            <Code>~/.sig/encryption.key</Code> (mode 0o400, owner-read only).
+                            <strong>AES-256-GCM encryption at rest</strong> — all credential files
+                            in <Code>~/.sig/credentials/</Code> are encrypted. The encryption key
+                            lives at <Code>~/.sig/encryption.key</Code> (mode 0o400, owner-read
+                            only).
                         </Li>
                         <Li>
-                            <strong>Audit logging</strong> — every credential access, login, logout, sync, and proxy start/stop is logged to{' '}
-                            <Code>~/.sig/audit.log</Code> as JSON Lines.
+                            <strong>Audit logging</strong> — every credential access, login, logout,
+                            sync, and proxy start/stop is logged to <Code>~/.sig/audit.log</Code> as
+                            JSON Lines.
                         </Li>
                         <Li>
-                            <strong>Result-based error handling</strong> — authentication failures return typed errors (<Code>{'Result<T, AuthError>'}</Code>), never throw exceptions. Credentials are never exposed in error messages.
+                            <strong>Result-based error handling</strong> — authentication failures
+                            return typed errors (<Code>{'Result<T, AuthError>'}</Code>), never throw
+                            exceptions. Credentials are never exposed in error messages.
                         </Li>
                         <Li>
-                            <strong>Automatic refresh</strong> — expired credentials are refreshed transparently before use. No stale tokens leak through error paths.
+                            <strong>Automatic refresh</strong> — expired credentials are refreshed
+                            transparently before use. No stale tokens leak through error paths.
                         </Li>
                     </List>
                 </>


### PR DESCRIPTION
## Summary
- Add **Security Model** section to website docs (EN + ZH) with 5-column comparison table ranking credential access methods: `proxy ≥ request > run > get`
- Expand **Getting Started** with hands-on onboarding: "Try: sig proxy", "Try: sig request", "Choosing a method" decision table
- Reorder CLI `--help` to show credentials by security level, add security notes to `proxy`, `request`, `run`, `get` command help
- Add Security section to README with comparison table and AI agent recommendation

## Test plan
- [x] `pnpm --filter @sigcli/cli build` — passes
- [x] `pnpm --filter website build` — passes
- [x] `sig --help` — shows security-ordered credential commands
- [x] Website `/docs/` — Security Model section renders with table, TOC navigation works
- [x] Website `/zh/docs/` — Chinese translation mirrors English structure
- [x] Individual command `--help` (proxy, request, run, get) — shows security context