### PR TITLE
Add V2EX skill with full read/write support

### DIFF
--- a/skills/install.sh
+++ b/skills/install.sh
@@ -12,7 +12,7 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ALL_SKILLS="sigcli-auth outlook msteams slack"
+ALL_SKILLS="sigcli-auth outlook msteams slack v2ex"
 
 # --- Agent detection ---
 

--- a/skills/pyproject.toml
+++ b/skills/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = ["requests>=2.28.0", "beautifulsoup4>=4.12.0"]
 dev = ["pytest>=8.0", "responses>=0.25.0", "ruff>=0.4.0"]
 
 [tool.pytest.ini_options]
-testpaths = ["outlook/tests", "msteams/tests", "slack/tests"]
+testpaths = ["outlook/tests", "msteams/tests", "slack/tests", "v2ex/tests"]
 pythonpath = ["."]
 addopts = "-v --tb=short"
 

--- a/skills/v2ex/SKILL.md
+++ b/skills/v2ex/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: v2ex
+description: 'Interact with V2EX (v2ex.com) — browse hot and latest topics, read topic details and replies, search posts, create topics, reply to discussions, thank posts, favorite topics/nodes, follow members, daily check-in. Use this skill whenever the user mentions V2EX, v2ex.com, wants to browse tech forum topics, read V2EX discussions, search V2EX posts, check V2EX notifications, create or reply to V2EX topics, or look up V2EX users/nodes. Also trigger when the user pastes a V2EX URL (e.g. v2ex.com/t/12345), mentions a V2EX node name, or asks about Chinese tech community discussions. Keywords: V2EX, v2ex, 论坛, 技术社区, 节点, 主题, 回复.'
+---
+
+# V2EX
+
+Browse, search, read, and interact with V2EX — the creative workers' community.
+
+## Authentication
+
+This skill uses **cookie-based authentication** for full read/write access to V2EX. Use `sig run` to inject the session cookie:
+
+```bash
+sig run v2ex -- bash -c 'python3 scripts/v2ex_hot.py --cookie "$SIG_V2EX_COOKIE"'
+```
+
+The default Signet provider is `v2ex`. The env var is `SIG_V2EX_COOKIE`.
+
+**Read-only operations** (hot topics, latest, topic detail, node info, member profile, search) work **without authentication** via the public V2EX API v1. The `--cookie` argument is optional for these scripts.
+
+**Write operations** (create topic, reply, thank, favorite, follow, daily check-in, append) **require a valid session cookie**.
+
+If a script returns 403 or auth error, re-authenticate:
+
+```bash
+sig login https://www.v2ex.com/
+```
+
+Then retry the `sig run` command.
+
+**Signet provider config:**
+
+```yaml
+v2ex:
+    domains: ['www.v2ex.com', 'v2ex.com']
+    entryUrl: https://www.v2ex.com/signin
+    strategy: cookie
+```
+
+## Scripts Reference
+
+All scripts are in this skill's `scripts/` directory. Run via Bash tool.
+
+### Read Operations
+
+| Script                  | Purpose                            | Auth     |
+| ----------------------- | ---------------------------------- | -------- |
+| `v2ex_hot.py`           | Hot topics of the day              | Optional |
+| `v2ex_latest.py`        | Latest topics                      | Optional |
+| `v2ex_topic.py`         | Topic detail + replies             | Optional |
+| `v2ex_node.py`          | Node info + topics, list nodes     | Optional |
+| `v2ex_member.py`        | Member profile + topics            | Optional |
+| `v2ex_search.py`        | Full-text search via SOV2EX        | None     |
+| `v2ex_notifications.py` | User notifications                 | Required |
+| `v2ex_profile.py`       | Authenticated user profile/balance | Required |
+
+### Write Operations
+
+| Script             | Purpose                           | Auth     |
+| ------------------ | --------------------------------- | -------- |
+| `v2ex_create.py`   | Create a new topic                | Required |
+| `v2ex_reply.py`    | Reply to a topic                  | Required |
+| `v2ex_thank.py`    | Thank a topic or reply            | Required |
+| `v2ex_favorite.py` | Favorite/unfavorite topic or node | Required |
+| `v2ex_follow.py`   | Follow/unfollow/block/unblock     | Required |
+| `v2ex_daily.py`    | Daily sign-in reward              | Required |
+| `v2ex_append.py`   | Append supplement to own topic    | Required |
+
+### v2ex_hot.py
+
+```
+--cookie COOKIE       V2EX session cookie (optional)
+```
+
+### v2ex_latest.py
+
+```
+--cookie COOKIE       V2EX session cookie (optional)
+```
+
+### v2ex_topic.py
+
+```
+--cookie COOKIE       V2EX session cookie (optional)
+--id ID               Topic ID (required)
+--page N              Reply page number (default: 1)
+```
+
+### v2ex_node.py
+
+```
+--cookie COOKIE       V2EX session cookie (optional)
+--name NAME           Node name (e.g., "python", "apple")
+--page N              Page number for topic listing (default: 1)
+--list-all            List all available nodes (flag)
+```
+
+### v2ex_member.py
+
+```
+--cookie COOKIE       V2EX session cookie (optional)
+--username NAME       Member username (required)
+--include-topics      Also fetch member's recent topics (flag)
+```
+
+### v2ex_search.py
+
+```
+--query TEXT          Search query (required)
+--size N             Max results (default: 20)
+--sort FIELD         Sort by: "sumup" (relevance, default) or "created"
+--node NAME          Filter by node name (optional)
+--username NAME      Filter by author (optional)
+```
+
+### v2ex_notifications.py
+
+```
+--cookie COOKIE       V2EX session cookie (required)
+--page N              Page number (default: 1)
+```
+
+### v2ex_profile.py
+
+```
+--cookie COOKIE       V2EX session cookie (required)
+```
+
+### v2ex_create.py
+
+```
+--cookie COOKIE       V2EX session cookie (required)
+--node NAME           Target node name (required, e.g., "python")
+--title TEXT          Topic title (required)
+--content TEXT        Topic body content (required)
+--syntax SYNTAX       Content syntax: "default" or "markdown" (default: "default")
+```
+
+### v2ex_reply.py
+
+```
+--cookie COOKIE       V2EX session cookie (required)
+--topic-id ID         Topic ID to reply to (required)
+--content TEXT        Reply content (required)
+```
+
+### v2ex_thank.py
+
+```
+--cookie COOKIE       V2EX session cookie (required)
+--type TYPE           "topic" or "reply" (required)
+--id ID               Topic ID or Reply ID (required)
+```
+
+### v2ex_favorite.py
+
+```
+--cookie COOKIE       V2EX session cookie (required)
+--type TYPE           "topic" or "node" (required)
+--id ID               Topic ID or Node ID (required)
+--undo                Unfavorite instead (flag)
+```
+
+### v2ex_follow.py
+
+```
+--cookie COOKIE       V2EX session cookie (required)
+--action ACTION       "follow", "unfollow", "block", or "unblock" (required)
+--id ID               Member numeric ID (required)
+```
+
+### v2ex_daily.py
+
+```
+--cookie COOKIE       V2EX session cookie (required)
+```
+
+### v2ex_append.py
+
+```
+--cookie COOKIE       V2EX session cookie (required)
+--topic-id ID         Topic ID to append to (required)
+--content TEXT        Supplement content (required)
+```
+
+## Safety
+
+**Always show the user the content (title, body, node) and get explicit confirmation before calling `v2ex_create.py`, `v2ex_reply.py`, or `v2ex_append.py`.** These actions post publicly and cannot be easily undone.
+
+**`v2ex_thank.py` costs coins and is irreversible — confirm with the user first.**
+
+## Key Concepts
+
+**Nodes** — V2EX organizes topics into nodes (like subreddits). Examples: `python`, `apple`, `jobs`, `create`, `programmer`, `shanghai`. Use `v2ex_node.py --list-all` to see all.
+
+**Once token** — V2EX uses a CSRF token called `once` for all write operations. The client extracts it automatically from HTML pages before each mutation.
+
+**Topic IDs** — Numeric IDs (e.g., `12345`). Found in URLs like `v2ex.com/t/12345`. Get from hot/latest/search results, then use with `v2ex_topic.py`.
+
+**Member IDs vs usernames** — Profiles use usernames, but follow/block actions require numeric member IDs. `v2ex_member.py` returns both.
+
+**Daily check-in** — V2EX awards coins for daily sign-in. Use `v2ex_daily.py` to redeem.
+
+**Search** — Uses the SOV2EX third-party search engine (sov2ex.com) which indexes V2EX content for full-text search.
+
+## Error Handling
+
+| Error            | Cause                        | Fix                              |
+| ---------------- | ---------------------------- | -------------------------------- |
+| 403 Forbidden    | Session expired / no cookie  | Re-authenticate via `sig login`  |
+| 302 Redirect     | Not logged in                | Check cookie is valid            |
+| `ONCE_NOT_FOUND` | Failed to extract CSRF token | Session may be expired, re-login |
+| `RATE_LIMITED`   | Too many requests            | Wait and retry                   |
+| `SEARCH_ERROR`   | SOV2EX service unavailable   | Try again later                  |
+
+## Workflow Examples
+
+### Browse hot topics
+
+1. `sig run v2ex -- bash -c 'python3 scripts/v2ex_hot.py --cookie "$SIG_V2EX_COOKIE"'`
+
+### Read a specific topic and its replies
+
+1. `sig run v2ex -- bash -c 'python3 scripts/v2ex_topic.py --cookie "$SIG_V2EX_COOKIE" --id 12345 --page 1'`
+
+### Search for topics
+
+1. `python3 scripts/v2ex_search.py --query "Docker 部署" --size 10`
+
+### Create a new topic
+
+1. **Show title/body/node to user and get confirmation**
+2. `sig run v2ex -- bash -c 'python3 scripts/v2ex_create.py --cookie "$SIG_V2EX_COOKIE" --node python --title "Question about asyncio" --content "How do I..."'`
+
+### Reply to a topic
+
+1. Read the topic first: `sig run v2ex -- bash -c 'python3 scripts/v2ex_topic.py --cookie "$SIG_V2EX_COOKIE" --id 12345'`
+2. **Show reply to user and get confirmation**
+3. `sig run v2ex -- bash -c 'python3 scripts/v2ex_reply.py --cookie "$SIG_V2EX_COOKIE" --topic-id 12345 --content "I think you should..."'`
+
+### Check notifications
+
+1. `sig run v2ex -- bash -c 'python3 scripts/v2ex_notifications.py --cookie "$SIG_V2EX_COOKIE"'`
+
+### Daily check-in
+
+1. `sig run v2ex -- bash -c 'python3 scripts/v2ex_daily.py --cookie "$SIG_V2EX_COOKIE"'`
+
+### Follow a member
+
+1. Look up member: `sig run v2ex -- bash -c 'python3 scripts/v2ex_member.py --cookie "$SIG_V2EX_COOKIE" --username livid'`
+2. Follow: `sig run v2ex -- bash -c 'python3 scripts/v2ex_follow.py --cookie "$SIG_V2EX_COOKIE" --action follow --id 1'`

