### PR TITLE
Add Skills docs with catalog and build guide

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -30,6 +30,27 @@ AI agent skills for authenticated access to web services via sigcli.
 | `msteams`     | Send and read messages, search conversations, look up people, check calendar          |
 | `slack`       | Read channels, search messages, check unreads, send messages, manage reactions        |
 
-## Adding Skills
+## Build Your Own
 
-Each skill is a directory with a `SKILL.md` file. Add new skills by creating a directory under `skills/` and adding it to the `ALL_SKILLS` list in `install.sh`.
+A skill is a directory with a `SKILL.md` file and optional Python scripts. See the full guide at [sigcli.ai/docs#skills-build](https://sigcli.ai/docs#skills-build).
+
+Quick version:
+
+```
+my-service/
+  SKILL.md              # YAML frontmatter + markdown guide for the agent
+  scripts/
+    list_items.py       # Python script: argparse CLI, JSON output
+    requirements.txt    # requests>=2.28.0
+  tests/
+    test_list_items.py  # pytest + responses library for HTTP mocking
+```
+
+Register in `install.sh` by adding the directory name to `ALL_SKILLS`.
+
+## Running Tests
+
+```bash
+pip install requests beautifulsoup4 pytest responses
+python -m pytest -v
+```

--- a/website/src/content/docs-zh.tsx
+++ b/website/src/content/docs-zh.tsx
@@ -131,6 +131,9 @@ export const pageContent = {
         tocItem('#sdk-ts', 'TypeScript SDK', { level: 1, parent: '#sdk', prefix: '├ ' }),
         tocItem('#sdk-python', 'Python SDK', { level: 1, parent: '#sdk', prefix: '└ ' }),
         tocItem('#ai-agents', 'AI 代理集成'),
+        tocItem('#skills', '技能'),
+        tocItem('#skills-catalog', '可用技能', { level: 1, parent: '#skills', prefix: '├ ' }),
+        tocItem('#skills-build', '创建技能', { level: 1, parent: '#skills', prefix: '└ ' }),
         tocItem('#remote-ssh', '远程与 SSH'),
         tocItem('#error-codes', '错误代码'),
     ] as FlatTocItem[],
@@ -1460,6 +1463,157 @@ sig status my-jira --format json
                         切勿在代理上下文或日志中显示 <Code>sig get</Code> 的输出——它可能包含原始
                         bearer 令牌或 API 密钥。
                     </P>
+                </>
+            ),
+        },
+
+        /* ── 技能 ── */
+        {
+            content: (
+                <>
+                    <SectionHeading id="skills" level={1}>
+                        技能
+                    </SectionHeading>
+                    <P>
+                        技能是可直接使用的扩展包，让 AI 代理（Claude
+                        Code、Cursor、Windsurf、Cline）能够通过认证访问特定服务。每个技能是一个包含{' '}
+                        <Code>SKILL.md</Code> 指南和 Python
+                        辅助脚本的目录。代理读取指南，调用脚本，sigcli 透明处理认证。
+                    </P>
+                    <CodeBlock lang="bash">{`# 安装所有技能（自动检测代理）
+./skills/install.sh
+
+# 指定代理
+./skills/install.sh --agent cursor
+
+# 查看已安装
+./skills/install.sh --list`}</CodeBlock>
+
+                    <SectionHeading id="skills-catalog" level={2}>
+                        可用技能
+                    </SectionHeading>
+                    <List>
+                        <Li>
+                            <Code>sigcli-auth</Code> — 认证指南：策略选择、命令参考、错误恢复。
+                        </Li>
+                        <Li>
+                            <Code>outlook</Code> — 通过 Microsoft Graph
+                            读取、发送、搜索、回复邮件。使用 <Code>ms-graph</Code>{' '}
+                            提供者（OAuth2）。
+                        </Li>
+                        <Li>
+                            <Code>msteams</Code> — 消息、对话、人员搜索、日历。使用{' '}
+                            <Code>ms-teams</Code> 和 <Code>ms-graph</Code> 提供者。
+                        </Li>
+                        <Li>
+                            <Code>slack</Code> — 频道、消息、搜索、表情。使用 <Code>app-slack</Code>{' '}
+                            提供者（cookie + localStorage）。
+                        </Li>
+                    </List>
+
+                    <SectionHeading id="skills-build" level={2}>
+                        10 分钟创建技能
+                    </SectionHeading>
+                    <P>
+                        一个技能只需一个文件：<Code>SKILL.md</Code>。如果 API
+                        响应解析复杂，可添加辅助脚本。
+                    </P>
+
+                    <P>
+                        <strong>1. 创建目录</strong>
+                    </P>
+                    <CodeBlock lang="bash">{`mkdir -p skills/my-service/scripts`}</CodeBlock>
+
+                    <P>
+                        <strong>
+                            2. 编写 <Code>SKILL.md</Code>
+                        </strong>
+                    </P>
+                    <CodeBlock lang="markdown">{`---
+name: my-service
+description: '与 My Service 交互 — 创建、列出和更新项目。'
+---
+
+# My Service
+
+通过 REST API 创建、列出和更新项目。
+
+## 认证
+
+| 提供者        | 类型   | 登录命令                                  |
+|------------- |--------|----------------------------------------|
+| \`my-service\` | cookie | \`sig login https://my-service.example.com/\` |
+
+**运行脚本：**
+\`\`\`bash
+sig run my-service -- python3 scripts/list_items.py \\
+  --cookie "$SIG_MY_SERVICE_COOKIE"
+\`\`\``}</CodeBlock>
+
+                    <P>
+                        <strong>3. 添加辅助脚本</strong>（可选）
+                    </P>
+                    <CodeBlock lang="python">{`#!/usr/bin/env python3
+"""列出 My Service API 中的项目。"""
+import argparse, json, sys, requests
+
+BASE = "https://my-service.example.com/api/v1"
+
+def list_items(cookie, query=None, limit=20):
+    headers = {"Cookie": cookie} if cookie else {}
+    params = {"limit": limit}
+    if query:
+        params["q"] = query
+    resp = requests.get(f"{BASE}/items", headers=headers, params=params, timeout=15)
+    resp.raise_for_status()
+    return {"items": resp.json().get("items", []), "count": len(resp.json().get("items", []))}
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--cookie", default="")
+    p.add_argument("--query")
+    p.add_argument("--limit", type=int, default=20)
+    args = p.parse_args()
+    try:
+        json.dump(list_items(args.cookie, args.query, args.limit), sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": f"HTTP_{e.response.status_code}"}, sys.stdout, indent=2)
+
+if __name__ == "__main__":
+    main()`}</CodeBlock>
+
+                    <P>
+                        <strong>4. 注册并安装</strong>
+                    </P>
+                    <CodeBlock lang="bash">{`# 在 skills/install.sh 的 ALL_SKILLS 中添加，然后：
+./skills/install.sh`}</CodeBlock>
+
+                    <P>
+                        就这样。代理读取 <Code>SKILL.md</Code>，调用{' '}
+                        <Code>sig run my-service -- python3 scripts/list_items.py</Code>，获取 JSON
+                        结果。无需 SDK，无需框架 — 只需一个 Markdown 文件和一个脚本。
+                    </P>
+                </>
+            ),
+            aside: (
+                <>
+                    <P>
+                        <strong>技能约定：</strong>
+                    </P>
+                    <List>
+                        <Li>脚本输出 JSON 到 stdout，错误格式为 {`{"error": "..."}`}</Li>
+                        <Li>
+                            凭证通过 <Code>sig run</Code> 环境变量传递：
+                            <Code>SIG_{'<PROVIDER>'}_COOKIE</Code>
+                        </Li>
+                        <Li>
+                            Token 参数可选（默认 <Code>{`""`}</Code>），兼容 <Code>sig run</Code> 和{' '}
+                            <Code>sig proxy</Code>
+                        </Li>
+                        <Li>
+                            测试使用 <Code>responses</Code> 库模拟 HTTP
+                        </Li>
+                    </List>
                 </>
             ),
         },

