### PR TITLE
feat(skills): add Douban skill

### DIFF
--- a/skills/douban/SKILL.md
+++ b/skills/douban/SKILL.md
@@ -15,15 +15,15 @@ Search, browse, and read Douban movies, books, music, reviews, and user profiles
 
 All scripts are in this skill's `scripts/` directory. Run via Bash tool.
 
-| Script             | Purpose                          | Auth |
-| ------------------ | -------------------------------- | ---- |
-| `douban_search.py` | Search movies/books/music        | None |
-| `douban_movie.py`  | Movie detail + reviews           | None |
-| `douban_book.py`   | Book detail + reviews            | None |
-| `douban_music.py`  | Music/album detail               | None |
-| `douban_hot.py`    | Hot/showing/coming soon movies   | None |
-| `douban_top250.py` | Top 250 movies (HTML scraping)   | None |
-| `douban_user.py`   | User profile                     | None |
+| Script             | Purpose                        | Auth |
+| ------------------ | ------------------------------ | ---- |
+| `douban_search.py` | Search movies/books/music      | None |
+| `douban_movie.py`  | Movie detail + reviews         | None |
+| `douban_book.py`   | Book detail + reviews          | None |
+| `douban_music.py`  | Music/album detail             | None |
+| `douban_hot.py`    | Hot/showing/coming soon movies | None |
+| `douban_top250.py` | Top 250 movies (HTML scraping) | None |
+| `douban_user.py`   | User profile                   | None |
 
 ### douban_search.py
 
@@ -86,12 +86,12 @@ All scripts are in this skill's `scripts/` directory. Run via Bash tool.
 
 ## Error Handling
 
-| Error        | Cause                         | Fix                     |
-| ------------ | ----------------------------- | ----------------------- |
-| HTTP_404     | Item or user not found        | Check the ID / uid      |
-| HTTP_429     | Rate limited by API           | Wait and retry          |
-| HTTP_400     | Invalid request parameters    | Check arguments         |
-| ERROR        | Network or unexpected failure | Check connectivity      |
+| Error    | Cause                         | Fix                |
+| -------- | ----------------------------- | ------------------ |
+| HTTP_404 | Item or user not found        | Check the ID / uid |
+| HTTP_429 | Rate limited by API           | Wait and retry     |
+| HTTP_400 | Invalid request parameters    | Check arguments    |
+| ERROR    | Network or unexpected failure | Check connectivity |
 
 ## Workflow Examples
 

--- a/skills/douban/SKILL.md
+++ b/skills/douban/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: douban
+description: 'Interact with Douban (douban.com) — search movies/books/music, read reviews, view ratings, browse Top 250, check user profiles. Use this skill whenever the user mentions Douban, 豆瓣, douban.com, wants to look up movie/book/music ratings, read Douban reviews, search Douban content, check Douban Top 250, or browse Douban user profiles. Also trigger when the user pastes a Douban URL or asks about Chinese movie/book/music reviews and ratings.'
+---
+
+# Douban
+
+Search, browse, and read Douban movies, books, music, reviews, and user profiles.
+
+## Authentication
+
+**No authentication is required.** All scripts use Douban's public Frodo mobile API and HTML scraping. No cookies, tokens, or `sig run` needed.
+
+## Scripts Reference
+
+All scripts are in this skill's `scripts/` directory. Run via Bash tool.
+
+| Script             | Purpose                          | Auth |
+| ------------------ | -------------------------------- | ---- |
+| `douban_search.py` | Search movies/books/music        | None |
+| `douban_movie.py`  | Movie detail + reviews           | None |
+| `douban_book.py`   | Book detail + reviews            | None |
+| `douban_music.py`  | Music/album detail               | None |
+| `douban_hot.py`    | Hot/showing/coming soon movies   | None |
+| `douban_top250.py` | Top 250 movies (HTML scraping)   | None |
+| `douban_user.py`   | User profile                     | None |
+
+### douban_search.py
+
+```
+--query TEXT          Search query (required)
+--type TYPE           Content type: "movie" (default), "book", "music"
+--limit N             Max results (default: 20)
+```
+
+### douban_movie.py
+
+```
+--id ID               Douban movie ID (required)
+--include-reviews     Also fetch recent reviews (flag)
+```
+
+### douban_book.py
+
+```
+--id ID               Douban book ID (required)
+--include-reviews     Also fetch recent reviews (flag)
+```
+
+### douban_music.py
+
+```
+--id ID               Douban music/album ID (required)
+```
+
+### douban_hot.py
+
+```
+--category CAT        Category: "hot" (default), "showing", "coming"
+--limit N             Max results (default: 20)
+```
+
+### douban_top250.py
+
+```
+--page N              Page number (default: 1, 25 movies per page)
+```
+
+### douban_user.py
+
+```
+--uid UID             Douban user uid or numeric ID (required)
+```
+
+## Key Concepts
+
+**Frodo API** -- Douban's mobile API at `frodo.douban.com/api/v2`. Requires an `apikey` query parameter and a mobile User-Agent header. All read operations are public.
+
+**Movie IDs** -- Numeric IDs found in URLs like `movie.douban.com/subject/1292052/`. Get IDs from search results, then use with `douban_movie.py`.
+
+**Top 250** -- Scraped from `movie.douban.com/top250`. Returns 25 movies per page with rank, title, rating, info, and quote.
+
+**Content types** -- Search supports `movie`, `book`, and `music` types. Each type returns different fields in the result items.
+
+**Reviews (interests)** -- Douban calls user reviews "interests". Use `--include-reviews` on movie/book scripts to fetch recent user ratings and comments.
+
+## Error Handling
+
+| Error        | Cause                         | Fix                     |
+| ------------ | ----------------------------- | ----------------------- |
+| HTTP_404     | Item or user not found        | Check the ID / uid      |
+| HTTP_429     | Rate limited by API           | Wait and retry          |
+| HTTP_400     | Invalid request parameters    | Check arguments         |
+| ERROR        | Network or unexpected failure | Check connectivity      |
+
+## Workflow Examples
+
+### Search for a movie
+
+1. `python3 scripts/douban_search.py --query "肖申克的救赎" --type movie --limit 5`
+
+### Get movie detail with reviews
+
+1. `python3 scripts/douban_movie.py --id 1292052 --include-reviews`
+
+### Browse hot movies
+
+1. `python3 scripts/douban_hot.py --category hot --limit 10`
+
+### Browse Top 250
+
+1. `python3 scripts/douban_top250.py --page 1`
+
+### Search for a book
+
+1. `python3 scripts/douban_search.py --query "三体" --type book --limit 5`
+
+### Get book detail
+
+1. `python3 scripts/douban_book.py --id 2567698 --include-reviews`
+
+### Look up a user
+
+1. `python3 scripts/douban_user.py --uid ahbei`

