### PR TITLE
feat(website): update header with branding and navigation

### DIFF
--- a/website/src/components/markdown.tsx
+++ b/website/src/components/markdown.tsx
@@ -1588,7 +1588,10 @@ export function EditorialPage({
             {/* Header: single row — logo + GitHub button, border aligned with content grid */}
             <div className="slot-navbar">
                 <div className="mx-auto flex items-center justify-between px-(--mobile-padding) py-(--header-padding-y) lg:max-w-(--grid-max-width) lg:px-0">
-                    <a href={locale === 'zh' ? '/zh/' : '/'} className="slot-logo no-underline flex items-center">
+                    <a
+                        href={locale === 'zh' ? '/zh/' : '/'}
+                        className="slot-logo no-underline flex items-center"
+                    >
                         <span
                             style={{
                                 fontFamily: "'Bubblegum Sans', cursive",
@@ -1618,7 +1621,16 @@ export function EditorialPage({
                                 e.currentTarget.style.borderColor = 'var(--page-border)';
                             }}
                         >
-                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                            <svg
+                                width="16"
+                                height="16"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                            >
                                 <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
                                 <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
                             </svg>


### PR DESCRIPTION
## Summary
- Add Bubblegum Sans logo text, Docs button, and locale-aware navigation to the website header
- Add 48px rounded corners to icon and favicon SVGs
- Fix Prettier formatting in markdown component

## Test plan
- [ ] Verify header renders correctly with logo, Docs link, and GitHub link
- [ ] Test locale switching (`/zh/` prefix) for logo and docs links
- [ ] Confirm CI lint/format checks pass