--- a/website/src/content/docs.tsx
+++ b/website/src/content/docs.tsx
@@ -122,6 +122,13 @@ export const pageContent = {
         tocItem('#sdk-ts', 'TypeScript SDK', { level: 1, parent: '#sdk', prefix: '├ ' }),
         tocItem('#sdk-python', 'Python SDK', { level: 1, parent: '#sdk', prefix: '└ ' }),
         tocItem('#ai-agents', 'AI Agent Integration'),
+        tocItem('#skills', 'Skills'),
+        tocItem('#skills-catalog', 'Available skills', {
+            level: 1,
+            parent: '#skills',
+            prefix: '├ ',
+        }),
+        tocItem('#skills-build', 'Build a skill', { level: 1, parent: '#skills', prefix: '└ ' }),
         tocItem('#remote-ssh', 'Remote & SSH'),
         tocItem('#error-codes', 'Error Codes'),
     ] as FlatTocItem[],
@@ -1267,6 +1274,213 @@ sig status my-jira --format json
                         Never display <Code>sig get</Code> output in agent context or logs — it may
                         contain raw bearer tokens or API keys.
                     </P>
+                </>
+            ),
+        },
+
+        /* ── Skills ── */
+        {
+            content: (
+                <>
+                    <SectionHeading id="skills" level={1}>
+                        Skills
+                    </SectionHeading>
+                    <P>
+                        Skills are drop-in packages that give AI agents (Claude Code, Cursor,
+                        Windsurf, Cline) authenticated access to specific services. Each skill is a
+                        directory with a <Code>SKILL.md</Code> guide and Python helper scripts. The
+                        agent reads the guide, shells out to the scripts, and sigcli handles auth
+                        transparently.
+                    </P>
+                    <CodeBlock lang="bash">{`# Install all skills (auto-detects your agent)
+./skills/install.sh
+
+# Or pick an agent
+./skills/install.sh --agent cursor
+
+# List what's installed
+./skills/install.sh --list`}</CodeBlock>
+
+                    <SectionHeading id="skills-catalog" level={2}>
+                        Available Skills
+                    </SectionHeading>
+                    <List>
+                        <Li>
+                            <Code>sigcli-auth</Code> — Authentication guide. Strategy selection,
+                            command reference, error recovery. Bundled with every install.
+                        </Li>
+                        <Li>
+                            <Code>outlook</Code> — Read, send, search, reply, forward emails via
+                            Microsoft Graph. Uses <Code>ms-graph</Code> provider (OAuth2).
+                        </Li>
+                        <Li>
+                            <Code>msteams</Code> — Messages, conversations, people search, calendar
+                            via Teams Chat API + Graph. Uses <Code>ms-teams</Code> and{' '}
+                            <Code>ms-graph</Code> providers.
+                        </Li>
+                        <Li>
+                            <Code>slack</Code> — Channels, messages, search, reactions via Slack Web
+                            API. Uses <Code>app-slack</Code> provider (cookie + localStorage).
+                        </Li>
+                    </List>
+                    <P>
+                        See <Code>skills/sigcli-auth/references/config-template.yaml</Code> for a
+                        ready-to-use config with all providers pre-configured.
+                    </P>
+
+                    <SectionHeading id="skills-build" level={2}>
+                        Build a Skill in 10 Minutes
+                    </SectionHeading>
+                    <P>
+                        A skill is a directory with one file: <Code>SKILL.md</Code>. Add helper
+                        scripts if the agent needs to parse complex API responses. Here's the full
+                        recipe.
+                    </P>
+
+                    <P>
+                        <strong>1. Create the directory</strong>
+                    </P>
+                    <CodeBlock lang="bash">{`mkdir -p skills/my-service/scripts`}</CodeBlock>
+
+                    <P>
+                        <strong>
+                            2. Write <Code>SKILL.md</Code>
+                        </strong>
+                    </P>
+                    <P>
+                        The frontmatter tells the agent when to trigger. The body teaches it how to
+                        use the service.
+                    </P>
+                    <CodeBlock lang="markdown">{`---
+name: my-service
+description: 'Interact with My Service — create, list, and update items.
+  Use this skill when the user mentions My Service, items, or tasks.'
+---
+
+# My Service
+
+Create, list, and update items via My Service REST API.
+
+## Authentication
+
+| Provider     | Type   | Login Command                          |
+|------------- |--------|----------------------------------------|
+| \`my-service\` | cookie | \`sig login https://my-service.example.com/\` |
+
+**Run scripts:**
+\`\`\`bash
+sig run my-service -- python3 scripts/list_items.py \\
+  --cookie "$SIG_MY_SERVICE_COOKIE"
+\`\`\`
+
+## Scripts
+
+### list_items.py
+List items from the API.
+\`\`\`
+--cookie TEXT    Auth cookie (from sig run)
+--limit  INT    Max results (default: 20)
+--query  TEXT   Filter by keyword (optional)
+\`\`\`
+
+## Error Handling
+| Code | Meaning                  | Fix                              |
+|------|--------------------------|----------------------------------|
+| 401  | Session expired          | \`sig login <url>\`                |
+| 429  | Rate limited             | Wait and retry                   |`}</CodeBlock>
+
+                    <P>
+                        <strong>3. Add a helper script</strong> (optional — only if parsing is
+                        non-trivial)
+                    </P>
+                    <CodeBlock lang="python">{`#!/usr/bin/env python3
+"""List items from My Service API."""
+import argparse, json, sys, requests
+
+BASE = "https://my-service.example.com/api/v1"
+
+def list_items(cookie, query=None, limit=20):
+    headers = {"Cookie": cookie} if cookie else {}
+    params = {"limit": limit}
+    if query:
+        params["q"] = query
+    resp = requests.get(f"{BASE}/items", headers=headers, params=params, timeout=15)
+    resp.raise_for_status()
+    return {"items": resp.json().get("items", []), "count": len(resp.json().get("items", []))}
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--cookie", default="")
+    p.add_argument("--query")
+    p.add_argument("--limit", type=int, default=20)
+    args = p.parse_args()
+    try:
+        json.dump(list_items(args.cookie, args.query, args.limit), sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": f"HTTP_{e.response.status_code}"}, sys.stdout, indent=2)
+
+if __name__ == "__main__":
+    main()`}</CodeBlock>
+
+                    <P>
+                        <strong>4. Add a test</strong>
+                    </P>
+                    <CodeBlock lang="python">{`"""Tests for my-service/scripts/list_items.py"""
+import re, responses
+from test_helpers import load_script
+
+mod = load_script("my-service", "list_items")
+
+class TestListItems:
+    @responses.activate
+    def test_basic_list(self):
+        responses.get(
+            url=re.compile(r"https://my-service\\.example\\.com/api/v1/items"),
+            json={"items": [{"id": 1, "name": "Task A"}]},
+        )
+        result = mod.list_items("session=abc", limit=10)
+        assert result["count"] == 1
+        assert result["items"][0]["name"] == "Task A"`}</CodeBlock>
+
+                    <P>
+                        <strong>5. Register and install</strong>
+                    </P>
+                    <CodeBlock lang="bash">{`# Add to skills/install.sh ALL_SKILLS list, then:
+./skills/install.sh
+# Test:
+cd skills && python -m pytest my-service/tests/ -v`}</CodeBlock>
+
+                    <P>
+                        That's it. The agent reads <Code>SKILL.md</Code>, calls{' '}
+                        <Code>sig run my-service -- python3 scripts/list_items.py</Code>, and gets
+                        JSON back. No SDK, no framework — just a markdown file and a script.
+                    </P>
+                </>
+            ),
+            aside: (
+                <>
+                    <P>
+                        <strong>Skill conventions:</strong>
+                    </P>
+                    <List>
+                        <Li>Scripts output JSON to stdout, errors as {`{"error": "..."}`}</Li>
+                        <Li>
+                            Credentials via <Code>sig run</Code> env vars:{' '}
+                            <Code>SIG_{'<PROVIDER>'}_COOKIE</Code> or{' '}
+                            <Code>SIG_{'<PROVIDER>'}_TOKEN</Code>
+                        </Li>
+                        <Li>
+                            Token args are optional (default <Code>{`""`}</Code>) so scripts work
+                            with both <Code>sig run</Code> and <Code>sig proxy</Code>
+                        </Li>
+                        <Li>
+                            Tests use <Code>responses</Code> library to mock HTTP
+                        </Li>
+                        <Li>
+                            <Code>install.sh</Code> excludes <Code>tests/</Code> when copying to
+                            agent directories
+                        </Li>
+                    </List>
                 </>
             ),
         },


### PR DESCRIPTION
## Summary

- Add **Skills** section to website docs (EN + ZH) with:
  - Available skills catalog (outlook, msteams, slack)
  - "Build a Skill in 10 Minutes" step-by-step guide with SKILL.md, Python script, and test examples
  - Conventions sidebar
- Update `skills/README.md` — concise catalog + pointer to website guide

## Test plan

- [x] Website builds clean (`pnpm --filter website build`)
- [x] Prettier formatting passes (`pnpm format:check`)
- [ ] Visual review of Skills section on docs page