--- a/skills/v2ex/SKILL.md
+++ b/skills/v2ex/SKILL.md
@@ -204,6 +204,27 @@ All scripts are in this skill's `scripts/` directory. Run via Bash tool.
 
 **Search** — Uses the SOV2EX third-party search engine (sov2ex.com) which indexes V2EX content for full-text search.
 
+## Proxy
+
+V2EX is blocked by firewalls in some regions. If scripts fail with `Connection reset by peer` or timeout errors, set a proxy via environment variables:
+
+```bash
+# SOCKS5 proxy
+HTTPS_PROXY=socks5://localhost:1080 HTTP_PROXY=socks5://localhost:1080 python3 scripts/v2ex_hot.py
+
+# HTTP proxy
+HTTPS_PROXY=http://localhost:8080 HTTP_PROXY=http://localhost:8080 python3 scripts/v2ex_hot.py
+```
+
+For SOCKS5 proxies, `pysocks` must be installed: `pip install pysocks`
+
+With `sig run`, pass the proxy env vars through:
+
+```bash
+HTTPS_PROXY=socks5://localhost:1080 HTTP_PROXY=socks5://localhost:1080 \
+  sig run v2ex -- bash -c 'python3 scripts/v2ex_hot.py --cookie "$SIG_V2EX_COOKIE"'
+```
+
 ## Error Handling
 
 | Error            | Cause                        | Fix                              |

--- a/skills/v2ex/scripts/v2ex_append.py
+++ b/skills/v2ex/scripts/v2ex_append.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Append a supplement to an existing V2EX topic."""
+
+import argparse
+import json
+import sys
+
+import requests
+
+from v2ex_client import V2EX_BASE, V2exClient, V2exError
+
+
+def append_topic(cookie, topic_id, content):
+    client = V2exClient(cookie)
+    client.require_cookie()
+
+    append_url = V2EX_BASE + "/append/topic/" + str(topic_id)
+    once, _ = client.get_once(V2EX_BASE + "/t/" + str(topic_id))
+
+    data = {
+        "content": content,
+        "once": once,
+    }
+
+    resp = client.post(append_url, data=data)
+
+    if resp.status_code in (301, 302):
+        return {
+            "success": True,
+            "topic_id": int(topic_id),
+            "url": V2EX_BASE + "/t/" + str(topic_id),
+            "message": "Supplement appended successfully",
+        }
+
+    if resp.status_code == 200:
+        if "不是你创建的主题" in resp.text:
+            raise V2exError("NOT_OWNER", "You can only append to your own topics")
+
+    raise V2exError("APPEND_FAILED", f"Unexpected response (HTTP {resp.status_code})")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Append supplement to a V2EX topic")
+    parser.add_argument("--cookie", required=True, help="V2EX session cookie")
+    parser.add_argument("--topic-id", required=True, help="Topic ID to append to")
+    parser.add_argument("--content", required=True, help="Supplement content")
+    args = parser.parse_args()
+
+    try:
+        result = append_topic(args.cookie, args.topic_id, args.content)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except V2exError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/v2ex/scripts/v2ex_append.py
+++ b/skills/v2ex/scripts/v2ex_append.py
@@ -6,7 +6,6 @@ import json
 import sys
 
 import requests
-
 from v2ex_client import V2EX_BASE, V2exClient, V2exError
 
 

--- a/skills/v2ex/scripts/v2ex_client.py
+++ b/skills/v2ex/scripts/v2ex_client.py
@@ -1,0 +1,233 @@
+"""Shared V2EX client — cookie session, CSRF token extraction, HTML helpers."""
+
+import os
+import re
+import time
+
+import requests
+from bs4 import BeautifulSoup
+
+V2EX_BASE = "https://www.v2ex.com"
+V2EX_API_V1 = V2EX_BASE + "/api"
+V2EX_API_V2 = V2EX_BASE + "/api/v2"
+SOV2EX_API = "https://www.sov2ex.com/api/search"
+
+USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
+)
+
+TIMEOUT = 15
+
+
+class V2exError(Exception):
+    def __init__(self, code, message=""):
+        self.code = code
+        self.message = message
+        super().__init__(f"{code}: {message}")
+
+
+class V2exClient:
+    def __init__(self, cookie=""):
+        self.cookie = cookie
+        self._session = requests.Session()
+        self._session.headers["User-Agent"] = USER_AGENT
+        if cookie:
+            self._session.headers["Cookie"] = cookie
+        self._once = None
+
+    @classmethod
+    def create(cls):
+        cookie = os.environ.get("SIG_V2EX_COOKIE", "")
+        return cls(cookie)
+
+    def get(self, url, params=None, timeout=TIMEOUT):
+        resp = self._session.get(url, params=params, timeout=timeout)
+        if resp.status_code == 429:
+            retry_after = int(resp.headers.get("Retry-After", "5"))
+            time.sleep(retry_after)
+            resp = self._session.get(url, params=params, timeout=timeout)
+        resp.raise_for_status()
+        return resp
+
+    def post(self, url, data=None, timeout=TIMEOUT):
+        resp = self._session.post(url, data=data, timeout=timeout, allow_redirects=False)
+        if resp.status_code == 429:
+            retry_after = int(resp.headers.get("Retry-After", "5"))
+            time.sleep(retry_after)
+            resp = self._session.post(url, data=data, timeout=timeout, allow_redirects=False)
+        return resp
+
+    def api_v1(self, path, params=None):
+        resp = self.get(V2EX_API_V1 + path, params=params)
+        return resp.json()
+
+    def api_v2(self, path, params=None):
+        resp = self.get(V2EX_API_V2 + path, params=params)
+        data = resp.json()
+        if not data.get("success"):
+            raise V2exError("API_ERROR", data.get("message", "Unknown error"))
+        return data.get("result")
+
+    def get_once(self, page_url=None):
+        url = page_url or V2EX_BASE + "/mission/daily"
+        resp = self.get(url)
+        html = resp.text
+        match = re.search(r'name="once"\s+value="(\d+)"', html)
+        if not match:
+            match = re.search(r"once=(\d+)", html)
+        if not match:
+            match = re.search(r"'once':\s*'(\d+)'", html)
+        if not match:
+            raise V2exError("ONCE_NOT_FOUND", "Failed to extract CSRF once token — session may be expired")
+        self._once = match.group(1)
+        return self._once, html
+
+    def require_cookie(self):
+        if not self.cookie:
+            raise V2exError("AUTH_REQUIRED", "This operation requires a V2EX session cookie. Run: sig login https://www.v2ex.com/")
+
+
+def get_v2ex_cookie():
+    return os.environ.get("SIG_V2EX_COOKIE", "")
+
+
+def parse_topic_item(t):
+    return {
+        "id": t.get("id"),
+        "title": t.get("title", ""),
+        "url": t.get("url", ""),
+        "content_preview": (t.get("content", "") or "")[:200],
+        "replies": t.get("replies", 0),
+        "created": t.get("created"),
+        "last_modified": t.get("last_modified"),
+        "last_touched": t.get("last_touched"),
+        "node": _parse_node_brief(t.get("node")) if t.get("node") else None,
+        "member": _parse_member_brief(t.get("member")) if t.get("member") else None,
+    }
+
+
+def parse_reply_item(r):
+    return {
+        "id": r.get("id"),
+        "content": r.get("content", ""),
+        "content_rendered": r.get("content_rendered", ""),
+        "created": r.get("created"),
+        "member": _parse_member_brief(r.get("member")) if r.get("member") else None,
+    }
+
+
+def _parse_node_brief(n):
+    if not n:
+        return None
+    return {
+        "id": n.get("id"),
+        "name": n.get("name", ""),
+        "title": n.get("title", ""),
+    }
+
+
+def _parse_member_brief(m):
+    if not m:
+        return None
+    return {
+        "id": m.get("id"),
+        "username": m.get("username", ""),
+        "avatar": m.get("avatar_normal", m.get("avatar_mini", "")),
+    }
+
+
+def parse_topic_page(html):
+    soup = BeautifulSoup(html, "html.parser")
+    topic = {}
+
+    header = soup.select_one("div.header h1")
+    if header:
+        topic["title"] = header.get_text(strip=True)
+
+    content_div = soup.select_one("div.topic_content")
+    if content_div:
+        topic["content_rendered"] = str(content_div)
+        topic["content"] = content_div.get_text(separator="\n", strip=True)
+
+    meta = soup.select_one("div.header small.gray")
+    if meta:
+        topic["meta"] = meta.get_text(strip=True)
+
+    supplements = []
+    for s in soup.select("div.subtle"):
+        text_div = s.select_one("div.topic_content")
+        if text_div:
+            supplements.append(text_div.get_text(separator="\n", strip=True))
+    if supplements:
+        topic["supplements"] = supplements
+
+    replies = []
+    for cell in soup.select("div.cell[id^='r_']"):
+        reply = {}
+        reply_id_str = cell.get("id", "").replace("r_", "")
+        if reply_id_str.isdigit():
+            reply["id"] = int(reply_id_str)
+        username_el = cell.select_one("strong a.dark")
+        if username_el:
+            reply["member"] = username_el.get_text(strip=True)
+        content_el = cell.select_one("div.reply_content")
+        if content_el:
+            reply["content_rendered"] = str(content_el)
+            reply["content"] = content_el.get_text(separator="\n", strip=True)
+        no_el = cell.select_one("span.no")
+        if no_el:
+            reply["floor"] = no_el.get_text(strip=True)
+        ago_el = cell.select_one("span.ago")
+        if ago_el:
+            reply["time"] = ago_el.get_text(strip=True)
+        thank_el = cell.select_one("span.small.fade")
+        if thank_el:
+            text = thank_el.get_text(strip=True)
+            if text:
+                reply["thanks"] = text
+        replies.append(reply)
+
+    return topic, replies
+
+
+def parse_notifications_page(html):
+    soup = BeautifulSoup(html, "html.parser")
+    notifications = []
+    for cell in soup.select("div.cell[id^='n_']"):
+        n = {}
+        nid = cell.get("id", "").replace("n_", "")
+        if nid.isdigit():
+            n["id"] = int(nid)
+        payload = cell.select_one("span.payload")
+        if payload:
+            n["text"] = payload.get_text(separator=" ", strip=True)
+        link = cell.select_one("a[href^='/member/']")
+        if link:
+            n["from_member"] = link.get_text(strip=True)
+        topic_link = cell.select_one("a[href^='/t/']")
+        if topic_link:
+            n["topic_title"] = topic_link.get_text(strip=True)
+            href = topic_link.get("href", "")
+            tid = re.search(r"/t/(\d+)", href)
+            if tid:
+                n["topic_id"] = int(tid.group(1))
+        ago = cell.select_one("span.snow")
+        if ago:
+            n["time"] = ago.get_text(strip=True)
+        notifications.append(n)
+    return notifications
+
+
+def parse_balance_page(html):
+    soup = BeautifulSoup(html, "html.parser")
+    balance = {}
+    balance_area = soup.select_one("div.balance_area")
+    if balance_area:
+        text = balance_area.get_text(strip=True)
+        nums = re.findall(r"(\d+)", text)
+        if len(nums) >= 3:
+            balance["gold"] = int(nums[0])
+            balance["silver"] = int(nums[1])
+            balance["bronze"] = int(nums[2])
+    return balance

--- a/skills/v2ex/scripts/v2ex_create.py
+++ b/skills/v2ex/scripts/v2ex_create.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Create a new topic on V2EX."""
+
+import argparse
+import json
+import re
+import sys
+
+import requests
+
+from v2ex_client import V2EX_BASE, V2exClient, V2exError
+
+
+def create_topic(cookie, node, title, content, syntax="default"):
+    client = V2exClient(cookie)
+    client.require_cookie()
+
+    once, _ = client.get_once(V2EX_BASE + "/new/" + node)
+
+    data = {
+        "title": title,
+        "content": content,
+        "node_name": node,
+        "syntax": syntax,
+        "once": once,
+    }
+
+    resp = client.post(V2EX_BASE + "/write", data=data)
+
+    if resp.status_code in (301, 302):
+        location = resp.headers.get("Location", "")
+        match = re.search(r"/t/(\d+)", location)
+        if match:
+            topic_id = match.group(1)
+            return {
+                "success": True,
+                "topic_id": int(topic_id),
+                "url": V2EX_BASE + "/t/" + topic_id,
+                "message": "Topic created successfully",
+            }
+
+    if resp.status_code == 200:
+        if "你上一次发布主题是在" in resp.text:
+            raise V2exError("RATE_LIMITED", "Too soon since last topic — V2EX enforces a cooldown between posts")
+        if "请输入主题标题" in resp.text:
+            raise V2exError("VALIDATION_ERROR", "Title is required")
+
+    raise V2exError("CREATE_FAILED", f"Unexpected response (HTTP {resp.status_code})")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create a new V2EX topic")
+    parser.add_argument("--cookie", required=True, help="V2EX session cookie")
+    parser.add_argument("--node", required=True, help="Target node name (e.g., python)")
+    parser.add_argument("--title", required=True, help="Topic title")
+    parser.add_argument("--content", required=True, help="Topic body content")
+    parser.add_argument("--syntax", default="default", choices=["default", "markdown"], help="Content syntax")
+    args = parser.parse_args()
+
+    try:
+        result = create_topic(args.cookie, args.node, args.title, args.content, args.syntax)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except V2exError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/v2ex/scripts/v2ex_create.py
+++ b/skills/v2ex/scripts/v2ex_create.py
@@ -7,7 +7,6 @@ import re
 import sys
 
 import requests
