### PR TITLE
feat(reddit): add flair support to submit script

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sigcli/cli",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "General-purpose authentication CLI with pluggable strategies and browser adapters",
     "main": "dist/index.js",
     "type": "module",

--- a/skills/reddit/SKILL.md
+++ b/skills/reddit/SKILL.md
@@ -148,6 +148,8 @@ All scripts are in this skill's `scripts/` directory. Run via Bash tool.
 --kind KIND           Post type: self, link (default: self)
 --text TEXT           Post body text (for self posts)
 --url URL             URL to share (for link posts)
+--flair-id ID         Flair template ID (from subreddit flair list)
+--flair-text TEXT     Flair text
 ```
 
 ### reddit_manage.py

--- a/skills/reddit/scripts/reddit_submit.py
+++ b/skills/reddit/scripts/reddit_submit.py
@@ -9,7 +9,7 @@ import requests
 from reddit_client import RedditApiError, RedditClient
 
 
-def submit_post(cookie: str, subreddit: str, title: str, kind: str = "self", text: str = "", url: str = "") -> dict:
+def submit_post(cookie: str, subreddit: str, title: str, kind: str = "self", text: str = "", url: str = "", flair_id: str = "", flair_text: str = "") -> dict:
     """Submit a new post to a subreddit."""
     client = RedditClient(cookie)
     client.require_cookie()
@@ -24,6 +24,10 @@ def submit_post(cookie: str, subreddit: str, title: str, kind: str = "self", tex
         data["text"] = text
     elif kind == "link":
         data["url"] = url
+    if flair_id:
+        data["flair_id"] = flair_id
+    if flair_text:
+        data["flair_text"] = flair_text
 
     resp = client.oauth_post("/api/submit", data=data)
 
@@ -50,10 +54,12 @@ def main():
     parser.add_argument("--kind", default="self", choices=["self", "link"], help="Post type (default: self)")
     parser.add_argument("--text", default="", help="Post body text (for self posts)")
     parser.add_argument("--url", default="", help="URL to share (for link posts)")
+    parser.add_argument("--flair-id", default="", help="Flair template ID (from subreddit flair list)")
+    parser.add_argument("--flair-text", default="", help="Flair text")
     args = parser.parse_args()
 
     try:
-        result = submit_post(args.cookie, args.subreddit, args.title, args.kind, args.text, args.url)
+        result = submit_post(args.cookie, args.subreddit, args.title, args.kind, args.text, args.url, args.flair_id, args.flair_text)
         json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
     except RedditApiError as e:
         json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)

--- a/skills/reddit/scripts/reddit_submit.py
+++ b/skills/reddit/scripts/reddit_submit.py
@@ -9,7 +9,10 @@ import requests
 from reddit_client import RedditApiError, RedditClient
 
 
-def submit_post(cookie: str, subreddit: str, title: str, kind: str = "self", text: str = "", url: str = "", flair_id: str = "", flair_text: str = "") -> dict:
+def submit_post(
+    cookie: str, subreddit: str, title: str, kind: str = "self",
+    text: str = "", url: str = "", flair_id: str = "", flair_text: str = "",
+) -> dict:
     """Submit a new post to a subreddit."""
     client = RedditClient(cookie)
     client.require_cookie()


### PR DESCRIPTION
## Summary

- Add `--flair-id` and `--flair-text` args to `reddit_submit.py`
- Some subreddits (e.g. r/ClaudeAI) require post flair — without this, submit fails with `SUBMIT_VALIDATION_FLAIR_REQUIRED`
- Update SKILL.md docs for the new args

## Test plan

- [x] 49/49 unit tests pass
- [x] Live tested: submitted a post to r/ClaudeAI with "Built with Claude" flair