### PR TITLE
fix(proxy): guard IPC disconnect on daemon fork

### DIFF
--- a/cli/src/cli/commands/proxy.ts
+++ b/cli/src/cli/commands/proxy.ts
@@ -108,7 +108,7 @@ async function handleStart(
     });
 
     child.unref();
-    child.disconnect();
+    if (child.connected) child.disconnect();
     closeSync(logFd);
 
     if (!started) {


### PR DESCRIPTION
## Summary
- Fix `ERR_IPC_DISCONNECTED` crash when starting proxy daemon
- When the forked child exits before the 2000ms timeout, Node auto-closes the IPC channel — the unconditional `child.disconnect()` then throws
- Add `child.connected` guard before calling `disconnect()`

## Test plan
- [x] `sig proxy start` no longer throws `ERR_IPC_DISCONNECTED`
- [x] `sig proxy status` confirms daemon is running
- [x] `sig proxy stop` cleanly stops daemon
- [x] All 666 CLI tests pass