### PR TITLE
fix(website): clean up fade gradient and improve layout alignment

### DIFF
--- a/website/src/components/markdown.tsx
+++ b/website/src/components/markdown.tsx
@@ -1688,16 +1688,8 @@ export function EditorialPage({
                 </div>
             </div>
 
-            {/* Hero: rendered above the 3-column grid, using the same column widths
-          so hero content aligns with the center content column (col 2). */}
-            {hero && (
-                <div className="mx-auto w-full max-w-full px-(--mobile-padding) lg:grid lg:grid-cols-[var(--grid-toc-width)_var(--grid-content-width)_var(--grid-sidebar-width)] lg:gap-x-(--grid-gap) lg:justify-between lg:max-w-(--grid-max-width) lg:px-0">
-                    <div className="lg:col-start-2">{hero}</div>
-                </div>
-            )}
-
             <div className="grid grid-cols-1 w-full max-w-full mx-auto px-(--mobile-padding) lg:grid-cols-[var(--grid-toc-width)_var(--grid-content-width)_var(--grid-sidebar-width)] lg:gap-x-(--grid-gap) lg:justify-between lg:max-w-(--grid-max-width) lg:px-0">
-                {/* TOC sidebar: sticky within its grid cell */}
+                {/* TOC sidebar: sticky within its grid cell, spans all rows including hero */}
                 <div className="slot-sidebar-left">
                     <div
                         style={{
@@ -1711,6 +1703,9 @@ export function EditorialPage({
                         <TableOfContents items={toc} logo={logo} />
                     </div>
                 </div>
+
+                {/* Hero: rendered inside the grid, in the center content column */}
+                {hero && <div className="lg:col-start-2">{hero}</div>}
 
                 {sections ? (
                     <>

--- a/website/src/content/en.tsx
+++ b/website/src/content/en.tsx
@@ -53,7 +53,6 @@ export const pageContent = {
                     fontWeight: 400,
                     lineHeight: 1.55,
                     color: 'var(--text-primary)',
-                    opacity: 0.72,
                     margin: 0,
                 }}
             >
@@ -309,6 +308,7 @@ $ sig request https://my-jira.example.com/rest/api/2/myself`}</CodeBlock>
                     <P>
                         <A href="/docs/">Full documentation →</A>
                     </P>
+                    <div style={{ paddingBottom: '80px' }} />
                 </>
             ),
             aside: (

--- a/website/src/content/zh.tsx
+++ b/website/src/content/zh.tsx
@@ -53,7 +53,6 @@ export const pageContent = {
                     fontWeight: 400,
                     lineHeight: 1.55,
                     color: 'var(--text-primary)',
-                    opacity: 0.72,
                     margin: 0,
                 }}
             >
@@ -337,6 +336,7 @@ $ sig run my-api -- node sync_data.js`}</CodeBlock>
                             </tr>
                         </tbody>
                     </table>
+                    <div style={{ paddingBottom: '80px' }} />
                 </>
             ),
             aside: (

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -115,7 +115,7 @@
     --text-tertiary: rgba(0, 0, 0, 0.25);
     --text-muted: rgba(0, 0, 0, 0.5);
     --text-hover: rgba(0, 0, 0, 0.7);
-    --text-tree-label: rgba(0, 0, 0, 0.6);
+    --text-tree-label: rgba(0, 0, 0, 0.85);
     --bg: #fff;
     --page-border: #e3e3e3;
     --divider: rgb(242, 242, 242);

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -76,9 +76,6 @@
     --layout-gap: 21px;
     --sticky-top: calc(var(--header-height) + var(--layout-gap));
 
-    /* Fade gradient */
-    --fade-top: calc(var(--header-row-height) + 19px);
-    --fade-height: 48px;
 
     /* Grid geometry */
     --grid-toc-width: 210px;
@@ -148,20 +145,6 @@
         0 0.3125rem 0.5rem rgba(0, 0, 0, 0.02), 0 0.125rem 0.25rem rgba(0, 0, 0, 0.016),
         0 0 0.125rem rgba(0, 0, 0, 0.01);
 
-    /* Header fade gradient stops */
-    --fade-0: rgb(255, 255, 255);
-    --fade-1: rgba(255, 255, 255, 0.737);
-    --fade-2: rgba(255, 255, 255, 0.541);
-    --fade-3: rgba(255, 255, 255, 0.382);
-    --fade-4: rgba(255, 255, 255, 0.278);
-    --fade-5: rgba(255, 255, 255, 0.194);
-    --fade-6: rgba(255, 255, 255, 0.126);
-    --fade-7: rgba(255, 255, 255, 0.075);
-    --fade-8: rgba(255, 255, 255, 0.042);
-    --fade-9: rgba(255, 255, 255, 0.021);
-    --fade-10: rgba(255, 255, 255, 0.008);
-    --fade-11: rgba(255, 255, 255, 0.002);
-    --fade-12: rgba(255, 255, 255, 0);
 
     /* Dark mode overrides */
     @variant dark {
@@ -219,19 +202,6 @@
             0 1rem 2rem rgba(0, 0, 0, 0.2), 0 0.625rem 1rem rgba(0, 0, 0, 0.15),
             0 0.3125rem 0.5rem rgba(0, 0, 0, 0.1), 0 0.125rem 0.25rem rgba(0, 0, 0, 0.08),
             0 0 0.125rem rgba(0, 0, 0, 0.05);
-        --fade-0: rgb(17, 17, 17);
-        --fade-1: rgba(17, 17, 17, 0.737);
-        --fade-2: rgba(17, 17, 17, 0.541);
-        --fade-3: rgba(17, 17, 17, 0.382);
-        --fade-4: rgba(17, 17, 17, 0.278);
-        --fade-5: rgba(17, 17, 17, 0.194);
-        --fade-6: rgba(17, 17, 17, 0.126);
-        --fade-7: rgba(17, 17, 17, 0.075);
-        --fade-8: rgba(17, 17, 17, 0.042);
-        --fade-9: rgba(17, 17, 17, 0.021);
-        --fade-10: rgba(17, 17, 17, 0.008);
-        --fade-11: rgba(17, 17, 17, 0.002);
-        --fade-12: rgba(17, 17, 17, 0);
     }
 }
 

--- a/website/src/styles/editorial.css
+++ b/website/src/styles/editorial.css
@@ -163,32 +163,3 @@
     }
 }
 
-/* ========================================================================
-   Header fade gradient
-   ======================================================================== */
-
-.slot-page::before {
-    content: '';
-    pointer-events: none;
-    z-index: 9;
-    position: fixed;
-    top: var(--fade-top);
-    left: 0;
-    right: 0;
-    height: var(--fade-height);
-    background: linear-gradient(
-        var(--fade-0) 0px,
-        var(--fade-1) 19%,
-        var(--fade-2) 34%,
-        var(--fade-3) 47%,
-        var(--fade-4) 56.5%,
-        var(--fade-5) 65%,
-        var(--fade-6) 73%,
-        var(--fade-7) 80.2%,
-        var(--fade-8) 86.1%,
-        var(--fade-9) 91%,
-        var(--fade-10) 95.2%,
-        var(--fade-11) 98.2%,
-        var(--fade-12) 100%
-    );
-}


### PR DESCRIPTION
## Summary
- Remove unused header fade gradient overlay (CSS variables + `.slot-page::before` pseudo-element)
- Move hero section inside the 3-column grid so the TOC sidebar spans all rows
- Increase tree-label text contrast (`0.6` → `0.85`) and remove subtitle opacity
- Add bottom padding to content sections (en + zh)

## Test plan
- [ ] Verify website renders correctly in light and dark mode
- [ ] Confirm hero section aligns with the center content column
- [ ] Check TOC sidebar spans full page height including hero row