### PR TITLE
fix(cli): replace import attributes with createRequire for Node 18 compat

### DIFF
--- a/cli/src/core/constants.ts
+++ b/cli/src/core/constants.ts
@@ -1,4 +1,6 @@
-import pkg from '../../package.json' with { type: 'json' };
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const pkg = require('../../package.json');
 
 /**
  * Shared constants for SigCLI.


### PR DESCRIPTION
## Summary
- `import ... with { type: 'json' }` in `cli/src/core/constants.ts` requires Node >= 20.10, but the project targets Node >= 18
- Replaced with `createRequire` from `node:module`, which works on all Node >= 12
- Fixes `SyntaxError: Unexpected token 'with'` on early Node 18.x versions

## Test plan
- [x] Reproduced crash on Node 18.13.0
- [x] Verified fix works on Node 18.13.0 and Node 22.16.0
- [x] All 666 tests pass (52 test files)
- [x] `sig init`, `sig --version` work on both Node versions