-
 from v2ex_client import V2EX_BASE, V2exClient, V2exError
 
 

--- a/skills/v2ex/scripts/v2ex_daily.py
+++ b/skills/v2ex/scripts/v2ex_daily.py
@@ -7,7 +7,6 @@ import re
 import sys
 
 import requests
-
 from v2ex_client import V2EX_BASE, V2exClient, V2exError
 
 

--- a/skills/v2ex/scripts/v2ex_daily.py
+++ b/skills/v2ex/scripts/v2ex_daily.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""V2EX daily sign-in to redeem coins."""
+
+import argparse
+import json
+import re
+import sys
+
+import requests
+
+from v2ex_client import V2EX_BASE, V2exClient, V2exError
+
+
+def daily_checkin(cookie):
+    client = V2exClient(cookie)
+    client.require_cookie()
+
+    resp = client.get(V2EX_BASE + "/mission/daily")
+    html = resp.text
+
+    if "每日登录奖励已领取" in html:
+        return {
+            "success": True,
+            "already_claimed": True,
+            "message": "Daily reward already claimed today",
+        }
+
+    match = re.search(r"/mission/daily/redeem\?once=(\d+)", html)
+    if not match:
+        once_match = re.search(r'name="once"\s+value="(\d+)"', html)
+        if not once_match:
+            raise V2exError("ONCE_NOT_FOUND", "Cannot find redeem link — session may be expired")
+        once = once_match.group(1)
+    else:
+        once = match.group(1)
+
+    redeem_url = V2EX_BASE + "/mission/daily/redeem?once=" + once
+    resp = client.get(redeem_url)
+
+    if "已成功领取" in resp.text or "每日登录奖励已领取" in resp.text:
+        return {
+            "success": True,
+            "already_claimed": False,
+            "message": "Daily reward redeemed successfully",
+        }
+
+    return {
+        "success": True,
+        "already_claimed": False,
+        "message": "Daily check-in completed",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="V2EX daily sign-in")
+    parser.add_argument("--cookie", required=True, help="V2EX session cookie")
+    args = parser.parse_args()
+
+    try:
+        result = daily_checkin(args.cookie)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except V2exError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/v2ex/scripts/v2ex_favorite.py
+++ b/skills/v2ex/scripts/v2ex_favorite.py
@@ -6,7 +6,6 @@ import json
 import sys
 
 import requests
-
 from v2ex_client import V2EX_BASE, V2exClient, V2exError
 
 
@@ -25,7 +24,7 @@ def favorite(cookie, target_type, target_id, undo=False):
     else:
         raise V2exError("INVALID_TYPE", "Type must be 'topic' or 'node'")
 
-    resp = client.get(url)
+    client.get(url)
 
     return {
         "success": True,

--- a/skills/v2ex/scripts/v2ex_favorite.py
+++ b/skills/v2ex/scripts/v2ex_favorite.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Favorite or unfavorite a V2EX topic or node."""
+
+import argparse
+import json
+import sys
+
+import requests
+
+from v2ex_client import V2EX_BASE, V2exClient, V2exError
+
+
+def favorite(cookie, target_type, target_id, undo=False):
+    client = V2exClient(cookie)
+    client.require_cookie()
+
+    once, _ = client.get_once()
+
+    action = "unfavorite" if undo else "favorite"
+
+    if target_type == "topic":
+        url = V2EX_BASE + "/" + action + "/topic/" + str(target_id) + "?once=" + once
+    elif target_type == "node":
+        url = V2EX_BASE + "/" + action + "/node/" + str(target_id) + "?once=" + once
+    else:
+        raise V2exError("INVALID_TYPE", "Type must be 'topic' or 'node'")
+
+    resp = client.get(url)
+
+    return {
+        "success": True,
+        "action": action,
+        "type": target_type,
+        "id": int(target_id),
+        "message": f"{'Unfavorited' if undo else 'Favorited'} {target_type} successfully",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Favorite/unfavorite a V2EX topic or node")
+    parser.add_argument("--cookie", required=True, help="V2EX session cookie")
+    parser.add_argument("--type", required=True, choices=["topic", "node"], help="Target type")
+    parser.add_argument("--id", required=True, help="Topic ID or Node ID")
+    parser.add_argument("--undo", action="store_true", help="Unfavorite instead")
+    args = parser.parse_args()
+
+    try:
+        result = favorite(args.cookie, args.type, args.id, args.undo)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except V2exError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/v2ex/scripts/v2ex_follow.py
+++ b/skills/v2ex/scripts/v2ex_follow.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Follow, unfollow, block, or unblock a V2EX member."""
+
+import argparse
+import json
+import sys
+
+import requests
+
+from v2ex_client import V2EX_BASE, V2exClient, V2exError
+
+VALID_ACTIONS = ("follow", "unfollow", "block", "unblock")
+
+
+def follow_action(cookie, action, member_id):
+    client = V2exClient(cookie)
+    client.require_cookie()
+
+    if action not in VALID_ACTIONS:
+        raise V2exError("INVALID_ACTION", f"Action must be one of: {', '.join(VALID_ACTIONS)}")
+
+    once, _ = client.get_once()
+
+    url = V2EX_BASE + "/" + action + "/" + str(member_id) + "?once=" + once
+    resp = client.get(url)
+
+    return {
+        "success": True,
+        "action": action,
+        "member_id": int(member_id),
+        "message": f"Successfully {action}ed member",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Follow/unfollow/block/unblock a V2EX member")
+    parser.add_argument("--cookie", required=True, help="V2EX session cookie")
+    parser.add_argument("--action", required=True, choices=VALID_ACTIONS, help="Action to perform")
+    parser.add_argument("--id", required=True, help="Member numeric ID")
+    args = parser.parse_args()
+
+    try:
+        result = follow_action(args.cookie, args.action, args.id)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except V2exError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/v2ex/scripts/v2ex_follow.py
+++ b/skills/v2ex/scripts/v2ex_follow.py
@@ -6,7 +6,6 @@ import json
 import sys
 
 import requests
-
 from v2ex_client import V2EX_BASE, V2exClient, V2exError
 
 VALID_ACTIONS = ("follow", "unfollow", "block", "unblock")
@@ -22,7 +21,7 @@ def follow_action(cookie, action, member_id):
     once, _ = client.get_once()
 
     url = V2EX_BASE + "/" + action + "/" + str(member_id) + "?once=" + once
-    resp = client.get(url)
+    client.get(url)
 
     return {
         "success": True,

--- a/skills/v2ex/scripts/v2ex_hot.py
+++ b/skills/v2ex/scripts/v2ex_hot.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Get hot topics from V2EX."""
+
+import argparse
+import json
+import sys
+
+import requests
+
+from v2ex_client import V2exClient, parse_topic_item
+
+
+def get_hot(cookie=""):
+    client = V2exClient(cookie)
+    topics = client.api_v1("/topics/hot.json")
+    return {
+        "count": len(topics),
+        "topics": [parse_topic_item(t) for t in topics],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get V2EX hot topics")
+    parser.add_argument("--cookie", default="", help="V2EX session cookie (optional)")
+    args = parser.parse_args()
+
+    try:
+        result = get_hot(args.cookie)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/v2ex/scripts/v2ex_hot.py
+++ b/skills/v2ex/scripts/v2ex_hot.py
@@ -6,7 +6,6 @@ import json
 import sys
 
 import requests
-
 from v2ex_client import V2exClient, parse_topic_item
 
 

--- a/skills/v2ex/scripts/v2ex_latest.py
+++ b/skills/v2ex/scripts/v2ex_latest.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Get latest topics from V2EX."""
+
+import argparse
+import json
+import sys
+
+import requests
+
+from v2ex_client import V2exClient, parse_topic_item
+
+
+def get_latest(cookie=""):
+    client = V2exClient(cookie)
+    topics = client.api_v1("/topics/latest.json")
+    return {
+        "count": len(topics),
+        "topics": [parse_topic_item(t) for t in topics],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get V2EX latest topics")
+    parser.add_argument("--cookie", default="", help="V2EX session cookie (optional)")
+    args = parser.parse_args()
+
+    try:
+        result = get_latest(args.cookie)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/v2ex/scripts/v2ex_latest.py
+++ b/skills/v2ex/scripts/v2ex_latest.py
@@ -6,7 +6,6 @@ import json
 import sys
 
 import requests
-
 from v2ex_client import V2exClient, parse_topic_item
 
 

--- a/skills/v2ex/scripts/v2ex_member.py
+++ b/skills/v2ex/scripts/v2ex_member.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Get V2EX member profile and topics."""
+
+import argparse
+import json
+import sys
+
+import requests
+
+from v2ex_client import V2exClient, parse_topic_item
+
+
+def get_member(username, include_topics=False, cookie=""):
+    client = V2exClient(cookie)
+    member = client.api_v1("/members/show.json", params={"username": username})
+
+    result = {
+        "member": {
+            "id": member.get("id"),
+            "username": member.get("username", ""),
+            "url": member.get("url", ""),
+            "website": member.get("website"),
+            "twitter": member.get("twitter"),
+            "github": member.get("github"),
+            "location": member.get("location"),
+            "tagline": member.get("tagline"),
+            "bio": member.get("bio"),
+            "avatar": member.get("avatar_large", member.get("avatar_normal", "")),
+            "created": member.get("created"),
+        },
+    }
+
+    if include_topics:
+        topics_data = client.api_v1("/topics/show.json", params={"username": username})
+        result["topics"] = {"count": len(topics_data), "items": [parse_topic_item(t) for t in topics_data]}
+
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get V2EX member profile")
+    parser.add_argument("--cookie", default="", help="V2EX session cookie (optional)")
+    parser.add_argument("--username", required=True, help="Member username")
+    parser.add_argument("--include-topics", action="store_true", help="Also fetch member's recent topics")
+    args = parser.parse_args()
+
+    try:
+        result = get_member(args.username, args.include_topics, args.cookie)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/v2ex/scripts/v2ex_member.py
+++ b/skills/v2ex/scripts/v2ex_member.py
@@ -6,7 +6,6 @@ import json
 import sys
 
 import requests
-
 from v2ex_client import V2exClient, parse_topic_item
 
 

--- a/skills/v2ex/scripts/v2ex_node.py
+++ b/skills/v2ex/scripts/v2ex_node.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Get V2EX node info and topics, or list all nodes."""
+
+import argparse
+import json
+import sys
+
+import requests
+
+from v2ex_client import V2exClient, parse_topic_item
+
+
+def list_all_nodes(cookie=""):
+    client = V2exClient(cookie)
+    nodes = client.api_v1("/nodes/all.json")
+    return {
+        "count": len(nodes),
+        "nodes": [
+            {
+                "id": n.get("id"),
+                "name": n.get("name", ""),
+                "title": n.get("title", ""),
+                "topics": n.get("topics", 0),
+                "stars": n.get("stars", 0),
+            }
+            for n in nodes
+        ],
+    }
+
+
+def get_node(name, page=1, cookie=""):
+    client = V2exClient(cookie)
+    node = client.api_v1("/nodes/show.json", params={"name": name})
+
+    topics_data = client.api_v1("/topics/show.json", params={"node_name": name})
+    topics = [parse_topic_item(t) for t in topics_data]
+
+    return {
+        "node": {
+            "id": node.get("id"),
+            "name": node.get("name", ""),
+            "title": node.get("title", ""),
+            "title_alternative": node.get("title_alternative", ""),
+            "header": node.get("header", ""),
+            "topics_count": node.get("topics", 0),
+            "stars": node.get("stars", 0),
+            "parent_node_name": node.get("parent_node_name", ""),
+        },
+        "topics": {"count": len(topics), "items": topics},
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get V2EX node info and topics")
+    parser.add_argument("--cookie", default="", help="V2EX session cookie (optional)")
+    parser.add_argument("--name", help="Node name (e.g., python, apple)")
+    parser.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
+    parser.add_argument("--list-all", action="store_true", help="List all available nodes")
+    args = parser.parse_args()
+
+    if not args.list_all and not args.name:
+        json.dump({"error": "MISSING_ARGS", "message": "Provide --name or --list-all"}, sys.stdout, indent=2)
+        return
+
+    try:
+        if args.list_all:
+            result = list_all_nodes(args.cookie)
+        else:
+            result = get_node(args.name, args.page, args.cookie)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/v2ex/scripts/v2ex_node.py
+++ b/skills/v2ex/scripts/v2ex_node.py
@@ -6,7 +6,6 @@ import json
 import sys
 
 import requests
-
 from v2ex_client import V2exClient, parse_topic_item
 
 

--- a/skills/v2ex/scripts/v2ex_notifications.py
+++ b/skills/v2ex/scripts/v2ex_notifications.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Get V2EX notifications."""
+
+import argparse
+import json
+import sys
+
+import requests
+
+from v2ex_client import V2EX_BASE, V2exClient, V2exError, parse_notifications_page
+
+
+def get_notifications(cookie, page=1):
+    client = V2exClient(cookie)
+    client.require_cookie()
+
+    url = V2EX_BASE + "/notifications"
+    if page > 1:
+        url += "?p=" + str(page)
+
+    resp = client.get(url)
+    notifications = parse_notifications_page(resp.text)
+
+    return {
+        "page": page,
+        "count": len(notifications),
+        "notifications": notifications,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get V2EX notifications")
+    parser.add_argument("--cookie", required=True, help="V2EX session cookie")
+    parser.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
+    args = parser.parse_args()
+
+    try:
+        result = get_notifications(args.cookie, args.page)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except V2exError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/v2ex/scripts/v2ex_notifications.py
+++ b/skills/v2ex/scripts/v2ex_notifications.py
@@ -6,7 +6,6 @@ import json
 import sys
 
 import requests
-
 from v2ex_client import V2EX_BASE, V2exClient, V2exError, parse_notifications_page
 
 

--- a/skills/v2ex/scripts/v2ex_profile.py
+++ b/skills/v2ex/scripts/v2ex_profile.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Get authenticated V2EX user profile and balance."""
+
+import argparse
+import json
+import re
+import sys
+
+import requests
+from bs4 import BeautifulSoup
+
+from v2ex_client import V2EX_BASE, V2exClient, V2exError, parse_balance_page
+
+
+def get_profile(cookie):
+    client = V2exClient(cookie)
+    client.require_cookie()
+
+    resp = client.get(V2EX_BASE + "/settings")
+    soup = BeautifulSoup(resp.text, "html.parser")
+
+    profile = {}
+    username_el = soup.select_one("a[href^='/member/'].top")
+    if username_el:
+        profile["username"] = username_el.get_text(strip=True)
+
+    avatar_el = soup.select_one("img.avatar")
+    if avatar_el:
+        profile["avatar"] = avatar_el.get("src", "")
+
+    for row in soup.select("table tr"):
+        cells = row.select("td")
+        if len(cells) >= 2:
+            label = cells[0].get_text(strip=True).lower()
+            value_input = cells[1].select_one("input")
+            if value_input:
+                val = value_input.get("value", "")
+                if "website" in label:
+                    profile["website"] = val
+                elif "twitter" in label:
+                    profile["twitter"] = val
+                elif "github" in label:
+                    profile["github"] = val
+                elif "location" in label:
+                    profile["location"] = val
+                elif "tagline" in label:
+                    profile["tagline"] = val
+
+    balance_resp = client.get(V2EX_BASE + "/balance")
+    profile["balance"] = parse_balance_page(balance_resp.text)
+
+    return {"profile": profile}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get V2EX user profile and balance")
+    parser.add_argument("--cookie", required=True, help="V2EX session cookie")
+    args = parser.parse_args()
+
+    try:
+        result = get_profile(args.cookie)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except V2exError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/v2ex/scripts/v2ex_profile.py
+++ b/skills/v2ex/scripts/v2ex_profile.py
@@ -3,12 +3,10 @@
 
 import argparse
 import json
-import re
 import sys
 
 import requests
 from bs4 import BeautifulSoup
-
 from v2ex_client import V2EX_BASE, V2exClient, V2exError, parse_balance_page
 
 

--- a/skills/v2ex/scripts/v2ex_reply.py
+++ b/skills/v2ex/scripts/v2ex_reply.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Reply to a V2EX topic."""
+
+import argparse
+import json
+import sys
+
+import requests
+
+from v2ex_client import V2EX_BASE, V2exClient, V2exError
+
+
+def reply_topic(cookie, topic_id, content):
+    client = V2exClient(cookie)
+    client.require_cookie()
+
+    topic_url = V2EX_BASE + "/t/" + str(topic_id)
+    once, _ = client.get_once(topic_url)
+
+    data = {
+        "content": content,
+        "once": once,
+    }
+
+    resp = client.post(topic_url, data=data)
+
+    if resp.status_code in (301, 302):
+        return {
+            "success": True,
+            "topic_id": int(topic_id),
+            "url": topic_url,
+            "message": "Reply posted successfully",
+        }
+
+    if resp.status_code == 200:
+        if "你上一次回复是在" in resp.text:
+            raise V2exError("RATE_LIMITED", "Too soon since last reply — V2EX enforces a cooldown")
+
+    raise V2exError("REPLY_FAILED", f"Unexpected response (HTTP {resp.status_code})")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Reply to a V2EX topic")
+    parser.add_argument("--cookie", required=True, help="V2EX session cookie")
+    parser.add_argument("--topic-id", required=True, help="Topic ID to reply to")
+    parser.add_argument("--content", required=True, help="Reply content")
+    args = parser.parse_args()
+
+    try:
+        result = reply_topic(args.cookie, args.topic_id, args.content)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except V2exError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/v2ex/scripts/v2ex_reply.py
+++ b/skills/v2ex/scripts/v2ex_reply.py
@@ -6,7 +6,6 @@ import json
 import sys
 
 import requests
-
 from v2ex_client import V2EX_BASE, V2exClient, V2exError
 
 

--- a/skills/v2ex/scripts/v2ex_search.py
+++ b/skills/v2ex/scripts/v2ex_search.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Search V2EX topics via SOV2EX full-text search."""
+
+import argparse
+import json
+import sys
+
+import requests
+
+from v2ex_client import SOV2EX_API
+
+
+def search(query, size=20, sort="sumup", node=None, username=None):
+    params = {"q": query, "size": min(size, 50), "sort": sort, "order": 0}
+    if node:
+        params["node"] = node
+    if username:
+        params["username"] = username
+
+    resp = requests.get(SOV2EX_API, params=params, timeout=15)
+    resp.raise_for_status()
+    data = resp.json()
+
+    hits = []
+    for h in data.get("hits", []):
+        source = h.get("_source", {})
+        hits.append(
+            {
+                "id": source.get("id"),
+                "title": source.get("title", ""),
+                "content_preview": (source.get("content", "") or "")[:200],
+                "node": source.get("node"),
+                "member": source.get("member"),
+                "replies": source.get("replies", 0),
+                "created": source.get("created"),
+            }
+        )
+
+    return {
+        "total": data.get("total", 0),
+        "took": data.get("took", 0),
+        "count": len(hits),
+        "hits": hits,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Search V2EX topics")
+    parser.add_argument("--query", required=True, help="Search query")
+    parser.add_argument("--size", type=int, default=20, help="Max results (default: 20)")
+    parser.add_argument("--sort", default="sumup", choices=["sumup", "created"], help="Sort by (default: sumup)")
+    parser.add_argument("--node", help="Filter by node name")
+    parser.add_argument("--username", help="Filter by author")
+    args = parser.parse_args()
+
+    try:
+        result = search(args.query, args.size, args.sort, args.node, args.username)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "SEARCH_ERROR", "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/v2ex/scripts/v2ex_search.py
+++ b/skills/v2ex/scripts/v2ex_search.py
@@ -6,7 +6,6 @@ import json
 import sys
 
 import requests
-
 from v2ex_client import SOV2EX_API
 
 

--- a/skills/v2ex/scripts/v2ex_thank.py
+++ b/skills/v2ex/scripts/v2ex_thank.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Thank a V2EX topic or reply (costs coins, irreversible)."""
+
+import argparse
+import json
+import sys
+
+import requests
+
+from v2ex_client import V2EX_BASE, V2exClient, V2exError
+
+
+def thank(cookie, target_type, target_id):
+    client = V2exClient(cookie)
+    client.require_cookie()
+
+    once, _ = client.get_once()
+
+    if target_type == "topic":
+        url = V2EX_BASE + "/thank/topic/" + str(target_id) + "?once=" + once
+    elif target_type == "reply":
+        url = V2EX_BASE + "/thank/reply/" + str(target_id) + "?once=" + once
+    else:
+        raise V2exError("INVALID_TYPE", "Type must be 'topic' or 'reply'")
+
+    resp = client.post(url)
+
+    if resp.status_code == 200:
+        try:
+            data = resp.json()
+            if data.get("success"):
+                return {
+                    "success": True,
+                    "type": target_type,
+                    "id": int(target_id),
+                    "message": f"Thanked {target_type} successfully",
+                }
+        except ValueError:
+            pass
+
+    if resp.status_code in (200, 302):
+        return {
+            "success": True,
+            "type": target_type,
+            "id": int(target_id),
+            "message": f"Thanked {target_type} (or already thanked)",
+        }
+
+    raise V2exError("THANK_FAILED", f"Unexpected response (HTTP {resp.status_code})")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Thank a V2EX topic or reply")
+    parser.add_argument("--cookie", required=True, help="V2EX session cookie")
+    parser.add_argument("--type", required=True, choices=["topic", "reply"], help="Target type")
+    parser.add_argument("--id", required=True, help="Topic ID or Reply ID")
+    args = parser.parse_args()
+
+    try:
+        result = thank(args.cookie, args.type, args.id)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except V2exError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/v2ex/scripts/v2ex_thank.py
+++ b/skills/v2ex/scripts/v2ex_thank.py
@@ -6,7 +6,6 @@ import json
 import sys
 
 import requests
-
 from v2ex_client import V2EX_BASE, V2exClient, V2exError
 
 

--- a/skills/v2ex/scripts/v2ex_topic.py
+++ b/skills/v2ex/scripts/v2ex_topic.py
@@ -6,7 +6,6 @@ import json
 import sys
 
 import requests
-
 from v2ex_client import V2EX_BASE, V2exClient, parse_reply_item, parse_topic_item, parse_topic_page
 
 

--- a/skills/v2ex/scripts/v2ex_topic.py
+++ b/skills/v2ex/scripts/v2ex_topic.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Get topic detail and replies from V2EX."""
+
+import argparse
+import json
+import sys
+
+import requests
+
+from v2ex_client import V2EX_BASE, V2exClient, parse_reply_item, parse_topic_item, parse_topic_page
+
+
+def get_topic(topic_id, page=1, cookie=""):
+    client = V2exClient(cookie)
+
+    if cookie:
+        url = V2EX_BASE + "/t/" + str(topic_id)
+        if page > 1:
+            url += "?p=" + str(page)
+        resp = client.get(url)
+        topic, replies = parse_topic_page(resp.text)
+        topic["id"] = int(topic_id)
+        topic["url"] = V2EX_BASE + "/t/" + str(topic_id)
+        return {
+            "topic": topic,
+            "replies": {"page": page, "count": len(replies), "items": replies},
+        }
+
+    topic_data = client.api_v1("/topics/show.json", params={"id": topic_id})
+    topic = parse_topic_item(topic_data[0]) if topic_data else {}
+
+    replies_data = client.api_v1("/replies/show.json", params={"topic_id": topic_id, "page": page, "page_size": 100})
+    replies = [parse_reply_item(r) for r in replies_data]
+
+    return {
+        "topic": topic,
+        "replies": {"page": page, "count": len(replies), "items": replies},
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get V2EX topic detail and replies")
+    parser.add_argument("--cookie", default="", help="V2EX session cookie (optional)")
+    parser.add_argument("--id", required=True, help="Topic ID")
+    parser.add_argument("--page", type=int, default=1, help="Reply page (default: 1)")
+    args = parser.parse_args()
+
+    try:
+        result = get_topic(args.id, args.page, args.cookie)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/v2ex/tests/test_append.py
+++ b/skills/v2ex/tests/test_append.py
@@ -1,0 +1,58 @@
+"""Tests for v2ex/scripts/v2ex_append.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("v2ex", "v2ex_append")
+
+ONCE_PAGE = '<html><body><input type="hidden" name="once" value="44444"></body></html>'
+
+
+class TestAppendTopic:
+    @responses.activate
+    def test_append_success(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/t/12345"),
+            body=ONCE_PAGE,
+            status=200,
+        )
+        responses.post(
+            url=re.compile(r"https://www\.v2ex\.com/append/topic/12345"),
+            status=302,
+            headers={"Location": "/t/12345"},
+        )
+        result = mod.append_topic("fakecookie", "12345", "Update: found the solution!")
+        assert result["success"] is True
+        assert result["topic_id"] == 12345
+
+    @responses.activate
+    def test_append_not_owner(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/t/12345"),
+            body=ONCE_PAGE,
+            status=200,
+        )
+        responses.post(
+            url=re.compile(r"https://www\.v2ex\.com/append/topic/12345"),
+            body="<html>不是你创建的主题</html>",
+            status=200,
+        )
+        from v2ex_client import V2exError
+
+        try:
+            mod.append_topic("fakecookie", "12345", "Update")
+            assert False, "Should have raised"
+        except V2exError as e:
+            assert e.code == "NOT_OWNER"
+
+    def test_requires_cookie(self):
+        from v2ex_client import V2exError
+
+        try:
+            mod.append_topic("", "12345", "Update")
+            assert False, "Should have raised"
+        except V2exError as e:
+            assert e.code == "AUTH_REQUIRED"

--- a/skills/v2ex/tests/test_create.py
+++ b/skills/v2ex/tests/test_create.py
@@ -1,0 +1,59 @@
+"""Tests for v2ex/scripts/v2ex_create.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("v2ex", "v2ex_create")
+
+ONCE_PAGE = '<html><body><input type="hidden" name="once" value="99999"></body></html>'
+
+
+class TestCreateTopic:
+    @responses.activate
+    def test_create_success(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/new/python"),
+            body=ONCE_PAGE,
+            status=200,
+        )
+        responses.post(
+            url=re.compile(r"https://www\.v2ex\.com/write"),
+            status=302,
+            headers={"Location": "/t/123456"},
+        )
+        result = mod.create_topic("fakecookie", "python", "Test Title", "Test content")
+        assert result["success"] is True
+        assert result["topic_id"] == 123456
+        assert "/t/123456" in result["url"]
+
+    @responses.activate
+    def test_create_rate_limited(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/new/python"),
+            body=ONCE_PAGE,
+            status=200,
+        )
+        responses.post(
+            url=re.compile(r"https://www\.v2ex\.com/write"),
+            body="<html>你上一次发布主题是在 5 分钟前</html>",
+            status=200,
+        )
+        from v2ex_client import V2exError
+
+        try:
+            mod.create_topic("fakecookie", "python", "Title", "Content")
+            assert False, "Should have raised"
+        except V2exError as e:
+            assert e.code == "RATE_LIMITED"
+
+    def test_requires_cookie(self):
+        from v2ex_client import V2exError
+
+        try:
+            mod.create_topic("", "python", "Title", "Content")
+            assert False, "Should have raised"
+        except V2exError as e:
+            assert e.code == "AUTH_REQUIRED"

--- a/skills/v2ex/tests/test_daily.py
+++ b/skills/v2ex/tests/test_daily.py
@@ -1,0 +1,47 @@
+"""Tests for v2ex/scripts/v2ex_daily.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("v2ex", "v2ex_daily")
+
+
+class TestDailyCheckin:
+    @responses.activate
+    def test_already_claimed(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/mission/daily"),
+            body="<html><body>每日登录奖励已领取</body></html>",
+            status=200,
+        )
+        result = mod.daily_checkin("fakecookie")
+        assert result["success"] is True
+        assert result["already_claimed"] is True
+
+    @responses.activate
+    def test_redeem_success(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/mission/daily$"),
+            body='<html><body><a href="/mission/daily/redeem?once=12345">领取</a></body></html>',
+            status=200,
+        )
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/mission/daily/redeem"),
+            body="<html><body>已成功领取每日登录奖励</body></html>",
+            status=200,
+        )
+        result = mod.daily_checkin("fakecookie")
+        assert result["success"] is True
+        assert result["already_claimed"] is False
+
+    def test_requires_cookie(self):
+        from v2ex_client import V2exError
+
+        try:
+            mod.daily_checkin("")
+            assert False, "Should have raised"
+        except V2exError as e:
+            assert e.code == "AUTH_REQUIRED"

--- a/skills/v2ex/tests/test_favorite.py
+++ b/skills/v2ex/tests/test_favorite.py
@@ -1,0 +1,52 @@
+"""Tests for v2ex/scripts/v2ex_favorite.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("v2ex", "v2ex_favorite")
+
+ONCE_PAGE = '<html><body><input type="hidden" name="once" value="66666"></body></html>'
+
+
+class TestFavorite:
+    @responses.activate
+    def test_favorite_topic(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/mission/daily"),
+            body=ONCE_PAGE,
+            status=200,
+        )
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/favorite/topic/12345"),
+            status=200,
+        )
+        result = mod.favorite("fakecookie", "topic", "12345")
+        assert result["success"] is True
+        assert result["action"] == "favorite"
+
+    @responses.activate
+    def test_unfavorite_node(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/mission/daily"),
+            body=ONCE_PAGE,
+            status=200,
+        )
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/unfavorite/node/90"),
+            status=200,
+        )
+        result = mod.favorite("fakecookie", "node", "90", undo=True)
+        assert result["success"] is True
+        assert result["action"] == "unfavorite"
+
+    def test_requires_cookie(self):
+        from v2ex_client import V2exError
+
+        try:
+            mod.favorite("", "topic", "12345")
+            assert False, "Should have raised"
+        except V2exError as e:
+            assert e.code == "AUTH_REQUIRED"

--- a/skills/v2ex/tests/test_follow.py
+++ b/skills/v2ex/tests/test_follow.py
@@ -1,0 +1,53 @@
+"""Tests for v2ex/scripts/v2ex_follow.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("v2ex", "v2ex_follow")
+
+ONCE_PAGE = '<html><body><input type="hidden" name="once" value="55555"></body></html>'
+
+
+class TestFollow:
+    @responses.activate
+    def test_follow_member(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/mission/daily"),
+            body=ONCE_PAGE,
+            status=200,
+        )
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/follow/1234"),
+            status=200,
+        )
+        result = mod.follow_action("fakecookie", "follow", "1234")
+        assert result["success"] is True
+        assert result["action"] == "follow"
+        assert result["member_id"] == 1234
+
+    @responses.activate
+    def test_block_member(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/mission/daily"),
+            body=ONCE_PAGE,
+            status=200,
+        )
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/block/5678"),
+            status=200,
+        )
+        result = mod.follow_action("fakecookie", "block", "5678")
+        assert result["success"] is True
+        assert result["action"] == "block"
+
+    def test_requires_cookie(self):
+        from v2ex_client import V2exError
+
+        try:
+            mod.follow_action("", "follow", "1234")
+            assert False, "Should have raised"
+        except V2exError as e:
+            assert e.code == "AUTH_REQUIRED"