--- a/skills/douban/scripts/douban_book.py
+++ b/skills/douban/scripts/douban_book.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Get Douban book detail and reviews."""
+
+import argparse
+import json
+import sys
+
+import requests
+from douban_client import DoubanClient, parse_book, parse_interest
+
+
+def get_book(book_id, include_reviews=False):
+    client = DoubanClient()
+    data = client.frodo_get(f"/book/{book_id}")
+    book = parse_book(data)
+    result = {"book": book}
+    if include_reviews:
+        reviews_data = client.frodo_get(f"/book/{book_id}/interests", params={"start": 0, "count": 10})
+        interests = reviews_data.get("interests", [])
+        result["reviews"] = [parse_interest(i) for i in interests if i]
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Douban book detail")
+    parser.add_argument("--id", required=True, help="Douban book ID")
+    parser.add_argument("--include-reviews", action="store_true", help="Also fetch recent reviews")
+    args = parser.parse_args()
+
+    try:
+        result = get_book(args.id, args.include_reviews)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/douban/scripts/douban_client.py
+++ b/skills/douban/scripts/douban_client.py
@@ -1,0 +1,159 @@
+"""Shared Douban client -- Frodo API helpers, HTML scraping, and item parsers."""
+
+import requests
+from bs4 import BeautifulSoup
+
+FRODO_BASE = "https://frodo.douban.com/api/v2"
+DOUBAN_BASE = "https://www.douban.com"
+MOVIE_DOUBAN_BASE = "https://movie.douban.com"
+
+FRODO_APIKEY = "0ac44ae016490db2204ce0a042db2916"
+
+MOBILE_UA = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) MicroMessenger/8.0.0"
+
+TIMEOUT = 15
+
+
+class DoubanClient:
+    def __init__(self):
+        self._session = requests.Session()
+        self._session.headers["User-Agent"] = MOBILE_UA
+
+    def frodo_get(self, path, params=None):
+        params = params or {}
+        params["apikey"] = FRODO_APIKEY
+        resp = self._session.get(FRODO_BASE + path, params=params, timeout=TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+
+    def html_get(self, url, params=None):
+        resp = self._session.get(url, params=params, timeout=TIMEOUT)
+        resp.raise_for_status()
+        return resp.text
+
+
+def parse_movie(m):
+    """Normalize a Frodo movie object to a consistent dict."""
+    if not m:
+        return None
+    rating = m.get("rating") or {}
+    directors = [d.get("name", "") for d in (m.get("directors") or [])]
+    actors = [a.get("name", "") for a in (m.get("actors") or [])]
+    pic = m.get("pic") or {}
+    return {
+        "id": m.get("id"),
+        "title": m.get("title", ""),
+        "original_title": m.get("original_title", ""),
+        "year": m.get("year", ""),
+        "rating": rating.get("value", 0),
+        "rating_count": rating.get("count", 0),
+        "genres": m.get("genres", []),
+        "directors": directors,
+        "actors": actors,
+        "intro": (m.get("intro") or "")[:500],
+        "cover": pic.get("large") or pic.get("normal", ""),
+        "url": m.get("url", ""),
+        "card_subtitle": m.get("card_subtitle", ""),
+    }
+
+
+def parse_book(b):
+    """Normalize a Frodo book object to a consistent dict."""
+    if not b:
+        return None
+    rating = b.get("rating") or {}
+    pic = b.get("pic") or {}
+    return {
+        "id": b.get("id"),
+        "title": b.get("title", ""),
+        "subtitle": b.get("subtitle", ""),
+        "author": b.get("author", []),
+        "publisher": b.get("publisher", ""),
+        "pubdate": b.get("pubdate", ""),
+        "pages": b.get("pages", ""),
+        "rating": rating.get("value", 0),
+        "rating_count": rating.get("count", 0),
+        "intro": (b.get("intro") or "")[:500],
+        "cover": pic.get("large") or pic.get("normal", "") if isinstance(pic, dict) else str(pic),
+        "url": b.get("url", ""),
+    }
+
+
+def parse_music(m):
+    """Normalize a Frodo music object to a consistent dict."""
+    if not m:
+        return None
+    rating = m.get("rating") or {}
+    pic = m.get("pic") or {}
+    attrs = m.get("attrs") or {}
+    return {
+        "id": m.get("id"),
+        "title": m.get("title", ""),
+        "rating": rating.get("value", 0),
+        "rating_count": rating.get("count", 0),
+        "intro": (m.get("intro") or "")[:500],
+        "cover": pic.get("large") or pic.get("normal", "") if isinstance(pic, dict) else str(pic),
+        "url": m.get("url", ""),
+        "singer": attrs.get("singer", []),
+        "publisher": attrs.get("publisher", []),
+    }
+
+
+def parse_user(u):
+    """Normalize a Frodo user object to a consistent dict."""
+    if not u:
+        return None
+    return {
+        "id": u.get("id", ""),
+        "name": u.get("name", ""),
+        "uid": u.get("uid", ""),
+        "avatar": u.get("avatar", ""),
+        "intro": u.get("intro", ""),
+        "url": u.get("url", ""),
+    }
+
+
+def parse_interest(i):
+    """Normalize a Frodo interest (review/rating) to a consistent dict."""
+    if not i:
+        return None
+    rating = i.get("rating") or {}
+    user = i.get("user") or {}
+    return {
+        "rating": rating.get("value", 0),
+        "comment": i.get("comment", ""),
+        "create_time": i.get("create_time", ""),
+        "user": user.get("name", ""),
+        "useful_count": i.get("useful_count", 0),
+    }
+
+
+def parse_top250_page(html):
+    """Parse the Top 250 HTML page and extract movie entries."""
+    soup = BeautifulSoup(html, "html.parser")
+    movies = []
+    for idx, item in enumerate(soup.select("ol.grid_view li")):
+        movie = {}
+        em = item.select_one("div.hd span.title")
+        if em:
+            movie["title"] = em.get_text(strip=True)
+        num = item.select_one("div.pic em")
+        if num:
+            movie["rank"] = int(num.get_text(strip=True))
+        rating_num = item.select_one("span.rating_num")
+        if rating_num:
+            try:
+                movie["rating"] = float(rating_num.get_text(strip=True))
+            except ValueError:
+                movie["rating"] = 0.0
+        info_el = item.select_one("div.bd p")
+        if info_el:
+            movie["info"] = info_el.get_text(separator=" ", strip=True)
+        quote_el = item.select_one("span.inq")
+        if quote_el:
+            movie["quote"] = quote_el.get_text(strip=True)
+        link = item.select_one("div.hd a")
+        if link:
+            movie["url"] = link.get("href", "")
+        movies.append(movie)
+    return movies

--- a/skills/douban/scripts/douban_hot.py
+++ b/skills/douban/scripts/douban_hot.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Get hot, now-showing, or coming-soon movies from Douban."""
+
+import argparse
+import json
+import sys
+
+import requests
+from douban_client import DoubanClient, parse_movie
+
+CATEGORY_PATHS = {
+    "hot": "/movie/hot_gird",
+    "showing": "/movie/movie_showing",
+    "coming": "/movie/movie_soon",
+}
+
+
+def get_hot(category="hot", limit=20):
+    client = DoubanClient()
+    path = CATEGORY_PATHS.get(category, CATEGORY_PATHS["hot"])
+    data = client.frodo_get(path, params={"start": 0, "count": min(limit, 50)})
+    items = data.get("items") or data.get("subject_collection_items") or []
+    movies = [parse_movie(m) for m in items if m]
+    return {
+        "category": category,
+        "count": len(movies),
+        "movies": movies,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Douban hot/showing/coming movies")
+    parser.add_argument("--category", default="hot", choices=["hot", "showing", "coming"], help="Movie category (default: hot)")
+    parser.add_argument("--limit", type=int, default=20, help="Max results (default: 20)")
+    args = parser.parse_args()
+
+    try:
+        result = get_hot(args.category, args.limit)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/douban/scripts/douban_movie.py
+++ b/skills/douban/scripts/douban_movie.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Get Douban movie detail and reviews."""
+
+import argparse
+import json
+import sys
+
+import requests
+from douban_client import DoubanClient, parse_interest, parse_movie
+
+
+def get_movie(movie_id, include_reviews=False):
+    client = DoubanClient()
+    data = client.frodo_get(f"/movie/{movie_id}")
+    movie = parse_movie(data)
+    result = {"movie": movie}
+    if include_reviews:
+        reviews_data = client.frodo_get(f"/movie/{movie_id}/interests", params={"start": 0, "count": 10})
+        interests = reviews_data.get("interests", [])
+        result["reviews"] = [parse_interest(i) for i in interests if i]
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Douban movie detail")
+    parser.add_argument("--id", required=True, help="Douban movie ID")
+    parser.add_argument("--include-reviews", action="store_true", help="Also fetch recent reviews")
+    args = parser.parse_args()
+
+    try:
+        result = get_movie(args.id, args.include_reviews)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/douban/scripts/douban_music.py
+++ b/skills/douban/scripts/douban_music.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Get Douban music/album detail."""
+
+import argparse
+import json
+import sys
+
+import requests
+from douban_client import DoubanClient, parse_music
+
+
+def get_music(music_id):
+    client = DoubanClient()
+    data = client.frodo_get(f"/music/{music_id}")
+    music = parse_music(data)
+    return {"music": music}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Douban music/album detail")
+    parser.add_argument("--id", required=True, help="Douban music/album ID")
+    args = parser.parse_args()
+
+    try:
+        result = get_music(args.id)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/douban/scripts/douban_search.py
+++ b/skills/douban/scripts/douban_search.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Search Douban movies, books, and music."""
+
+import argparse
+import json
+import sys
+
+import requests
+from douban_client import DoubanClient, parse_book, parse_movie, parse_music
+
+PARSERS = {
+    "movie": parse_movie,
+    "book": parse_book,
+    "music": parse_music,
+}
+
+
+def search(query, search_type="movie", limit=20):
+    client = DoubanClient()
+    data = client.frodo_get("/search", params={"q": query, "type": search_type, "start": 0, "count": min(limit, 50)})
+    items = []
+    for entry in data.get("items", []):
+        target_type = entry.get("target_type", "")
+        target = entry.get("target")
+        parser = PARSERS.get(target_type)
+        if parser and target:
+            parsed = parser(target)
+            if parsed:
+                parsed["target_type"] = target_type
+                items.append(parsed)
+    return {
+        "total": data.get("total", 0),
+        "count": len(items),
+        "items": items,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Search Douban movies/books/music")
+    parser.add_argument("--query", required=True, help="Search query")
+    parser.add_argument("--type", default="movie", choices=["movie", "book", "music"], help="Content type (default: movie)")
+    parser.add_argument("--limit", type=int, default=20, help="Max results (default: 20)")
+    args = parser.parse_args()
+
+    try:
+        result = search(args.query, args.type, args.limit)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/douban/scripts/douban_top250.py
+++ b/skills/douban/scripts/douban_top250.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Get Douban Top 250 movies via HTML scraping."""
+
+import argparse
+import json
+import sys
+
+import requests
+from douban_client import DoubanClient, parse_top250_page
+
+
+def get_top250(page=1):
+    client = DoubanClient()
+    start = (page - 1) * 25
+    html = client.html_get("https://movie.douban.com/top250", params={"start": start})
+    movies = parse_top250_page(html)
+    return {
+        "page": page,
+        "count": len(movies),
+        "movies": movies,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Douban Top 250 movies")
+    parser.add_argument("--page", type=int, default=1, help="Page number (default: 1, 25 movies per page)")
+    args = parser.parse_args()
+
+    try:
+        result = get_top250(args.page)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/douban/scripts/douban_user.py
+++ b/skills/douban/scripts/douban_user.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Get Douban user profile."""
+
+import argparse
+import json
+import sys
+
+import requests
+from douban_client import DoubanClient, parse_user
+
+
+def get_user(uid):
+    client = DoubanClient()
+    data = client.frodo_get(f"/user/{uid}")
+    user = parse_user(data)
+    return {"user": user}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Douban user profile")
+    parser.add_argument("--uid", required=True, help="Douban user uid or numeric ID")
+    args = parser.parse_args()
+
+    try:
+        result = get_user(args.uid)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/douban/tests/test_book.py
+++ b/skills/douban/tests/test_book.py
@@ -1,0 +1,81 @@
+"""Tests for douban/scripts/douban_book.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("douban", "douban_book")
+
+SAMPLE_BOOK = {
+    "id": "2567698",
+    "title": "三体",
+    "subtitle": "地球往事",
+    "author": ["刘慈欣"],
+    "publisher": "重庆出版社",
+    "pubdate": "2008-1",
+    "pages": "302",
+    "rating": {"value": 8.8, "count": 500000},
+    "intro": "文化大革命如火如荼进行的同时...",
+    "pic": {"normal": "https://img.doubanio.com/small.jpg", "large": "https://img.doubanio.com/large.jpg"},
+    "url": "https://book.douban.com/subject/2567698/",
+}
+
+SAMPLE_INTEREST = {
+    "rating": {"value": 5},
+    "comment": "科幻巨作",
+    "create_time": "2026-02-15 12:00:00",
+    "user": {"name": "bookworm"},
+    "useful_count": 10,
+}
+
+
+class TestGetBook:
+    @responses.activate
+    def test_book_detail(self):
+        responses.get(
+            url=re.compile(r"https://frodo\.douban\.com/api/v2/book/2567698"),
+            json=SAMPLE_BOOK,
+            status=200,
+        )
+        result = mod.get_book("2567698")
+        book = result["book"]
+        assert book["id"] == "2567698"
+        assert book["title"] == "三体"
+        assert book["author"] == ["刘慈欣"]
+        assert book["rating"] == 8.8
+        assert book["publisher"] == "重庆出版社"
+        assert "reviews" not in result
+
+    @responses.activate
+    def test_book_with_reviews(self):
+        responses.get(
+            url=re.compile(r"https://frodo\.douban\.com/api/v2/book/2567698\b(?!/)"),
+            json=SAMPLE_BOOK,
+            status=200,
+        )
+        responses.get(
+            url=re.compile(r"https://frodo\.douban\.com/api/v2/book/2567698/interests"),
+            json={"interests": [SAMPLE_INTEREST]},
+            status=200,
+        )
+        result = mod.get_book("2567698", include_reviews=True)
+        assert result["book"]["title"] == "三体"
+        assert len(result["reviews"]) == 1
+        assert result["reviews"][0]["comment"] == "科幻巨作"
+
+    @responses.activate
+    def test_book_empty_reviews(self):
+        responses.get(
+            url=re.compile(r"https://frodo\.douban\.com/api/v2/book/999\b(?!/)"),
+            json=SAMPLE_BOOK,
+            status=200,
+        )
+        responses.get(
+            url=re.compile(r"https://frodo\.douban\.com/api/v2/book/999/interests"),
+            json={"interests": []},
+            status=200,
+        )
+        result = mod.get_book("999", include_reviews=True)
+        assert result["reviews"] == []

--- a/skills/douban/tests/test_client.py
+++ b/skills/douban/tests/test_client.py
@@ -1,0 +1,140 @@
+"""Tests for douban/scripts/douban_client.py"""
+
+from test_helpers import load_script
+
+mod = load_script("douban", "douban_client")
+
+
+class TestParseMovie:
+    def test_parse_full_movie(self):
+        raw = {
+            "id": "1292052",
+            "title": "肖申克的救赎",
+            "original_title": "The Shawshank Redemption",
+            "year": "1994",
+            "rating": {"value": 9.7, "count": 2500000},
+            "genres": ["剧情", "犯罪"],
+            "directors": [{"name": "弗兰克·德拉邦特"}],
+            "actors": [{"name": "蒂姆·罗宾斯"}],
+            "intro": "一场冤狱引出了一段传奇。",
+            "pic": {"normal": "https://img.doubanio.com/small.jpg", "large": "https://img.doubanio.com/large.jpg"},
+            "url": "https://movie.douban.com/subject/1292052/",
+            "card_subtitle": "1994 / 美国",
+        }
+        result = mod.parse_movie(raw)
+        assert result["id"] == "1292052"
+        assert result["title"] == "肖申克的救赎"
+        assert result["rating"] == 9.7
+        assert result["directors"] == ["弗兰克·德拉邦特"]
+        assert result["cover"] == "https://img.doubanio.com/large.jpg"
+
+    def test_parse_none(self):
+        assert mod.parse_movie(None) is None
+
+    def test_parse_missing_fields(self):
+        result = mod.parse_movie({"id": "1"})
+        assert result["id"] == "1"
+        assert result["title"] == ""
+        assert result["rating"] == 0
+        assert result["directors"] == []
+
+
+class TestParseBook:
+    def test_parse_full_book(self):
+        raw = {
+            "id": "2567698",
+            "title": "三体",
+            "subtitle": "地球往事",
+            "author": ["刘慈欣"],
+            "publisher": "重庆出版社",
+            "pubdate": "2008-1",
+            "pages": "302",
+            "rating": {"value": 8.8, "count": 500000},
+            "intro": "文化大革命如火如荼进行的同时...",
+            "pic": {"normal": "https://img.doubanio.com/small.jpg", "large": "https://img.doubanio.com/large.jpg"},
+            "url": "https://book.douban.com/subject/2567698/",
+        }
+        result = mod.parse_book(raw)
+        assert result["id"] == "2567698"
+        assert result["author"] == ["刘慈欣"]
+        assert result["rating"] == 8.8
+
+    def test_parse_none(self):
+        assert mod.parse_book(None) is None
+
+
+class TestParseMusic:
+    def test_parse_full_music(self):
+        raw = {
+            "id": "1401853",
+            "title": "范特西",
+            "rating": {"value": 9.2, "count": 120000},
+            "intro": "周杰伦的第二张专辑。",
+            "pic": {"normal": "https://img.doubanio.com/small.jpg", "large": "https://img.doubanio.com/large.jpg"},
+            "url": "https://music.douban.com/subject/1401853/",
+            "attrs": {"singer": ["周杰伦"], "publisher": ["BMG"]},
+        }
+        result = mod.parse_music(raw)
+        assert result["id"] == "1401853"
+        assert result["singer"] == ["周杰伦"]
+        assert result["rating"] == 9.2
+
+    def test_parse_none(self):
+        assert mod.parse_music(None) is None
+
+
+class TestParseUser:
+    def test_parse_full_user(self):
+        raw = {"id": "1000001", "name": "阿北", "uid": "ahbei", "avatar": "https://img.doubanio.com/icon.jpg", "intro": "豆瓣创始人", "url": "https://www.douban.com/people/ahbei/"}
+        result = mod.parse_user(raw)
+        assert result["name"] == "阿北"
+        assert result["uid"] == "ahbei"
+
+    def test_parse_none(self):
+        assert mod.parse_user(None) is None
+
+
+class TestParseInterest:
+    def test_parse_interest(self):
+        raw = {"rating": {"value": 5}, "comment": "好看", "create_time": "2026-01-01", "user": {"name": "fan"}, "useful_count": 3}
+        result = mod.parse_interest(raw)
+        assert result["rating"] == 5
+        assert result["comment"] == "好看"
+        assert result["user"] == "fan"
+
+    def test_parse_none(self):
+        assert mod.parse_interest(None) is None
+
+
+class TestParseTop250Page:
+    def test_parse_html(self):
+        html = """
+        <html><body>
+        <ol class="grid_view">
+          <li>
+            <div class="item">
+              <div class="pic"><em>1</em></div>
+              <div class="info">
+                <div class="hd"><a href="https://movie.douban.com/subject/1292052/"><span class="title">肖申克的救赎</span></a></div>
+                <div class="bd">
+                  <p>1994 / 美国 / 犯罪 剧情</p>
+                  <div class="star"><span class="rating_num">9.7</span></div>
+                  <p class="quote"><span class="inq">希望让人自由。</span></p>
+                </div>
+              </div>
+            </div>
+          </li>
+        </ol>
+        </body></html>
+        """
+        movies = mod.parse_top250_page(html)
+        assert len(movies) == 1
+        assert movies[0]["rank"] == 1
+        assert movies[0]["title"] == "肖申克的救赎"
+        assert movies[0]["rating"] == 9.7
+        assert movies[0]["quote"] == "希望让人自由。"
+
+    def test_parse_empty_html(self):
+        html = "<html><body><ol class='grid_view'></ol></body></html>"
+        movies = mod.parse_top250_page(html)
+        assert movies == []

--- a/skills/douban/tests/test_hot.py
+++ b/skills/douban/tests/test_hot.py
@@ -1,0 +1,73 @@
+"""Tests for douban/scripts/douban_hot.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("douban", "douban_hot")
+
+SAMPLE_MOVIE = {
+    "id": "35267208",
+    "title": "流浪地球2",
+    "original_title": "The Wandering Earth II",
+    "year": "2023",
+    "rating": {"value": 8.3, "count": 800000},
+    "genres": ["科幻", "冒险"],
+    "directors": [{"name": "郭帆"}],
+    "actors": [{"name": "吴京"}, {"name": "刘德华"}],
+    "intro": "太阳即将毁灭...",
+    "pic": {"normal": "https://img.doubanio.com/small.jpg", "large": "https://img.doubanio.com/large.jpg"},
+    "url": "https://movie.douban.com/subject/35267208/",
+    "card_subtitle": "2023 / 中国大陆 / 科幻 冒险",
+}
+
+
+class TestGetHot:
+    @responses.activate
+    def test_hot_movies(self):
+        responses.get(
+            url=re.compile(r"https://frodo\.douban\.com/api/v2/movie/hot_gird"),
+            json={"items": [SAMPLE_MOVIE]},
+            status=200,
+        )
+        result = mod.get_hot(category="hot", limit=10)
+        assert result["category"] == "hot"
+        assert result["count"] == 1
+        movie = result["movies"][0]
+        assert movie["id"] == "35267208"
+        assert movie["title"] == "流浪地球2"
+
+    @responses.activate
+    def test_showing_movies(self):
+        responses.get(
+            url=re.compile(r"https://frodo\.douban\.com/api/v2/movie/movie_showing"),
+            json={"items": [SAMPLE_MOVIE]},
+            status=200,
+        )
+        result = mod.get_hot(category="showing")
+        assert result["category"] == "showing"
+        assert result["count"] == 1
+
+    @responses.activate
+    def test_coming_movies(self):
+        responses.get(
+            url=re.compile(r"https://frodo\.douban\.com/api/v2/movie/movie_soon"),
+            json={"subject_collection_items": [SAMPLE_MOVIE]},
+            status=200,
+        )
+        result = mod.get_hot(category="coming")
+        assert result["category"] == "coming"
+        assert result["count"] == 1
+
+    @responses.activate
+    def test_empty_result(self):
+        responses.get(
+            url=re.compile(r"https://frodo\.douban\.com/api/v2/movie/hot_gird"),
+            json={"items": []},
+            status=200,
+        )
+        result = mod.get_hot()
+        assert result["count"] == 0
+        assert result["movies"] == []

--- a/skills/douban/tests/test_movie.py
+++ b/skills/douban/tests/test_movie.py
@@ -1,0 +1,86 @@
+"""Tests for douban/scripts/douban_movie.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("douban", "douban_movie")
+
+SAMPLE_MOVIE = {
+    "id": "1292052",
+    "title": "肖申克的救赎",
+    "original_title": "The Shawshank Redemption",
+    "year": "1994",
+    "rating": {"value": 9.7, "count": 2500000},
+    "genres": ["剧情", "犯罪"],
+    "directors": [{"name": "弗兰克·德拉邦特"}],
+    "actors": [{"name": "蒂姆·罗宾斯"}, {"name": "摩根·弗里曼"}],
+    "intro": "一场冤狱引出了一段传奇。",
+    "pic": {"normal": "https://img.doubanio.com/small.jpg", "large": "https://img.doubanio.com/large.jpg"},
+    "url": "https://movie.douban.com/subject/1292052/",
+    "card_subtitle": "1994 / 美国 / 剧情 犯罪",
+}
+
+SAMPLE_INTEREST = {
+    "rating": {"value": 5},
+    "comment": "经典之作，百看不厌",
+    "create_time": "2026-01-01 10:00:00",
+    "user": {"name": "filmfan"},
+    "useful_count": 42,
+}
+
+
+class TestGetMovie:
+    @responses.activate
+    def test_movie_detail(self):
+        responses.get(
+            url=re.compile(r"https://frodo\.douban\.com/api/v2/movie/1292052"),
+            json=SAMPLE_MOVIE,
+            status=200,
+        )
+        result = mod.get_movie("1292052")
+        movie = result["movie"]
+        assert movie["id"] == "1292052"
+        assert movie["title"] == "肖申克的救赎"
+        assert movie["year"] == "1994"
+        assert movie["rating"] == 9.7
+        assert movie["directors"] == ["弗兰克·德拉邦特"]
+        assert movie["actors"] == ["蒂姆·罗宾斯", "摩根·弗里曼"]
+        assert "reviews" not in result
+
+    @responses.activate
+    def test_movie_with_reviews(self):
+        responses.get(
+            url=re.compile(r"https://frodo\.douban\.com/api/v2/movie/1292052\b(?!/)"),
+            json=SAMPLE_MOVIE,
+            status=200,
+        )
+        responses.get(
+            url=re.compile(r"https://frodo\.douban\.com/api/v2/movie/1292052/interests"),
+            json={"interests": [SAMPLE_INTEREST]},
+            status=200,
+        )
+        result = mod.get_movie("1292052", include_reviews=True)
+        assert result["movie"]["title"] == "肖申克的救赎"
+        assert len(result["reviews"]) == 1
+        review = result["reviews"][0]
+        assert review["comment"] == "经典之作，百看不厌"
+        assert review["user"] == "filmfan"
+        assert review["rating"] == 5
+
+    @responses.activate
+    def test_movie_no_reviews_data(self):
+        responses.get(
+            url=re.compile(r"https://frodo\.douban\.com/api/v2/movie/999\b(?!/)"),
+            json=SAMPLE_MOVIE,
+            status=200,
+        )
+        responses.get(
+            url=re.compile(r"https://frodo\.douban\.com/api/v2/movie/999/interests"),
+            json={"interests": []},
+            status=200,
+        )
+        result = mod.get_movie("999", include_reviews=True)
+        assert result["reviews"] == []

--- a/skills/douban/tests/test_music.py
+++ b/skills/douban/tests/test_music.py
@@ -1,0 +1,49 @@
+"""Tests for douban/scripts/douban_music.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("douban", "douban_music")
+
+SAMPLE_MUSIC = {
+    "id": "1401853",
+    "title": "范特西",
+    "rating": {"value": 9.2, "count": 120000},
+    "intro": "周杰伦的第二张专辑。",
+    "pic": {"normal": "https://img.doubanio.com/small.jpg", "large": "https://img.doubanio.com/large.jpg"},
+    "url": "https://music.douban.com/subject/1401853/",
+    "attrs": {"singer": ["周杰伦"], "publisher": ["BMG"]},
+}
+
+
+class TestGetMusic:
+    @responses.activate
+    def test_music_detail(self):
+        responses.get(
+            url=re.compile(r"https://frodo\.douban\.com/api/v2/music/1401853"),
+            json=SAMPLE_MUSIC,
+            status=200,
+        )
+        result = mod.get_music("1401853")
+        music = result["music"]
+        assert music["id"] == "1401853"
+        assert music["title"] == "范特西"
+        assert music["rating"] == 9.2
+        assert music["singer"] == ["周杰伦"]
+        assert music["publisher"] == ["BMG"]
+
+    @responses.activate
+    def test_music_missing_attrs(self):
+        music_data = {**SAMPLE_MUSIC, "attrs": None}
+        responses.get(
+            url=re.compile(r"https://frodo\.douban\.com/api/v2/music/999"),
+            json=music_data,
+            status=200,
+        )
+        result = mod.get_music("999")
+        music = result["music"]
+        assert music["singer"] == []
+        assert music["publisher"] == []

--- a/skills/douban/tests/test_search.py
+++ b/skills/douban/tests/test_search.py
@@ -1,0 +1,101 @@
+"""Tests for douban/scripts/douban_search.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("douban", "douban_search")
+
+SAMPLE_MOVIE = {
+    "id": "1292052",
+    "title": "肖申克的救赎",
+    "original_title": "The Shawshank Redemption",
+    "year": "1994",
+    "rating": {"value": 9.7, "count": 2500000},
+    "genres": ["剧情", "犯罪"],
+    "directors": [{"name": "弗兰克·德拉邦特"}],
+    "actors": [{"name": "蒂姆·罗宾斯"}, {"name": "摩根·弗里曼"}],
+    "intro": "一场冤狱引出了一段传奇。",
+    "pic": {"normal": "https://img.doubanio.com/small.jpg", "large": "https://img.doubanio.com/large.jpg"},
+    "url": "https://movie.douban.com/subject/1292052/",
+    "card_subtitle": "1994 / 美国 / 剧情 犯罪",
+}
+
+SAMPLE_BOOK = {
+    "id": "2567698",
+    "title": "三体",
+    "subtitle": "地球往事",
+    "author": ["刘慈欣"],
+    "publisher": "重庆出版社",
+    "pubdate": "2008-1",
+    "pages": "302",
+    "rating": {"value": 8.8, "count": 500000},
+    "intro": "文化大革命如火如荼进行的同时...",
+    "pic": {"normal": "https://img.doubanio.com/small.jpg", "large": "https://img.doubanio.com/large.jpg"},
+    "url": "https://book.douban.com/subject/2567698/",
+}
+
+
+class TestSearch:
+    @responses.activate
+    def test_search_movie(self):
+        responses.get(
+            url=re.compile(r"https://frodo\.douban\.com/api/v2/search"),
+            json={
+                "total": 1,
+                "items": [{"target_type": "movie", "target": SAMPLE_MOVIE}],
+            },
+            status=200,
+        )
+        result = mod.search("肖申克的救赎", search_type="movie", limit=5)
+        assert result["total"] == 1
+        assert result["count"] == 1
+        item = result["items"][0]
+        assert item["id"] == "1292052"
+        assert item["title"] == "肖申克的救赎"
+        assert item["target_type"] == "movie"
+        assert item["rating"] == 9.7
+
+    @responses.activate
+    def test_search_book(self):
+        responses.get(
+            url=re.compile(r"https://frodo\.douban\.com/api/v2/search"),
+            json={
+                "total": 1,
+                "items": [{"target_type": "book", "target": SAMPLE_BOOK}],
+            },
+            status=200,
+        )
+        result = mod.search("三体", search_type="book")
+        assert result["count"] == 1
+        item = result["items"][0]
+        assert item["title"] == "三体"
+        assert item["target_type"] == "book"
+
+    @responses.activate
+    def test_search_empty(self):
+        responses.get(
+            url=re.compile(r"https://frodo\.douban\.com/api/v2/search"),
+            json={"total": 0, "items": []},
+            status=200,
+        )
+        result = mod.search("nonexistent_query_xyz")
+        assert result["total"] == 0
+        assert result["count"] == 0
+        assert result["items"] == []
+
+    @responses.activate
+    def test_search_unknown_type_skipped(self):
+        responses.get(
+            url=re.compile(r"https://frodo\.douban\.com/api/v2/search"),
+            json={
+                "total": 1,
+                "items": [{"target_type": "unknown", "target": {"id": "1"}}],
+            },
+            status=200,
+        )
+        result = mod.search("test")
+        assert result["count"] == 0
+        assert result["items"] == []

--- a/skills/douban/tests/test_top250.py
+++ b/skills/douban/tests/test_top250.py
@@ -1,0 +1,105 @@
+"""Tests for douban/scripts/douban_top250.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("douban", "douban_top250")
+
+SAMPLE_HTML = """
+<html>
+<body>
+<ol class="grid_view">
+  <li>
+    <div class="item">
+      <div class="pic">
+        <em>1</em>
+      </div>
+      <div class="info">
+        <div class="hd">
+          <a href="https://movie.douban.com/subject/1292052/">
+            <span class="title">肖申克的救赎</span>
+          </a>
+        </div>
+        <div class="bd">
+          <p>导演: 弗兰克·德拉邦特 主演: 蒂姆·罗宾斯 / 摩根·弗里曼 1994 / 美国 / 犯罪 剧情</p>
+          <div class="star">
+            <span class="rating_num">9.7</span>
+          </div>
+          <p class="quote"><span class="inq">希望让人自由。</span></p>
+        </div>
+      </div>
+    </div>
+  </li>
+  <li>
+    <div class="item">
+      <div class="pic">
+        <em>2</em>
+      </div>
+      <div class="info">
+        <div class="hd">
+          <a href="https://movie.douban.com/subject/1291546/">
+            <span class="title">霸王别姬</span>
+          </a>
+        </div>
+        <div class="bd">
+          <p>导演: 陈凯歌 主演: 张国荣 / 张丰毅 1993 / 中国大陆 / 剧情 爱情</p>
+          <div class="star">
+            <span class="rating_num">9.6</span>
+          </div>
+          <p class="quote"><span class="inq">风华绝代。</span></p>
+        </div>
+      </div>
+    </div>
+  </li>
+</ol>
+</body>
+</html>
+"""
+
+
+class TestGetTop250:
+    @responses.activate
+    def test_top250_page1(self):
+        responses.get(
+            url=re.compile(r"https://movie\.douban\.com/top250"),
+            body=SAMPLE_HTML,
+            status=200,
+        )
+        result = mod.get_top250(page=1)
+        assert result["page"] == 1
+        assert result["count"] == 2
+        first = result["movies"][0]
+        assert first["rank"] == 1
+        assert first["title"] == "肖申克的救赎"
+        assert first["rating"] == 9.7
+        assert first["quote"] == "希望让人自由。"
+        assert "1292052" in first["url"]
+        second = result["movies"][1]
+        assert second["rank"] == 2
+        assert second["title"] == "霸王别姬"
+        assert second["rating"] == 9.6
+
+    @responses.activate
+    def test_top250_empty_page(self):
+        responses.get(
+            url=re.compile(r"https://movie\.douban\.com/top250"),
+            body="<html><body><ol class='grid_view'></ol></body></html>",
+            status=200,
+        )
+        result = mod.get_top250(page=10)
+        assert result["page"] == 10
+        assert result["count"] == 0
+        assert result["movies"] == []
+
+    @responses.activate
+    def test_top250_page_offset(self):
+        responses.get(
+            url=re.compile(r"https://movie\.douban\.com/top250"),
+            body=SAMPLE_HTML,
+            status=200,
+        )
+        mod.get_top250(page=3)
+        assert "start=50" in responses.calls[0].request.url

--- a/skills/douban/tests/test_user.py
+++ b/skills/douban/tests/test_user.py
@@ -1,0 +1,56 @@
+"""Tests for douban/scripts/douban_user.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("douban", "douban_user")
+
+SAMPLE_USER = {
+    "id": "1000001",
+    "name": "阿北",
+    "uid": "ahbei",
+    "avatar": "https://img.doubanio.com/icon/u1000001.jpg",
+    "intro": "豆瓣创始人",
+    "url": "https://www.douban.com/people/ahbei/",
+}
+
+
+class TestGetUser:
+    @responses.activate
+    def test_user_profile(self):
+        responses.get(
+            url=re.compile(r"https://frodo\.douban\.com/api/v2/user/ahbei"),
+            json=SAMPLE_USER,
+            status=200,
+        )
+        result = mod.get_user("ahbei")
+        user = result["user"]
+        assert user["id"] == "1000001"
+        assert user["name"] == "阿北"
+        assert user["uid"] == "ahbei"
+        assert user["intro"] == "豆瓣创始人"
+
+    @responses.activate
+    def test_user_numeric_id(self):
+        responses.get(
+            url=re.compile(r"https://frodo\.douban\.com/api/v2/user/1000001"),
+            json=SAMPLE_USER,
+            status=200,
+        )
+        result = mod.get_user("1000001")
+        assert result["user"]["name"] == "阿北"
+
+    @responses.activate
+    def test_user_empty_fields(self):
+        user_data = {"id": "2", "name": "", "uid": "empty", "avatar": "", "intro": "", "url": ""}
+        responses.get(
+            url=re.compile(r"https://frodo\.douban\.com/api/v2/user/empty"),
+            json=user_data,
+            status=200,
+        )
+        result = mod.get_user("empty")
+        assert result["user"]["id"] == "2"
+        assert result["user"]["name"] == ""


### PR DESCRIPTION
## Summary
- Add complete Douban (豆瓣) skill with 8 scripts covering search, movie/book/music detail, hot movies, Top 250, and user profiles
- Uses Douban's Frodo mobile API for structured data and HTML scraping with BeautifulSoup for Top 250
- Includes 35 tests with full mocked HTTP responses covering all scripts and parsers

## Test plan
- [x] `ruff check douban/` passes clean
- [x] `pytest douban/tests/ -v` — all 35 tests pass
- [ ] Manual smoke test with live Douban API endpoints