### PR TITLE
feat(skills): add Telegram skill

### DIFF
--- a/skills/telegram/SKILL.md
+++ b/skills/telegram/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: telegram
+description: 'Interact with Telegram — send messages, read chat history, get updates, manage chats, forward messages, send media. Use this skill whenever the user mentions Telegram, TG, Telegram bot, wants to send a Telegram message, read Telegram chats, check Telegram updates, manage Telegram channels/groups, or interact with Telegram bots. Also trigger when the user mentions a Telegram bot token, chat ID, or wants to automate Telegram messaging.'
+---
+
+# Telegram
+
+Send messages, read chat history, get updates, manage chats, forward messages, and send polls via the Telegram Bot API.
+
+## Authentication
+
+Use `sig run` to inject the bot token as an environment variable. The shared `telegram_client.py` reads `SIG_TELEGRAM_TOKEN` from the environment, or you can pass `--token` directly.
+
+```bash
+sig run telegram -- python scripts/tg_send.py --chat-id 123456 --text "Hello"
+```
+
+The default provider is `telegram`. The env var name follows the rule: `SIG_<PROVIDER>_TOKEN` where `<PROVIDER>` is the provider name uppercased.
+
+If you get an auth error:
+
+```bash
+sig login telegram
+```
+
+Then retry the `sig run` command.
+
+## Setup
+
+Obtain a bot token from [@BotFather](https://t.me/BotFather) on Telegram. The token format is `123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`.
+
+To configure `telegram` as a provider, run:
+
+```bash
+sig init
+```
+
+## Scripts Reference
+
+All scripts are in this skill's `scripts/` directory. Run via Bash tool.
+
+| Script           | Purpose                     |
+| ---------------- | --------------------------- |
+| `tg_send.py`     | Send a text message         |
+| `tg_messages.py` | Get recent messages/updates |
+| `tg_chat.py`     | Get chat info               |
+| `tg_forward.py`  | Forward a message           |
+| `tg_me.py`       | Get bot info                |
+| `tg_poll.py`     | Send a poll                 |
+| `tg_manage.py`   | Delete/pin/unpin messages   |
+
+### tg_send.py
+
+```
+--token TOKEN         Bot token (or set SIG_TELEGRAM_TOKEN)
+--chat-id ID          Target chat ID (required)
+--text TEXT            Message text (required)
+--parse-mode MODE     html or markdown (optional)
+--reply-to ID         Reply to a message ID (optional)
+--silent              Send without notification
+```
+
+### tg_messages.py
+
+```
+--token TOKEN         Bot token (or set SIG_TELEGRAM_TOKEN)
+--limit N             Max messages to return (default: 20)
+--offset N            Update offset for pagination (optional)
+```
+
+### tg_chat.py
+
+```
+--token TOKEN         Bot token (or set SIG_TELEGRAM_TOKEN)
+--chat-id ID          Chat ID (required)
+```
+
+### tg_forward.py
+
+```
+--token TOKEN         Bot token (or set SIG_TELEGRAM_TOKEN)
+--chat-id ID          Destination chat ID (required)
+--from-chat-id ID     Source chat ID (required)
+--message-id ID       Message ID to forward (required)
+--silent              Forward without notification
+```
+
+### tg_me.py
+
+```
+--token TOKEN         Bot token (or set SIG_TELEGRAM_TOKEN)
+```
+
+### tg_poll.py
+
+```
+--token TOKEN         Bot token (or set SIG_TELEGRAM_TOKEN)
+--chat-id ID          Target chat ID (required)
+--question TEXT        Poll question (required)
+--options OPT1,OPT2   Comma-separated options (required)
+--anonymous           Make poll anonymous
+--type TYPE           regular or quiz (default: regular)
+```
+
+### tg_manage.py
+
+```
+--token TOKEN         Bot token (or set SIG_TELEGRAM_TOKEN)
+--chat-id ID          Chat ID (required)
+--message-id ID       Message ID (required)
+--action ACTION       delete, pin, or unpin (required)
+```
+
+## Key Concepts
+
+**Bot tokens** — Obtained from @BotFather. Format: `123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`. Keep them secret.
+
+**Chat IDs** — Numeric identifiers for chats. Can be positive (user/group) or negative (supergroup/channel). Use `tg_messages.py` to discover chat IDs from incoming messages.
+
+**Update offsets** — The `last_update_id` returned by `tg_messages.py` can be incremented by 1 and passed as `--offset` to get only newer updates.
+
+**Parse modes** — Use `html` for HTML formatting or `markdown` for Markdown formatting in messages.
+
+## Error Handling
+
+| Error             | Cause                      | Fix                             |
+| ----------------- | -------------------------- | ------------------------------- |
+| UNAUTHORIZED      | Invalid bot token          | Check token with `tg_me.py`     |
+| BAD_REQUEST       | Invalid parameters         | Check chat ID, message ID, etc. |
+| FORBIDDEN         | Bot blocked or not in chat | Add bot to chat or unblock      |
+| NOT_FOUND         | Chat or message not found  | Verify the chat/message ID      |
+| TOO_MANY_REQUESTS | Rate limited               | Wait and retry                  |
+
+## Workflow Examples
+
+### Send a message
+
+1. `sig run telegram -- python scripts/tg_send.py --chat-id 123456 --text "Hello!"`
+2. With formatting: `sig run telegram -- python scripts/tg_send.py --chat-id 123456 --text "<b>Bold</b>" --parse-mode html`
+
+### Check for new messages
+
+1. `sig run telegram -- python scripts/tg_messages.py --limit 10`
+2. Get newer updates: `sig run telegram -- python scripts/tg_messages.py --offset 123456790`
+
+### Get chat info
+
+1. `sig run telegram -- python scripts/tg_chat.py --chat-id -1001234567890`
+
+### Forward a message
+
+1. `sig run telegram -- python scripts/tg_forward.py --chat-id 123456 --from-chat-id 789012 --message-id 42`
+
+### Send a poll
+
+1. `sig run telegram -- python scripts/tg_poll.py --chat-id 123456 --question "Favorite color?" --options "Red,Blue,Green"`
+
+### Delete a message
+
+1. `sig run telegram -- python scripts/tg_manage.py --chat-id 123456 --message-id 42 --action delete`

--- a/skills/telegram/scripts/telegram_client.py
+++ b/skills/telegram/scripts/telegram_client.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Shared Telegram Bot API client for Telegram skill scripts.
+
+Handles bot token extraction, HTTP transport, error handling,
+and response normalization for the Telegram Bot API.
+"""
+
+from __future__ import annotations
+
+import os
+
+import requests
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+TELEGRAM_API_BASE = "https://api.telegram.org"
+TIMEOUT = 30
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class TelegramError(Exception):
+    """Raised when the Telegram Bot API returns ok=false."""
+
+    def __init__(self, code: str, message: str = ""):
+        self.code = code
+        self.message = message or code
+        super().__init__(self.message)
+
+
+def error_response(code: str, message: str) -> dict:
+    """Build a standard error dict for JSON output."""
+    return {"error": code, "message": message}
+
+
+# ---------------------------------------------------------------------------
+# Token extraction
+# ---------------------------------------------------------------------------
+
+
+def get_bot_token(token_arg: str | None = None) -> str:
+    """Retrieve the Telegram bot token.
+
+    Checks the --token argument first, then SIG_TELEGRAM_TOKEN env var.
+
+    Returns:
+        Bot token string.
+
+    Raises:
+        RuntimeError: If no token is available.
+    """
+    token = token_arg or os.environ.get("SIG_TELEGRAM_TOKEN", "")
+    if not token:
+        raise RuntimeError(
+            "No Telegram bot token provided. "
+            "Pass --token or set SIG_TELEGRAM_TOKEN via 'sig run telegram --'."
+        )
+    return token
+
+
+# ---------------------------------------------------------------------------
+# Telegram Bot API client
+# ---------------------------------------------------------------------------
+
+
+class TelegramClient:
+    """Thin HTTP client for the Telegram Bot API.
+
+    All requests go to https://api.telegram.org/bot{token}/{method}.
+    """
+
+    def __init__(self, bot_token: str):
+        self.bot_token = bot_token
+        self.base_url = f"{TELEGRAM_API_BASE}/bot{bot_token}/"
+        self._session = requests.Session()
+
+    @classmethod
+    def create(cls, token_arg: str | None = None) -> TelegramClient:
+        """Create a client by extracting the bot token."""
+        token = get_bot_token(token_arg)
+        return cls(token)
+
+    def api_call(self, method: str, params: dict | None = None) -> dict:
+        """POST to the Telegram Bot API.
+
+        Returns:
+            The ``result`` field from the API response.
+
+        Raises:
+            TelegramError: If the API returns ``ok: false``.
+            requests.HTTPError: On HTTP-level errors.
+        """
+        url = f"{self.base_url}{method}"
+        resp = self._session.post(url, json=params or {}, timeout=TIMEOUT)
+
+        # Let requests handle HTTP errors for non-JSON responses
+        if resp.status_code >= 500:
+            resp.raise_for_status()
+
+        data = resp.json()
+
+        if not data.get("ok"):
+            error_code = str(data.get("error_code", resp.status_code))
+            description = data.get("description", "Telegram API returned ok=false")
+            raise TelegramError(error_code, description)
+
+        return data.get("result", {})
+
+
+# ---------------------------------------------------------------------------
+# Response parsers
+# ---------------------------------------------------------------------------
+
+
+def parse_user(user: dict) -> dict:
+    """Normalize a Telegram User object."""
+    return {
+        "id": user.get("id"),
+        "is_bot": user.get("is_bot", False),
+        "first_name": user.get("first_name", ""),
+        "last_name": user.get("last_name", ""),
+        "username": user.get("username", ""),
+        "language_code": user.get("language_code", ""),
+    }
+
+
+def parse_chat(chat: dict) -> dict:
+    """Normalize a Telegram Chat object."""
+    return {
+        "id": chat.get("id"),
+        "type": chat.get("type", ""),
+        "title": chat.get("title", ""),
+        "username": chat.get("username", ""),
+        "first_name": chat.get("first_name", ""),
+        "description": chat.get("description", ""),
+    }
+
+
+def parse_message(msg: dict) -> dict:
+    """Normalize a Telegram Message object."""
+    result = {
+        "message_id": msg.get("message_id"),
+        "date": msg.get("date"),
+        "text": msg.get("text", ""),
+        "caption": msg.get("caption", ""),
+    }
+    if msg.get("from"):
+        result["from"] = parse_user(msg["from"])
+    if msg.get("chat"):
+        result["chat"] = parse_chat(msg["chat"])
+    if msg.get("reply_to_message"):
+        result["reply_to_message_id"] = msg["reply_to_message"]["message_id"]
+    if msg.get("forward_from"):
+        result["forward_from"] = parse_user(msg["forward_from"])
+    return result

--- a/skills/telegram/scripts/tg_chat.py
+++ b/skills/telegram/scripts/tg_chat.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Get chat info via Telegram Bot API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import requests
+from telegram_client import TelegramClient, TelegramError, error_response, parse_chat
+
+
+def get_chat(client: TelegramClient, chat_id: str) -> dict:
+    """Fetch chat information."""
+    result = client.api_call("getChat", {"chat_id": chat_id})
+    return {"chat": parse_chat(result)}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Telegram chat info")
+    parser.add_argument("--token", help="Bot token (or set SIG_TELEGRAM_TOKEN)")
+    parser.add_argument("--chat-id", required=True, help="Chat ID")
+    args = parser.parse_args()
+
+    try:
+        client = TelegramClient.create(args.token)
+        result = get_chat(client, args.chat_id)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except TelegramError as e:
+        json.dump(error_response(e.code, e.message), sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump(error_response("HTTP_" + str(e.response.status_code), str(e)), sys.stdout, indent=2)
+    except Exception as e:
+        json.dump(error_response("ERROR", str(e)), sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/telegram/scripts/tg_forward.py
+++ b/skills/telegram/scripts/tg_forward.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Forward a message via Telegram Bot API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import requests
+from telegram_client import TelegramClient, TelegramError, error_response
+
+
+def forward_message(
+    client: TelegramClient,
+    chat_id: str,
+    from_chat_id: str,
+    message_id: int,
+    silent: bool = False,
+) -> dict:
+    """Forward a message from one chat to another."""
+    params: dict = {
+        "chat_id": chat_id,
+        "from_chat_id": from_chat_id,
+        "message_id": message_id,
+    }
+    if silent:
+        params["disable_notification"] = True
+
+    result = client.api_call("forwardMessage", params)
+
+    return {
+        "success": True,
+        "message_id": result["message_id"],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Forward a Telegram message")
+    parser.add_argument("--token", help="Bot token (or set SIG_TELEGRAM_TOKEN)")
+    parser.add_argument("--chat-id", required=True, help="Destination chat ID")
+    parser.add_argument("--from-chat-id", required=True, help="Source chat ID")
+    parser.add_argument("--message-id", type=int, required=True, help="Message ID to forward")
+    parser.add_argument("--silent", action="store_true", help="Forward without notification")
+    args = parser.parse_args()
+
+    try:
+        client = TelegramClient.create(args.token)
+        result = forward_message(client, args.chat_id, args.from_chat_id, args.message_id, args.silent)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except TelegramError as e:
+        json.dump(error_response(e.code, e.message), sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump(error_response("HTTP_" + str(e.response.status_code), str(e)), sys.stdout, indent=2)
+    except Exception as e:
+        json.dump(error_response("ERROR", str(e)), sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/telegram/scripts/tg_manage.py
+++ b/skills/telegram/scripts/tg_manage.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Delete, pin, or unpin messages via Telegram Bot API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import requests
+from telegram_client import TelegramClient, TelegramError, error_response
+
+ACTION_METHODS = {
+    "delete": "deleteMessage",
+    "pin": "pinChatMessage",
+    "unpin": "unpinChatMessage",
+}
+
+
+def manage_message(
+    client: TelegramClient,
+    chat_id: str,
+    message_id: int,
+    action: str,
+) -> dict:
+    """Perform delete, pin, or unpin on a message."""
+    method = ACTION_METHODS.get(action)
+    if not method:
+        raise ValueError(f"Invalid action: {action}. Use delete, pin, or unpin.")
+
+    params: dict = {
+        "chat_id": chat_id,
+        "message_id": message_id,
+    }
+
+    client.api_call(method, params)
+
+    return {
+        "success": True,
+        "action": action,
+        "message_id": message_id,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Delete/pin/unpin a Telegram message")
+    parser.add_argument("--token", help="Bot token (or set SIG_TELEGRAM_TOKEN)")
+    parser.add_argument("--chat-id", required=True, help="Chat ID")
+    parser.add_argument("--message-id", type=int, required=True, help="Message ID")
+    parser.add_argument("--action", required=True, choices=["delete", "pin", "unpin"], help="Action to perform")
+    args = parser.parse_args()
+
+    try:
+        client = TelegramClient.create(args.token)
+        result = manage_message(client, args.chat_id, args.message_id, args.action)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except TelegramError as e:
+        json.dump(error_response(e.code, e.message), sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump(error_response("HTTP_" + str(e.response.status_code), str(e)), sys.stdout, indent=2)
+    except Exception as e:
+        json.dump(error_response("ERROR", str(e)), sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/telegram/scripts/tg_me.py
+++ b/skills/telegram/scripts/tg_me.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Get bot info via Telegram Bot API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import requests
+from telegram_client import TelegramClient, TelegramError, error_response, parse_user
+
+
+def get_me(client: TelegramClient) -> dict:
+    """Fetch bot information."""
+    result = client.api_call("getMe")
+    return {"bot": parse_user(result)}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Telegram bot info")
+    parser.add_argument("--token", help="Bot token (or set SIG_TELEGRAM_TOKEN)")
+    args = parser.parse_args()
+
+    try:
+        client = TelegramClient.create(args.token)
+        result = get_me(client)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except TelegramError as e:
+        json.dump(error_response(e.code, e.message), sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump(error_response("HTTP_" + str(e.response.status_code), str(e)), sys.stdout, indent=2)
+    except Exception as e:
+        json.dump(error_response("ERROR", str(e)), sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/telegram/scripts/tg_messages.py
+++ b/skills/telegram/scripts/tg_messages.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Get recent messages via Telegram Bot API getUpdates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import requests
+from telegram_client import TelegramClient, TelegramError, error_response, parse_message
+
+
+def get_messages(
+    client: TelegramClient,
+    limit: int = 20,
+    offset: int | None = None,
+) -> dict:
+    """Fetch recent updates containing messages."""
+    params: dict = {"limit": limit}
+    if offset is not None:
+        params["offset"] = offset
+
+    updates = client.api_call("getUpdates", params)
+
+    messages = []
+    last_update_id = None
+    for update in updates:
+        last_update_id = update["update_id"]
+        msg = update.get("message") or update.get("edited_message") or update.get("channel_post")
+        if msg:
+            messages.append(parse_message(msg))
+
+    result: dict = {
+        "count": len(messages),
+        "messages": messages,
+    }
+    if last_update_id is not None:
+        result["last_update_id"] = last_update_id
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get recent Telegram messages")
+    parser.add_argument("--token", help="Bot token (or set SIG_TELEGRAM_TOKEN)")
+    parser.add_argument("--limit", type=int, default=20, help="Max messages (default: 20)")
+    parser.add_argument("--offset", type=int, help="Update offset for pagination")
+    args = parser.parse_args()
+
+    try:
+        client = TelegramClient.create(args.token)
+        result = get_messages(client, args.limit, args.offset)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except TelegramError as e:
+        json.dump(error_response(e.code, e.message), sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump(error_response("HTTP_" + str(e.response.status_code), str(e)), sys.stdout, indent=2)
+    except Exception as e:
+        json.dump(error_response("ERROR", str(e)), sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/telegram/scripts/tg_poll.py
+++ b/skills/telegram/scripts/tg_poll.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Send a poll via Telegram Bot API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import requests
+from telegram_client import TelegramClient, TelegramError, error_response
+
+
+def send_poll(
+    client: TelegramClient,
+    chat_id: str,
+    question: str,
+    options: list[str],
+    anonymous: bool = False,
+    poll_type: str = "regular",
+) -> dict:
+    """Send a poll to a Telegram chat."""
+    params: dict = {
+        "chat_id": chat_id,
+        "question": question,
+        "options": json.dumps(options),
+        "is_anonymous": anonymous,
+        "type": poll_type,
+    }
+
+    result = client.api_call("sendPoll", params)
+
+    return {
+        "success": True,
+        "message_id": result["message_id"],
+        "poll_id": result["poll"]["id"],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Send a Telegram poll")
+    parser.add_argument("--token", help="Bot token (or set SIG_TELEGRAM_TOKEN)")
+    parser.add_argument("--chat-id", required=True, help="Target chat ID")
+    parser.add_argument("--question", required=True, help="Poll question")
+    parser.add_argument("--options", required=True, help="Comma-separated poll options")
+    parser.add_argument("--anonymous", action="store_true", help="Make poll anonymous")
+    parser.add_argument("--type", default="regular", choices=["regular", "quiz"], help="Poll type (default: regular)")
+    args = parser.parse_args()
+
+    options = [o.strip() for o in args.options.split(",")]
+
+    try:
+        client = TelegramClient.create(args.token)
+        result = send_poll(client, args.chat_id, args.question, options, args.anonymous, args.type)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except TelegramError as e:
+        json.dump(error_response(e.code, e.message), sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump(error_response("HTTP_" + str(e.response.status_code), str(e)), sys.stdout, indent=2)
+    except Exception as e:
+        json.dump(error_response("ERROR", str(e)), sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/telegram/scripts/tg_send.py
+++ b/skills/telegram/scripts/tg_send.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Send a text message via Telegram Bot API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import requests
+from telegram_client import TelegramClient, TelegramError, error_response
+
+
+def send_message(
+    client: TelegramClient,
+    chat_id: str,
+    text: str,
+    parse_mode: str | None = None,
+    reply_to: int | None = None,
+    silent: bool = False,
+) -> dict:
+    """Send a text message to a Telegram chat."""
+    params: dict = {
+        "chat_id": chat_id,
+        "text": text,
+    }
+    if parse_mode:
+        params["parse_mode"] = parse_mode
+    if reply_to:
+        params["reply_to_message_id"] = reply_to
+    if silent:
+        params["disable_notification"] = True
+
+    result = client.api_call("sendMessage", params)
+
+    return {
+        "success": True,
+        "message_id": result["message_id"],
+        "chat_id": result["chat"]["id"],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Send a Telegram message")
+    parser.add_argument("--token", help="Bot token (or set SIG_TELEGRAM_TOKEN)")
+    parser.add_argument("--chat-id", required=True, help="Target chat ID")
+    parser.add_argument("--text", required=True, help="Message text")
+    parser.add_argument("--parse-mode", choices=["html", "markdown"], help="Parse mode")
+    parser.add_argument("--reply-to", type=int, help="Reply to message ID")
+    parser.add_argument("--silent", action="store_true", help="Send without notification")
+    args = parser.parse_args()
+
+    try:
+        client = TelegramClient.create(args.token)
+        result = send_message(client, args.chat_id, args.text, args.parse_mode, args.reply_to, args.silent)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except TelegramError as e:
+        json.dump(error_response(e.code, e.message), sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump(error_response("HTTP_" + str(e.response.status_code), str(e)), sys.stdout, indent=2)
+    except Exception as e:
+        json.dump(error_response("ERROR", str(e)), sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/telegram/tests/test_telegram_client.py
+++ b/skills/telegram/tests/test_telegram_client.py
@@ -1,0 +1,108 @@
+"""Tests for telegram/scripts/telegram_client.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("telegram", "telegram_client")
+
+FAKE_TOKEN = "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+
+
+class TestTelegramClient:
+    def test_base_url_construction(self):
+        client = mod.TelegramClient(FAKE_TOKEN)
+        assert client.base_url == f"https://api.telegram.org/bot{FAKE_TOKEN}/"
+
+    @responses.activate
+    def test_api_call_success(self):
+        responses.post(
+            url=re.compile(r"https://api\.telegram\.org/bot.+/getMe"),
+            json={"ok": True, "result": {"id": 123, "is_bot": True, "first_name": "TestBot"}},
+            status=200,
+        )
+        client = mod.TelegramClient(FAKE_TOKEN)
+        result = client.api_call("getMe")
+        assert result["id"] == 123
+        assert result["is_bot"] is True
+
+    @responses.activate
+    def test_api_call_error(self):
+        responses.post(
+            url=re.compile(r"https://api\.telegram\.org/bot.+/sendMessage"),
+            json={"ok": False, "error_code": 400, "description": "Bad Request: chat not found"},
+            status=400,
+        )
+        client = mod.TelegramClient(FAKE_TOKEN)
+        try:
+            client.api_call("sendMessage", {"chat_id": "invalid", "text": "hi"})
+            assert False, "Should have raised TelegramError"
+        except mod.TelegramError as e:
+            assert e.code == "400"
+            assert "chat not found" in e.message
+
+
+class TestGetBotToken:
+    def test_token_from_arg(self):
+        token = mod.get_bot_token("my-token")
+        assert token == "my-token"
+
+    def test_token_from_env(self, monkeypatch):
+        monkeypatch.setenv("SIG_TELEGRAM_TOKEN", "env-token")
+        token = mod.get_bot_token(None)
+        assert token == "env-token"
+
+    def test_no_token_raises(self, monkeypatch):
+        monkeypatch.delenv("SIG_TELEGRAM_TOKEN", raising=False)
+        try:
+            mod.get_bot_token(None)
+            assert False, "Should have raised RuntimeError"
+        except RuntimeError as e:
+            assert "No Telegram bot token" in str(e)
+
+
+class TestParsers:
+    def test_parse_user(self):
+        user = mod.parse_user({
+            "id": 42,
+            "is_bot": False,
+            "first_name": "John",
+            "last_name": "Doe",
+            "username": "johndoe",
+            "language_code": "en",
+        })
+        assert user["id"] == 42
+        assert user["first_name"] == "John"
+        assert user["username"] == "johndoe"
+
+    def test_parse_chat(self):
+        chat = mod.parse_chat({
+            "id": -1001234567890,
+            "type": "supergroup",
+            "title": "Test Group",
+            "username": "testgroup",
+        })
+        assert chat["id"] == -1001234567890
+        assert chat["type"] == "supergroup"
+        assert chat["title"] == "Test Group"
+
+    def test_parse_message(self):
+        msg = mod.parse_message({
+            "message_id": 100,
+            "date": 1700000000,
+            "text": "Hello world",
+            "from": {"id": 42, "is_bot": False, "first_name": "John"},
+            "chat": {"id": 123, "type": "private"},
+        })
+        assert msg["message_id"] == 100
+        assert msg["text"] == "Hello world"
+        assert msg["from"]["id"] == 42
+        assert msg["chat"]["id"] == 123
+
+    def test_parse_message_minimal(self):
+        msg = mod.parse_message({"message_id": 1, "date": 0})
+        assert msg["message_id"] == 1
+        assert msg["text"] == ""
+        assert "from" not in msg

--- a/skills/telegram/tests/test_tg_chat.py
+++ b/skills/telegram/tests/test_tg_chat.py
@@ -1,0 +1,58 @@
+"""Tests for telegram/scripts/tg_chat.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("telegram", "tg_chat")
+client_mod = load_script("telegram", "telegram_client")
+
+FAKE_TOKEN = "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+
+
+class TestGetChat:
+    @responses.activate
+    def test_get_chat_success(self):
+        responses.post(
+            url=re.compile(r"https://api\.telegram\.org/bot.+/getChat"),
+            json={
+                "ok": True,
+                "result": {
+                    "id": -1001234567890,
+                    "type": "supergroup",
+                    "title": "Test Group",
+                    "username": "testgroup",
+                    "description": "A test group",
+                },
+            },
+            status=200,
+        )
+        client = client_mod.TelegramClient(FAKE_TOKEN)
+        result = mod.get_chat(client, "-1001234567890")
+        assert result["chat"]["id"] == -1001234567890
+        assert result["chat"]["type"] == "supergroup"
+        assert result["chat"]["title"] == "Test Group"
+        assert result["chat"]["description"] == "A test group"
+
+    @responses.activate
+    def test_get_chat_private(self):
+        responses.post(
+            url=re.compile(r"https://api\.telegram\.org/bot.+/getChat"),
+            json={
+                "ok": True,
+                "result": {
+                    "id": 42,
+                    "type": "private",
+                    "first_name": "John",
+                    "username": "johndoe",
+                },
+            },
+            status=200,
+        )
+        client = client_mod.TelegramClient(FAKE_TOKEN)
+        result = mod.get_chat(client, "42")
+        assert result["chat"]["id"] == 42
+        assert result["chat"]["type"] == "private"
+        assert result["chat"]["first_name"] == "John"

--- a/skills/telegram/tests/test_tg_forward.py
+++ b/skills/telegram/tests/test_tg_forward.py
@@ -1,0 +1,55 @@
+"""Tests for telegram/scripts/tg_forward.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("telegram", "tg_forward")
+client_mod = load_script("telegram", "telegram_client")
+
+FAKE_TOKEN = "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+
+
+class TestForwardMessage:
+    @responses.activate
+    def test_forward_success(self):
+        responses.post(
+            url=re.compile(r"https://api\.telegram\.org/bot.+/forwardMessage"),
+            json={
+                "ok": True,
+                "result": {
+                    "message_id": 99,
+                    "date": 1700000000,
+                    "chat": {"id": 123, "type": "private"},
+                    "forward_from": {"id": 42, "is_bot": False, "first_name": "John"},
+                    "text": "Forwarded",
+                },
+            },
+            status=200,
+        )
+        client = client_mod.TelegramClient(FAKE_TOKEN)
+        result = mod.forward_message(client, "123", "456", 10)
+        assert result["success"] is True
+        assert result["message_id"] == 99
+
+    @responses.activate
+    def test_forward_silent(self):
+        responses.post(
+            url=re.compile(r"https://api\.telegram\.org/bot.+/forwardMessage"),
+            json={
+                "ok": True,
+                "result": {
+                    "message_id": 100,
+                    "date": 1700000000,
+                    "chat": {"id": 123, "type": "private"},
+                    "text": "Forwarded quietly",
+                },
+            },
+            status=200,
+        )
+        client = client_mod.TelegramClient(FAKE_TOKEN)
+        result = mod.forward_message(client, "123", "456", 10, silent=True)
+        assert result["success"] is True
+        assert result["message_id"] == 100

--- a/skills/telegram/tests/test_tg_manage.py
+++ b/skills/telegram/tests/test_tg_manage.py
@@ -1,0 +1,61 @@
+"""Tests for telegram/scripts/tg_manage.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("telegram", "tg_manage")
+client_mod = load_script("telegram", "telegram_client")
+
+FAKE_TOKEN = "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+
+
+class TestManageMessage:
+    @responses.activate
+    def test_delete_message(self):
+        responses.post(
+            url=re.compile(r"https://api\.telegram\.org/bot.+/deleteMessage"),
+            json={"ok": True, "result": True},
+            status=200,
+        )
+        client = client_mod.TelegramClient(FAKE_TOKEN)
+        result = mod.manage_message(client, "123", 42, "delete")
+        assert result["success"] is True
+        assert result["action"] == "delete"
+        assert result["message_id"] == 42
+
+    @responses.activate
+    def test_pin_message(self):
+        responses.post(
+            url=re.compile(r"https://api\.telegram\.org/bot.+/pinChatMessage"),
+            json={"ok": True, "result": True},
+            status=200,
+        )
+        client = client_mod.TelegramClient(FAKE_TOKEN)
+        result = mod.manage_message(client, "123", 42, "pin")
+        assert result["success"] is True
+        assert result["action"] == "pin"
+        assert result["message_id"] == 42
+
+    @responses.activate
+    def test_unpin_message(self):
+        responses.post(
+            url=re.compile(r"https://api\.telegram\.org/bot.+/unpinChatMessage"),
+            json={"ok": True, "result": True},
+            status=200,
+        )
+        client = client_mod.TelegramClient(FAKE_TOKEN)
+        result = mod.manage_message(client, "123", 42, "unpin")
+        assert result["success"] is True
+        assert result["action"] == "unpin"
+        assert result["message_id"] == 42
+
+    def test_invalid_action(self):
+        client = client_mod.TelegramClient(FAKE_TOKEN)
+        try:
+            mod.manage_message(client, "123", 42, "invalid")
+            assert False, "Should have raised ValueError"
+        except ValueError as e:
+            assert "Invalid action" in str(e)

--- a/skills/telegram/tests/test_tg_me.py
+++ b/skills/telegram/tests/test_tg_me.py
@@ -1,0 +1,36 @@
+"""Tests for telegram/scripts/tg_me.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("telegram", "tg_me")
+client_mod = load_script("telegram", "telegram_client")
+
+FAKE_TOKEN = "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+
+
+class TestGetMe:
+    @responses.activate
+    def test_get_me_success(self):
+        responses.post(
+            url=re.compile(r"https://api\.telegram\.org/bot.+/getMe"),
+            json={
+                "ok": True,
+                "result": {
+                    "id": 123456789,
+                    "is_bot": True,
+                    "first_name": "TestBot",
+                    "username": "test_bot",
+                },
+            },
+            status=200,
+        )
+        client = client_mod.TelegramClient(FAKE_TOKEN)
+        result = mod.get_me(client)
+        assert result["bot"]["id"] == 123456789
+        assert result["bot"]["is_bot"] is True
+        assert result["bot"]["first_name"] == "TestBot"
+        assert result["bot"]["username"] == "test_bot"

--- a/skills/telegram/tests/test_tg_messages.py
+++ b/skills/telegram/tests/test_tg_messages.py
@@ -1,0 +1,84 @@
+"""Tests for telegram/scripts/tg_messages.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("telegram", "tg_messages")
+client_mod = load_script("telegram", "telegram_client")
+
+FAKE_TOKEN = "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+
+SAMPLE_UPDATE = {
+    "update_id": 100,
+    "message": {
+        "message_id": 1,
+        "date": 1700000000,
+        "text": "Hello",
+        "from": {"id": 42, "is_bot": False, "first_name": "John"},
+        "chat": {"id": 123, "type": "private"},
+    },
+}
+
+
+class TestGetMessages:
+    @responses.activate
+    def test_get_messages_success(self):
+        responses.post(
+            url=re.compile(r"https://api\.telegram\.org/bot.+/getUpdates"),
+            json={"ok": True, "result": [SAMPLE_UPDATE]},
+            status=200,
+        )
+        client = client_mod.TelegramClient(FAKE_TOKEN)
+        result = mod.get_messages(client, limit=10)
+        assert result["count"] == 1
+        assert result["last_update_id"] == 100
+        assert result["messages"][0]["text"] == "Hello"
+
+    @responses.activate
+    def test_get_messages_empty(self):
+        responses.post(
+            url=re.compile(r"https://api\.telegram\.org/bot.+/getUpdates"),
+            json={"ok": True, "result": []},
+            status=200,
+        )
+        client = client_mod.TelegramClient(FAKE_TOKEN)
+        result = mod.get_messages(client, limit=10)
+        assert result["count"] == 0
+        assert result["messages"] == []
+        assert "last_update_id" not in result
+
+    @responses.activate
+    def test_get_messages_with_offset(self):
+        responses.post(
+            url=re.compile(r"https://api\.telegram\.org/bot.+/getUpdates"),
+            json={"ok": True, "result": [SAMPLE_UPDATE]},
+            status=200,
+        )
+        client = client_mod.TelegramClient(FAKE_TOKEN)
+        result = mod.get_messages(client, limit=10, offset=99)
+        assert result["count"] == 1
+
+    @responses.activate
+    def test_get_messages_edited(self):
+        update = {
+            "update_id": 101,
+            "edited_message": {
+                "message_id": 2,
+                "date": 1700000001,
+                "text": "Edited",
+                "from": {"id": 42, "is_bot": False, "first_name": "John"},
+                "chat": {"id": 123, "type": "private"},
+            },
+        }
+        responses.post(
+            url=re.compile(r"https://api\.telegram\.org/bot.+/getUpdates"),
+            json={"ok": True, "result": [update]},
+            status=200,
+        )
+        client = client_mod.TelegramClient(FAKE_TOKEN)
+        result = mod.get_messages(client, limit=10)
+        assert result["count"] == 1
+        assert result["messages"][0]["text"] == "Edited"

--- a/skills/telegram/tests/test_tg_poll.py
+++ b/skills/telegram/tests/test_tg_poll.py
@@ -1,0 +1,74 @@
+"""Tests for telegram/scripts/tg_poll.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("telegram", "tg_poll")
+client_mod = load_script("telegram", "telegram_client")
+
+FAKE_TOKEN = "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+
+
+class TestSendPoll:
+    @responses.activate
+    def test_send_poll_success(self):
+        responses.post(
+            url=re.compile(r"https://api\.telegram\.org/bot.+/sendPoll"),
+            json={
+                "ok": True,
+                "result": {
+                    "message_id": 50,
+                    "date": 1700000000,
+                    "chat": {"id": 123, "type": "group"},
+                    "poll": {
+                        "id": "poll_abc123",
+                        "question": "Favorite color?",
+                        "options": [
+                            {"text": "Red", "voter_count": 0},
+                            {"text": "Blue", "voter_count": 0},
+                        ],
+                        "is_anonymous": False,
+                        "type": "regular",
+                    },
+                },
+            },
+            status=200,
+        )
+        client = client_mod.TelegramClient(FAKE_TOKEN)
+        result = mod.send_poll(client, "123", "Favorite color?", ["Red", "Blue"])
+        assert result["success"] is True
+        assert result["message_id"] == 50
+        assert result["poll_id"] == "poll_abc123"
+
+    @responses.activate
+    def test_send_poll_anonymous(self):
+        responses.post(
+            url=re.compile(r"https://api\.telegram\.org/bot.+/sendPoll"),
+            json={
+                "ok": True,
+                "result": {
+                    "message_id": 51,
+                    "date": 1700000000,
+                    "chat": {"id": 123, "type": "group"},
+                    "poll": {
+                        "id": "poll_def456",
+                        "question": "Best language?",
+                        "options": [
+                            {"text": "Python", "voter_count": 0},
+                            {"text": "Rust", "voter_count": 0},
+                            {"text": "Go", "voter_count": 0},
+                        ],
+                        "is_anonymous": True,
+                        "type": "regular",
+                    },
+                },
+            },
+            status=200,
+        )
+        client = client_mod.TelegramClient(FAKE_TOKEN)
+        result = mod.send_poll(client, "123", "Best language?", ["Python", "Rust", "Go"], anonymous=True)
+        assert result["success"] is True
+        assert result["poll_id"] == "poll_def456"

--- a/skills/telegram/tests/test_tg_send.py
+++ b/skills/telegram/tests/test_tg_send.py
@@ -1,0 +1,94 @@
+"""Tests for telegram/scripts/tg_send.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("telegram", "tg_send")
+client_mod = load_script("telegram", "telegram_client")
+
+FAKE_TOKEN = "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+
+
+class TestSendMessage:
+    @responses.activate
+    def test_send_basic(self):
+        responses.post(
+            url=re.compile(r"https://api\.telegram\.org/bot.+/sendMessage"),
+            json={
+                "ok": True,
+                "result": {
+                    "message_id": 42,
+                    "chat": {"id": 123, "type": "private"},
+                    "date": 1700000000,
+                    "text": "Hello",
+                },
+            },
+            status=200,
+        )
+        client = client_mod.TelegramClient(FAKE_TOKEN)
+        result = mod.send_message(client, "123", "Hello")
+        assert result["success"] is True
+        assert result["message_id"] == 42
+        assert result["chat_id"] == 123
+
+    @responses.activate
+    def test_send_with_parse_mode(self):
+        responses.post(
+            url=re.compile(r"https://api\.telegram\.org/bot.+/sendMessage"),
+            json={
+                "ok": True,
+                "result": {
+                    "message_id": 43,
+                    "chat": {"id": 123, "type": "private"},
+                    "date": 1700000000,
+                    "text": "Bold",
+                },
+            },
+            status=200,
+        )
+        client = client_mod.TelegramClient(FAKE_TOKEN)
+        result = mod.send_message(client, "123", "<b>Bold</b>", parse_mode="html")
+        assert result["success"] is True
+        assert result["message_id"] == 43
+
+    @responses.activate
+    def test_send_with_reply(self):
+        responses.post(
+            url=re.compile(r"https://api\.telegram\.org/bot.+/sendMessage"),
+            json={
+                "ok": True,
+                "result": {
+                    "message_id": 44,
+                    "chat": {"id": 123, "type": "private"},
+                    "date": 1700000000,
+                    "text": "Reply",
+                },
+            },
+            status=200,
+        )
+        client = client_mod.TelegramClient(FAKE_TOKEN)
+        result = mod.send_message(client, "123", "Reply", reply_to=10)
+        assert result["success"] is True
+        assert result["message_id"] == 44
+
+    @responses.activate
+    def test_send_silent(self):
+        responses.post(
+            url=re.compile(r"https://api\.telegram\.org/bot.+/sendMessage"),
+            json={
+                "ok": True,
+                "result": {
+                    "message_id": 45,
+                    "chat": {"id": 123, "type": "private"},
+                    "date": 1700000000,
+                    "text": "Quiet",
+                },
+            },
+            status=200,
+        )
+        client = client_mod.TelegramClient(FAKE_TOKEN)
+        result = mod.send_message(client, "123", "Quiet", silent=True)
+        assert result["success"] is True


### PR DESCRIPTION
## Summary
- Add new Telegram skill at `skills/telegram/` with 8 scripts and 8 test files
- Shared `telegram_client.py` wraps the Telegram Bot API with `TelegramClient` class, error handling, and response parsers
- Scripts: `tg_send`, `tg_messages`, `tg_chat`, `tg_forward`, `tg_me`, `tg_poll`, `tg_manage`
- All 29 tests pass, ruff lint clean

## Test plan
- [x] `ruff check telegram/` passes with no errors
- [x] `pytest telegram/tests/ -v` passes all 29 tests
- [ ] Manual smoke test with a real bot token