--- a/skills/v2ex/tests/test_hot.py
+++ b/skills/v2ex/tests/test_hot.py
@@ -1,0 +1,62 @@
+"""Tests for v2ex/scripts/v2ex_hot.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("v2ex", "v2ex_hot")
+
+SAMPLE_TOPIC = {
+    "id": 100001,
+    "title": "Python 3.13 有什么新特性？",
+    "url": "https://www.v2ex.com/t/100001",
+    "content": "最近看到 Python 3.13 发布了，想了解一下新特性。",
+    "replies": 42,
+    "created": 1714000000,
+    "last_modified": 1714003600,
+    "last_touched": 1714003600,
+    "node": {"id": 90, "name": "python", "title": "Python"},
+    "member": {"id": 1234, "username": "testuser", "avatar_normal": "https://cdn.v2ex.com/avatar.png"},
+}
+
+
+class TestGetHot:
+    @responses.activate
+    def test_hot_topics(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/api/topics/hot\.json"),
+            json=[SAMPLE_TOPIC],
+            status=200,
+        )
+        result = mod.get_hot()
+        assert result["count"] == 1
+        t = result["topics"][0]
+        assert t["id"] == 100001
+        assert t["title"] == "Python 3.13 有什么新特性？"
+        assert t["node"]["name"] == "python"
+        assert t["member"]["username"] == "testuser"
+
+    @responses.activate
+    def test_hot_empty(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/api/topics/hot\.json"),
+            json=[],
+            status=200,
+        )
+        result = mod.get_hot()
+        assert result["count"] == 0
+        assert result["topics"] == []
+
+    @responses.activate
+    def test_content_preview_truncation(self):
+        long_content = "x" * 300
+        topic = {**SAMPLE_TOPIC, "content": long_content}
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/api/topics/hot\.json"),
+            json=[topic],
+            status=200,
+        )
+        result = mod.get_hot()
+        assert len(result["topics"][0]["content_preview"]) <= 200

--- a/skills/v2ex/tests/test_latest.py
+++ b/skills/v2ex/tests/test_latest.py
@@ -1,0 +1,46 @@
+"""Tests for v2ex/scripts/v2ex_latest.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("v2ex", "v2ex_latest")
+
+SAMPLE_TOPIC = {
+    "id": 200001,
+    "title": "macOS 上最好用的终端是什么？",
+    "url": "https://www.v2ex.com/t/200001",
+    "content": "想换一个终端，大家有什么推荐？",
+    "replies": 15,
+    "created": 1714000000,
+    "node": {"id": 12, "name": "apple", "title": "Apple"},
+    "member": {"id": 5678, "username": "devuser", "avatar_normal": "https://cdn.v2ex.com/avatar2.png"},
+}
+
+
+class TestGetLatest:
+    @responses.activate
+    def test_latest_topics(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/api/topics/latest\.json"),
+            json=[SAMPLE_TOPIC],
+            status=200,
+        )
+        result = mod.get_latest()
+        assert result["count"] == 1
+        t = result["topics"][0]
+        assert t["id"] == 200001
+        assert t["replies"] == 15
+        assert t["node"]["name"] == "apple"
+
+    @responses.activate
+    def test_latest_empty(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/api/topics/latest\.json"),
+            json=[],
+            status=200,
+        )
+        result = mod.get_latest()
+        assert result["count"] == 0

