### PR TITLE
chore(cli): bump version to 1.2.1

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sigcli/cli",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "General-purpose authentication CLI with pluggable strategies and browser adapters",
     "main": "dist/index.js",
     "type": "module",


### PR DESCRIPTION
## Summary
- Bump @sigcli/cli version to 1.2.1 for release

## Changes
- Version bump only (patch release for proxy IPC disconnect fix from #42)