### PR TITLE
fix(website): move demo gif to hero section

### DIFF
--- a/website/src/content/en.tsx
+++ b/website/src/content/en.tsx
@@ -60,6 +60,18 @@ export const pageContent = {
                 The authentication layer for AI agents. Log in once in your browser — your AI agent
                 handles the rest.
             </p>
+            <div style={{ margin: '24px 0 0' }}>
+                <img
+                    src="/demo.gif"
+                    alt="sig demo — login, status, request, run, proxy"
+                    style={{
+                        width: '100%',
+                        maxWidth: '720px',
+                        borderRadius: '8px',
+                        border: '1px solid var(--border-primary)',
+                    }}
+                />
+            </div>
         </div>
     ),
 
@@ -149,18 +161,6 @@ curl https://my-jira.example.com/rest/api/2/myself`}</CodeBlock>
                         Three steps: configure, authenticate once, let your AI agent operate. The
                         auth flow runs once; every subsequent call reads from encrypted storage.
                     </P>
-                    <div style={{ margin: '24px 0' }}>
-                        <img
-                            src="/demo.gif"
-                            alt="sig demo — login, status, request, run, proxy"
-                            style={{
-                                width: '100%',
-                                maxWidth: '720px',
-                                borderRadius: '8px',
-                                border: '1px solid var(--border-primary)',
-                            }}
-                        />
-                    </div>
 
                     <CodeBlock lang="diagram" showLineNumbers={false}>{`
  ┌──────────────────┐    ┌───────────────────────┐    ┌──────────────────────┐

--- a/website/src/content/zh.tsx
+++ b/website/src/content/zh.tsx
@@ -59,6 +59,18 @@ export const pageContent = {
             >
                 AI 代理的认证层。在浏览器中登录一次——剩下的交给 AI。
             </p>
+            <div style={{ margin: '24px 0 0' }}>
+                <img
+                    src="/demo.gif"
+                    alt="sig 演示 — 登录、状态、请求、运行、代理"
+                    style={{
+                        width: '100%',
+                        maxWidth: '720px',
+                        borderRadius: '8px',
+                        border: '1px solid var(--border-primary)',
+                    }}
+                />
+            </div>
         </div>
     ),
 
@@ -89,18 +101,6 @@ export const pageContent = {
                         捕获 cookie、令牌和请求头，加密存储——然后注入到 AI
                         代理运行的任何进程中。代理顺利完成任务，但永远看不到你的秘密。
                     </P>
-                    <div style={{ margin: '24px 0' }}>
-                        <img
-                            src="/demo.gif"
-                            alt="sig 演示 — 登录、状态、请求、运行、代理"
-                            style={{
-                                width: '100%',
-                                maxWidth: '720px',
-                                borderRadius: '8px',
-                                border: '1px solid var(--border-primary)',
-                            }}
-                        />
-                    </div>
 
                     <CodeBlock lang="diagram" showLineNumbers={false}>{`
  ┌──────────────────┐    ┌───────────────────────┐    ┌──────────────────────┐


### PR DESCRIPTION
## Summary
- Move demo.gif from content sections to directly under the hero subtitle in both EN and ZH pages
- The gif now appears right after "The authentication layer for AI agents. Log in once in your browser — your AI agent handles the rest."

## Test plan
- [ ] Verify gif renders under the hero text on the English page
- [ ] Verify gif renders under the hero text on the Chinese page
- [ ] Confirm gif no longer appears in the "How it works" / overview sections