--- a/skills/v2ex/tests/test_member.py
+++ b/skills/v2ex/tests/test_member.py
@@ -1,0 +1,68 @@
+"""Tests for v2ex/scripts/v2ex_member.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("v2ex", "v2ex_member")
+
+SAMPLE_MEMBER = {
+    "id": 1,
+    "username": "livid",
+    "url": "https://www.v2ex.com/member/livid",
+    "website": "https://livid.v2ex.com",
+    "twitter": "livid",
+    "github": "livid",
+    "location": "San Francisco",
+    "tagline": "V2EX Creator",
+    "bio": "I created V2EX.",
+    "avatar_large": "https://cdn.v2ex.com/avatar/large.png",
+    "avatar_normal": "https://cdn.v2ex.com/avatar/normal.png",
+    "created": 1272203146,
+}
+
+SAMPLE_TOPIC = {
+    "id": 1,
+    "title": "Welcome to V2EX",
+    "url": "https://www.v2ex.com/t/1",
+    "content": "Hello everyone",
+    "replies": 100,
+    "created": 1272203200,
+    "node": {"id": 1, "name": "v2ex", "title": "V2EX"},
+    "member": {"id": 1, "username": "livid", "avatar_normal": "https://cdn.v2ex.com/avatar/normal.png"},
+}
+
+
+class TestGetMember:
+    @responses.activate
+    def test_profile_only(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/api/members/show\.json"),
+            json=SAMPLE_MEMBER,
+            status=200,
+        )
+        result = mod.get_member("livid")
+        m = result["member"]
+        assert m["username"] == "livid"
+        assert m["github"] == "livid"
+        assert m["location"] == "San Francisco"
+        assert "topics" not in result
+
+    @responses.activate
+    def test_profile_with_topics(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/api/members/show\.json"),
+            json=SAMPLE_MEMBER,
+            status=200,
+        )
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/api/topics/show\.json"),
+            json=[SAMPLE_TOPIC],
+            status=200,
+        )
+        result = mod.get_member("livid", include_topics=True)
+        assert result["member"]["username"] == "livid"
+        assert result["topics"]["count"] == 1
+        assert result["topics"]["items"][0]["title"] == "Welcome to V2EX"

--- a/skills/v2ex/tests/test_node.py
+++ b/skills/v2ex/tests/test_node.py
@@ -1,0 +1,65 @@
+"""Tests for v2ex/scripts/v2ex_node.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("v2ex", "v2ex_node")
+
+SAMPLE_NODE = {
+    "id": 90,
+    "name": "python",
+    "title": "Python",
+    "title_alternative": "Python",
+    "header": "All about Python",
+    "topics": 5000,
+    "stars": 1200,
+    "parent_node_name": "programming",
+}
+
+SAMPLE_TOPIC = {
+    "id": 300001,
+    "title": "Flask vs FastAPI",
+    "url": "https://www.v2ex.com/t/300001",
+    "content": "Which one should I use?",
+    "replies": 30,
+    "created": 1714000000,
+    "node": {"id": 90, "name": "python", "title": "Python"},
+    "member": {"id": 9999, "username": "webdev", "avatar_normal": "https://cdn.v2ex.com/c.png"},
+}
+
+
+class TestListAllNodes:
+    @responses.activate
+    def test_list_all(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/api/nodes/all\.json"),
+            json=[SAMPLE_NODE],
+            status=200,
+        )
+        result = mod.list_all_nodes()
+        assert result["count"] == 1
+        assert result["nodes"][0]["name"] == "python"
+        assert result["nodes"][0]["topics"] == 5000
+
+
+class TestGetNode:
+    @responses.activate
+    def test_get_node_with_topics(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/api/nodes/show\.json"),
+            json=SAMPLE_NODE,
+            status=200,
+        )
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/api/topics/show\.json"),
+            json=[SAMPLE_TOPIC],
+            status=200,
+        )
+        result = mod.get_node("python")
+        assert result["node"]["name"] == "python"
+        assert result["node"]["topics_count"] == 5000
+        assert result["topics"]["count"] == 1
+        assert result["topics"]["items"][0]["title"] == "Flask vs FastAPI"

