### PR TITLE
chore(cli): bump version to 1.2.2

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sigcli/cli",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "General-purpose authentication CLI with pluggable strategies and browser adapters",
     "main": "dist/index.js",
     "type": "module",


### PR DESCRIPTION
## Summary
- Bump CLI version to 1.2.2 for patch release
- Includes fix from #51 (Node 18 import attributes compat)

## Test plan
- [x] 666 tests pass
- [x] Build succeeds