--- a/skills/v2ex/tests/test_notifications.py
+++ b/skills/v2ex/tests/test_notifications.py
@@ -1,0 +1,56 @@
+"""Tests for v2ex/scripts/v2ex_notifications.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("v2ex", "v2ex_notifications")
+
+
+NOTIFICATIONS_HTML = """
+<html><body>
+<div class="cell" id="n_10001">
+    <a href="/member/alice">alice</a> replied to your topic
+    <a href="/t/12345#reply50">How to learn Rust?</a>
+    <span class="payload">I recommend the official Rust book.</span>
+    <span class="snow">2 hours ago</span>
+</div>
+<div class="cell" id="n_10002">
+    <a href="/member/bob">bob</a> thanked your topic
+    <a href="/t/12346">Best VSCode extensions</a>
+    <span class="payload">Thanks for sharing!</span>
+    <span class="snow">3 hours ago</span>
+</div>
+</body></html>
+"""
+
+
+class TestGetNotifications:
+    @responses.activate
+    def test_parse_notifications(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/notifications"),
+            body=NOTIFICATIONS_HTML,
+            status=200,
+        )
+        result = mod.get_notifications("fakecookie", page=1)
+        assert result["count"] == 2
+        assert result["page"] == 1
+        n1 = result["notifications"][0]
+        assert n1["id"] == 10001
+        assert n1["from_member"] == "alice"
+        assert n1["topic_id"] == 12345
+        n2 = result["notifications"][1]
+        assert n2["id"] == 10002
+        assert n2["from_member"] == "bob"
+
+    def test_requires_cookie(self):
+        from v2ex_client import V2exError
+
+        try:
+            mod.get_notifications("", page=1)
+            assert False, "Should have raised V2exError"
+        except V2exError as e:
+            assert e.code == "AUTH_REQUIRED"

--- a/skills/v2ex/tests/test_reply.py
+++ b/skills/v2ex/tests/test_reply.py
@@ -1,0 +1,58 @@
+"""Tests for v2ex/scripts/v2ex_reply.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("v2ex", "v2ex_reply")
+
+ONCE_PAGE = '<html><body><input type="hidden" name="once" value="88888"></body></html>'
+
+
+class TestReplyTopic:
+    @responses.activate
+    def test_reply_success(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/t/12345"),
+            body=ONCE_PAGE,
+            status=200,
+        )
+        responses.post(
+            url=re.compile(r"https://www\.v2ex\.com/t/12345"),
+            status=302,
+            headers={"Location": "/t/12345#reply100"},
+        )
+        result = mod.reply_topic("fakecookie", "12345", "Great post!")
+        assert result["success"] is True
+        assert result["topic_id"] == 12345
+
+    @responses.activate
+    def test_reply_rate_limited(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/t/12345"),
+            body=ONCE_PAGE,
+            status=200,
+        )
+        responses.post(
+            url=re.compile(r"https://www\.v2ex\.com/t/12345"),
+            body="<html>你上一次回复是在 30 秒前</html>",
+            status=200,
+        )
+        from v2ex_client import V2exError
+
+        try:
+            mod.reply_topic("fakecookie", "12345", "Hello")
+            assert False, "Should have raised"
+        except V2exError as e:
+            assert e.code == "RATE_LIMITED"
+
+    def test_requires_cookie(self):
+        from v2ex_client import V2exError
+
+        try:
+            mod.reply_topic("", "12345", "Hello")
+            assert False, "Should have raised"
+        except V2exError as e:
+            assert e.code == "AUTH_REQUIRED"

--- a/skills/v2ex/tests/test_search.py
+++ b/skills/v2ex/tests/test_search.py
@@ -1,0 +1,69 @@
+"""Tests for v2ex/scripts/v2ex_search.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("v2ex", "v2ex_search")
+
+
+class TestSearch:
+    @responses.activate
+    def test_basic_search(self):
+        responses.get(
+            url=re.compile(r"https://www\.sov2ex\.com/api/search"),
+            json={
+                "total": 1,
+                "took": 5,
+                "hits": [
+                    {
+                        "_source": {
+                            "id": 100001,
+                            "title": "Docker 部署最佳实践",
+                            "content": "分享一下我的 Docker 部署经验...",
+                            "node": "docker",
+                            "member": "devops_guru",
+                            "replies": 25,
+                            "created": "2026-04-01T10:00:00",
+                        }
+                    }
+                ],
+            },
+            status=200,
+        )
+        result = mod.search("Docker 部署")
+        assert result["total"] == 1
+        assert result["count"] == 1
+        h = result["hits"][0]
+        assert h["id"] == 100001
+        assert h["title"] == "Docker 部署最佳实践"
+        assert h["node"] == "docker"
+
+    @responses.activate
+    def test_empty_search(self):
+        responses.get(
+            url=re.compile(r"https://www\.sov2ex\.com/api/search"),
+            json={"total": 0, "took": 1, "hits": []},
+            status=200,
+        )
+        result = mod.search("nonexistent_query_xyz")
+        assert result["total"] == 0
+        assert result["count"] == 0
+        assert result["hits"] == []
+
+    @responses.activate
+    def test_content_preview_truncation(self):
+        long_content = "x" * 300
+        responses.get(
+            url=re.compile(r"https://www\.sov2ex\.com/api/search"),
+            json={
+                "total": 1,
+                "took": 1,
+                "hits": [{"_source": {"id": 1, "title": "Test", "content": long_content}}],
+            },
+            status=200,
+        )
+        result = mod.search("test")
+        assert len(result["hits"][0]["content_preview"]) <= 200

--- a/skills/v2ex/tests/test_thank.py
+++ b/skills/v2ex/tests/test_thank.py
@@ -1,0 +1,55 @@
+"""Tests for v2ex/scripts/v2ex_thank.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("v2ex", "v2ex_thank")
+
+ONCE_PAGE = '<html><body><input type="hidden" name="once" value="77777"></body></html>'
+
+
+class TestThank:
+    @responses.activate
+    def test_thank_topic(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/mission/daily"),
+            body=ONCE_PAGE,
+            status=200,
+        )
+        responses.post(
+            url=re.compile(r"https://www\.v2ex\.com/thank/topic/12345"),
+            json={"success": True},
+            status=200,
+        )
+        result = mod.thank("fakecookie", "topic", "12345")
+        assert result["success"] is True
+        assert result["type"] == "topic"
+        assert result["id"] == 12345
+
+    @responses.activate
+    def test_thank_reply(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/mission/daily"),
+            body=ONCE_PAGE,
+            status=200,
+        )
+        responses.post(
+            url=re.compile(r"https://www\.v2ex\.com/thank/reply/500001"),
+            json={"success": True},
+            status=200,
+        )
+        result = mod.thank("fakecookie", "reply", "500001")
+        assert result["success"] is True
+        assert result["type"] == "reply"
+
+    def test_requires_cookie(self):
+        from v2ex_client import V2exError
+
+        try:
+            mod.thank("", "topic", "12345")
+            assert False, "Should have raised"
+        except V2exError as e:
+            assert e.code == "AUTH_REQUIRED"

--- a/skills/v2ex/tests/test_topic.py
+++ b/skills/v2ex/tests/test_topic.py
@@ -1,0 +1,90 @@
+"""Tests for v2ex/scripts/v2ex_topic.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("v2ex", "v2ex_topic")
+
+SAMPLE_TOPIC = {
+    "id": 100001,
+    "title": "Test topic",
+    "url": "https://www.v2ex.com/t/100001",
+    "content": "Hello world",
+    "replies": 2,
+    "created": 1714000000,
+    "node": {"id": 90, "name": "python", "title": "Python"},
+    "member": {"id": 1234, "username": "testuser", "avatar_normal": "https://cdn.v2ex.com/a.png"},
+}
+
+SAMPLE_REPLY = {
+    "id": 500001,
+    "topic_id": 100001,
+    "content": "Great post!",
+    "content_rendered": "<p>Great post!</p>",
+    "created": 1714001000,
+    "member": {"id": 5678, "username": "replier", "avatar_normal": "https://cdn.v2ex.com/b.png"},
+}
+
+
+class TestGetTopicV1:
+    @responses.activate
+    def test_topic_with_replies(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/api/topics/show\.json"),
+            json=[SAMPLE_TOPIC],
+            status=200,
+        )
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/api/replies/show\.json"),
+            json=[SAMPLE_REPLY],
+            status=200,
+        )
+        result = mod.get_topic("100001", page=1, cookie="")
+        assert result["topic"]["id"] == 100001
+        assert result["replies"]["count"] == 1
+        assert result["replies"]["items"][0]["content"] == "Great post!"
+
+    @responses.activate
+    def test_topic_no_replies(self):
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/api/topics/show\.json"),
+            json=[SAMPLE_TOPIC],
+            status=200,
+        )
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/api/replies/show\.json"),
+            json=[],
+            status=200,
+        )
+        result = mod.get_topic("100001", page=1, cookie="")
+        assert result["replies"]["count"] == 0
+
+
+class TestGetTopicWithCookie:
+    @responses.activate
+    def test_topic_html_parsing(self):
+        html = """
+        <html><body>
+        <div class="header"><h1>Test Topic Title</h1><small class="gray">by testuser</small></div>
+        <div class="topic_content"><p>Hello world content</p></div>
+        <div class="cell" id="r_500001">
+            <strong><a class="dark" href="/member/replier">replier</a></strong>
+            <div class="reply_content"><p>Nice post!</p></div>
+            <span class="no">1</span>
+            <span class="ago">2 hours ago</span>
+        </div>
+        </body></html>
+        """
+        responses.get(
+            url=re.compile(r"https://www\.v2ex\.com/t/100001"),
+            body=html,
+            status=200,
+        )
+        result = mod.get_topic("100001", page=1, cookie="fakecookie")
+        assert result["topic"]["title"] == "Test Topic Title"
+        assert result["replies"]["count"] == 1
+        assert result["replies"]["items"][0]["member"] == "replier"
+        assert result["replies"]["items"][0]["floor"] == "1"


### PR DESCRIPTION
## Summary

- Add new V2EX (v2ex.com) skill with **16 scripts** covering full read/write interaction with the Chinese tech community forum
- **8 read scripts**: hot topics, latest topics, topic detail + replies, node info, member profiles, search (via SOV2EX), notifications, authenticated profile/balance
- **7 write scripts**: create topic, reply, thank topic/reply, favorite/unfavorite, follow/block members, daily check-in, append supplement — all using cookie-based auth with automatic CSRF `once` token extraction
- **1 shared client** (`v2ex_client.py`): session management, CSRF token extraction, HTML parsing with BeautifulSoup, rate-limit retry
- 38 tests, all passing
- Updated `install.sh` and `pyproject.toml` to include the new skill

## Signet Provider Config

To use this skill, add the V2EX provider to `~/.sig/config.yaml`:

```yaml
v2ex:
  domains: [ "www.v2ex.com", "v2ex.com" ]
  entryUrl: https://www.v2ex.com/signin
  strategy: cookie
  config:
    ttl: "7d"
    requiredCookies: [ "A2" ]
```

Then authenticate: `sig login https://www.v2ex.com/`

## Test plan

- [x] `python3 -m pytest v2ex/tests/ -v` — 38/38 tests pass
- [ ] Manual: `python3 scripts/v2ex_hot.py` returns hot topics JSON without auth
- [ ] Manual: `python3 scripts/v2ex_search.py --query "python"` returns search results
- [ ] Manual: `sig run v2ex -- bash -c 'python3 scripts/v2ex_notifications.py --cookie "$SIG_V2EX_COOKIE"'` with real cookie
- [ ] Manual: `./install.sh --list` shows v2ex in available skills