### PR TITLE
feat(x): add X (Twitter) skill

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sigcli/cli",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "General-purpose authentication CLI with pluggable strategies and browser adapters",
     "main": "dist/index.js",
     "type": "module",

--- a/skills/x/SKILL.md
+++ b/skills/x/SKILL.md
@@ -157,6 +157,18 @@ All scripts are in this skill's `scripts/` directory. Run via Bash tool.
 
 **`x_like.py`, `x_retweet.py`, `x_follow.py`, and `x_bookmark.py` are reversible** — use `--undo` to reverse the action.
 
+## Known Limitations
+
+**Verified live** (working): `x_user.py`, `x_tweets.py`, `x_tweet.py`, `x_trending.py`
+
+**Not yet verified live** (unit-tested only): `x_search.py`, `x_followers.py`, `x_post.py`, `x_like.py`, `x_retweet.py`, `x_follow.py`, `x_bookmark.py`. These scripts follow the same GraphQL patterns as the verified ones but have not been tested against the live API. If you encounter issues, please open an issue or PR.
+
+**Query ID rotation** — X rotates GraphQL query IDs with each deployment. The client auto-resolves fresh IDs from X's JS bundles and caches them for 1 hour. If a request returns 404, it may be a stale query ID — restart the script to force a refresh.
+
+**Account restrictions** — Some endpoints (search, followers) may return 404 for accounts that are new, unverified, or suspended. This is an X-side restriction, not a script bug.
+
+**Login caution** — Using `sig login https://x.com/` (headless browser) can trigger X's bot detection and result in account suspension. Prefer `sig login --cookie "..."` with cookies copied from a real browser session.
+
 ## Key Concepts
 
 **Screen names** — Always pass without the `@` prefix. Use `elonmusk` not `@elonmusk`.

--- a/skills/x/SKILL.md
+++ b/skills/x/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: x
+description: 'Interact with X (Twitter) — view profiles, read tweets and threads, search posts, check trending topics, view followers, post tweets, like, retweet, follow users, and bookmark tweets. Use this skill whenever the user mentions X, Twitter, tweets, @handles, wants to browse X posts, search X, view user profiles, or interact with X content. Also trigger when the user pastes an x.com or twitter.com URL.'
+---
+
+# X (Twitter)
+
+View profiles, read tweets, search posts, check trending topics, and interact with X/Twitter.
+
+## Authentication
+
+**Read operations** (user profile, tweets, tweet detail, search) use X's public bearer token — no session cookie needed.
+
+**Write operations** (post, like, retweet, follow, bookmark) and some read operations (trending, followers) require a **session cookie**. Use `sig run` to inject it:
+
+```bash
+sig run x -- bash -c 'python3 scripts/x_like.py --cookie "$SIG_X_COOKIE" --id 12345'
+```
+
+The default Signet provider is `x`. The env var is `SIG_X_COOKIE`.
+
+If a script returns an auth error, re-authenticate:
+
+```bash
+sig login https://x.com/
+```
+
+**Note:** X's login page may block automated browsers. If `sig login` fails, copy the cookie manually:
+
+1. Open https://x.com/ in your browser and log in
+2. Open DevTools (F12) → Application → Cookies → `x.com`
+3. Copy the full cookie string (you need at least `ct0` and `auth_token`)
+4. Run: `sig login https://x.com/ --as x --cookie "ct0=<your-ct0>; auth_token=<your-token>"`
+
+**Signet provider config:**
+
+```yaml
+x:
+    domains: ['x.com', 'twitter.com']
+    entryUrl: https://x.com/i/flow/login
+    strategy: cookie
+    config:
+        ttl: '7d'
+        requiredCookies: ['ct0', 'auth_token']
+```
+
+## Scripts Reference
+
+All scripts are in this skill's `scripts/` directory. Run via Bash tool.
+
+### Read Operations
+
+| Script           | Purpose                | Auth     |
+| ---------------- | ---------------------- | -------- |
+| `x_user.py`      | User profile           | None     |
+| `x_tweets.py`    | User's tweet timeline  | None     |
+| `x_tweet.py`     | Single tweet + thread  | None     |
+| `x_search.py`    | Search tweets          | None     |
+| `x_trending.py`  | Trending topics        | Required |
+| `x_followers.py` | Followers or following | Required |
+
+### Write Operations
+
+| Script          | Purpose                | Auth     |
+| --------------- | ---------------------- | -------- |
+| `x_post.py`     | Create a tweet         | Required |
+| `x_like.py`     | Like or unlike         | Required |
+| `x_retweet.py`  | Retweet or unretweet   | Required |
+| `x_follow.py`   | Follow or unfollow     | Required |
+| `x_bookmark.py` | Bookmark or unbookmark | Required |
+
+### x_user.py
+
+```
+--username NAME       Screen name without @ (required)
+```
+
+### x_tweets.py
+
+```
+--username NAME       Screen name with or without @ (required)
+--limit N             Max tweets to return (default: 20)
+```
+
+### x_tweet.py
+
+```
+--id ID               Tweet ID or full URL (required)
+--limit N             Max tweets in thread (default: 50)
+```
+
+### x_search.py
+
+```
+--query TEXT          Search query (required)
+--limit N            Max results (default: 20)
+--type TYPE          Result type: latest, top (default: latest)
+```
+
+### x_trending.py
+
+```
+--limit N            Number of trends (default: 20)
+```
+
+### x_followers.py
+
+```
+--username NAME       Screen name without @ (required)
+--limit N             Max users (default: 50)
+--mode MODE           List type: followers, following (default: followers)
+```
+
+### x_post.py
+
+```
+--cookie COOKIE       X session cookie (required)
+--text TEXT           Tweet text content (required)
+--reply-to ID        Tweet ID to reply to (optional)
+```
+
+### x_like.py
+
+```
+--cookie COOKIE       X session cookie (required)
+--id ID               Tweet ID or URL (required)
+--undo                Unlike instead of like (flag)
+```
+
+### x_retweet.py
+
+```
+--cookie COOKIE       X session cookie (required)
+--id ID               Tweet ID or URL (required)
+--undo                Undo retweet (flag)
+```
+
+### x_follow.py
+
+```
+--cookie COOKIE       X session cookie (required)
+--username NAME       Screen name without @ (required)
+--undo                Unfollow instead of follow (flag)
+```
+
+### x_bookmark.py
+
+```
+--cookie COOKIE       X session cookie (required)
+--id ID               Tweet ID or URL (required)
+--undo                Remove bookmark (flag)
+```
+
+## Safety
+
+**Always show the user the tweet text and get explicit confirmation before calling `x_post.py`.** Tweets are public.
+
+**`x_like.py`, `x_retweet.py`, `x_follow.py`, and `x_bookmark.py` are reversible** — use `--undo` to reverse the action.
+
+## Key Concepts
+
+**Screen names** — Always pass without the `@` prefix. Use `elonmusk` not `@elonmusk`.
+
+**Tweet IDs** — Scripts accept bare IDs (`12345`) or full URLs (`https://x.com/user/status/12345`). The ID is extracted automatically.
+
+**GraphQL API** — X uses a GraphQL API with operation-specific query IDs. These IDs may change periodically; the client includes fallback defaults.
+
+**ct0 CSRF token** — Write operations require the `ct0` cookie value as a CSRF token. The client extracts it automatically from the session cookie.
+
+**Bearer token** — X uses a public bearer token embedded in its frontend JS. This is the same for all users and is used for all API requests.
+
+**Pagination** — Timeline endpoints support cursor-based pagination handled internally by the scripts (up to 5 pages).
+
+## Error Handling
+
+| Error         | Cause                     | Fix                            |
+| ------------- | ------------------------- | ------------------------------ |
+| HTTP_401      | Invalid or expired cookie | Run `sig login https://x.com/` |
+| HTTP_403      | Rate limited or blocked   | Wait and retry                 |
+| HTTP_429      | Rate limited              | Wait a few seconds and retry   |
+| NOT_FOUND     | User or tweet not found   | Check the ID or username       |
+| AUTH_REQUIRED | No cookie for write op    | Run `sig login` and retry      |
+| POST_FAILED   | Tweet creation failed     | Check error details            |
+| PARSE_ERROR   | Unexpected API response   | API may have changed           |
+
+## Workflow Examples
+
+### View a user profile
+
+1. `python3 scripts/x_user.py --username elonmusk`
+
+### Read recent tweets
+
+1. `python3 scripts/x_tweets.py --username elonmusk --limit 10`
+
+### Read a tweet thread
+
+1. `python3 scripts/x_tweet.py --id 12345678 --limit 30`
+2. Or with URL: `python3 scripts/x_tweet.py --id "https://x.com/user/status/12345678"`
+
+### Search for tweets
+
+1. `python3 scripts/x_search.py --query "machine learning" --type top --limit 10`
+
+### Check trending topics
+
+1. `sig run x -- python3 scripts/x_trending.py --limit 10`
+
+### View followers
+
+1. `sig run x -- bash -c 'python3 scripts/x_followers.py --username elonmusk --limit 20 --mode followers'`
+
+### Post a tweet
+
+1. **Show tweet text to user and get confirmation**
+2. `sig run x -- bash -c 'python3 scripts/x_post.py --cookie "$SIG_X_COOKIE" --text "Hello from sigcli!"'`
+
+### Like a tweet
+
+1. `sig run x -- bash -c 'python3 scripts/x_like.py --cookie "$SIG_X_COOKIE" --id 12345'`
+
+### Retweet
+
+1. `sig run x -- bash -c 'python3 scripts/x_retweet.py --cookie "$SIG_X_COOKIE" --id 12345'`
+
+### Follow a user
+
+1. `sig run x -- bash -c 'python3 scripts/x_follow.py --cookie "$SIG_X_COOKIE" --username elonmusk'`
+
+### Bookmark a tweet
+
+1. `sig run x -- bash -c 'python3 scripts/x_bookmark.py --cookie "$SIG_X_COOKIE" --id 12345'`

--- a/skills/x/scripts/x_bookmark.py
+++ b/skills/x/scripts/x_bookmark.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Bookmark or unbookmark a tweet on X (Twitter)."""
+
+import argparse
+import json
+import sys
+
+import requests
+from x_client import XApiError, XClient, resolve_tweet_id
+
+
+def bookmark_tweet(cookie: str, tweet_id: str, undo: bool = False) -> dict:
+    """Bookmark or unbookmark a tweet."""
+    client = XClient(cookie)
+    client.require_cookie()
+
+    operation = "DeleteBookmark" if undo else "CreateBookmark"
+    variables = {"tweet_id": tweet_id}
+    client.graphql_post(operation, variables)
+
+    action = "unbookmarked" if undo else "bookmarked"
+    return {
+        "success": True,
+        "tweet_id": tweet_id,
+        "action": action,
+        "message": f"Tweet {action} successfully",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Bookmark or unbookmark a tweet on X")
+    parser.add_argument("--cookie", required=True, help="X session cookie")
+    parser.add_argument("--id", required=True, help="Tweet ID or URL")
+    parser.add_argument("--undo", action="store_true", help="Remove bookmark")
+    args = parser.parse_args()
+
+    try:
+        tweet_id = resolve_tweet_id(args.id)
+        result = bookmark_tweet(args.cookie, tweet_id, args.undo)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except XApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/x/scripts/x_client.py
+++ b/skills/x/scripts/x_client.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Shared X (Twitter) GraphQL client for X skill scripts.
+
+Handles HTTP transport with bearer auth, CSRF token extraction,
+rate-limit retries, and response normalization for X's GraphQL API.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+import urllib.parse
+
+import requests
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+GRAPHQL_BASE = "https://x.com/i/api/graphql"
+BEARER_TOKEN = "AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA"
+USER_AGENT = "sigcli-skill/1.0"
+TIMEOUT = 20
+
+# ---------------------------------------------------------------------------
+# Query IDs (fallback defaults — may need periodic updates)
+# ---------------------------------------------------------------------------
+
+QUERY_IDS = {
+    "UserByScreenName": "qRednkZG-rn1P6b48NINmQ",
+    "UserTweets": "Y59DTUMfcKmUAATiT2SlTw",
+    "TweetDetail": "nBS-WpgA6ZG0CyNHD517JQ",
+    "SearchTimeline": "MJnbGFOB_MF-5ywMj2FdTg",
+    "Followers": "rRXFSG5vR6drKr5M37YOTw",
+    "Following": "iSicc7LrzWGBgDPL0tM_TQ",
+    "CreateTweet": "bDE2rBtZb3uyrczSZ_pI9g",
+    "FavoriteTweet": "lI07N6OaolGPl9u_Z1FxcA",
+    "UnfavoriteTweet": "ZYKSe-w7KEslx3JhSIk5LA",
+    "CreateRetweet": "ojPdsZsimiJrUGLR1sjUtA",
+    "DeleteRetweet": "iQtK4dl5hBmXewYZuEOKVw",
+    "CreateBookmark": "aaDnft_gKxX4OWoR900UMQ",
+    "DeleteBookmark": "Wlmlj2-xISz1HUqEPgNxVQ",
+}
+
+# ---------------------------------------------------------------------------
+# Feature flags (required by most GraphQL endpoints)
+# ---------------------------------------------------------------------------
+
+FEATURES_USER = {
+    "hidden_profile_subscriptions_enabled": True,
+    "rweb_tipjar_consumption_enabled": True,
+    "responsive_web_graphql_exclude_directive_enabled": True,
+    "verified_phone_label_enabled": False,
+    "subscriptions_verification_info_is_identity_verified_enabled": True,
+    "subscriptions_verification_info_verified_since_enabled": True,
+    "highlights_tweets_tab_ui_enabled": True,
+    "responsive_web_twitter_article_notes_tab_enabled": True,
+    "subscriptions_feature_can_gift_premium": True,
+    "creator_subscriptions_tweet_preview_api_enabled": True,
+    "responsive_web_graphql_skip_user_profile_image_extensions_enabled": False,
+    "responsive_web_graphql_timeline_navigation_enabled": True,
+}
+
+FEATURES_TIMELINE = {
+    "rweb_tipjar_consumption_enabled": True,
+    "responsive_web_graphql_exclude_directive_enabled": True,
+    "verified_phone_label_enabled": False,
+    "creator_subscriptions_tweet_preview_api_enabled": True,
+    "responsive_web_graphql_timeline_navigation_enabled": True,
+    "responsive_web_graphql_skip_user_profile_image_extensions_enabled": False,
+    "communities_web_enable_tweet_community_results_fetch": True,
+    "c9s_tweet_anatomy_moderator_badge_enabled": True,
+    "articles_preview_enabled": True,
+    "responsive_web_edit_tweet_api_enabled": True,
+    "graphql_is_translatable_rweb_tweet_is_translatable_enabled": True,
+    "view_counts_everywhere_api_enabled": True,
+    "longform_notetweets_consumption_enabled": True,
+    "responsive_web_twitter_article_tweet_consumption_enabled": True,
+    "tweet_awards_web_tipping_enabled": False,
+    "freedom_of_speech_not_reach_fetch_enabled": True,
+    "standardized_nudges_misinfo": True,
+    "tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled": True,
+    "longform_notetweets_rich_text_read_enabled": True,
+    "longform_notetweets_inline_media_enabled": True,
+    "responsive_web_enhance_cards_enabled": False,
+}
+
+FEATURES_TWEET_DETAIL = {
+    "responsive_web_graphql_exclude_directive_enabled": True,
+    "verified_phone_label_enabled": False,
+    "creator_subscriptions_tweet_preview_api_enabled": True,
+    "responsive_web_graphql_timeline_navigation_enabled": True,
+    "responsive_web_graphql_skip_user_profile_image_extensions_enabled": False,
+    "longform_notetweets_consumption_enabled": True,
+    "longform_notetweets_rich_text_read_enabled": True,
+    "longform_notetweets_inline_media_enabled": True,
+    "freedom_of_speech_not_reach_fetch_enabled": True,
+}
+
+FIELD_TOGGLES_TWEET_DETAIL = {
+    "withArticleRichContentState": True,
+    "withArticlePlainText": False,
+}
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class XApiError(Exception):
+    """Raised when X returns an unexpected response."""
+
+    def __init__(self, code: str, message: str = ""):
+        self.code = code
+        self.message = message or code
+        super().__init__(self.message)
+
+
+def error_response(code: str, message: str) -> dict:
+    return {"error": code, "message": message}
+
+
+# ---------------------------------------------------------------------------
+# X GraphQL API client
+# ---------------------------------------------------------------------------
+
+
+class XClient:
+    """HTTP client for X's GraphQL API with cookie auth.
+
+    Read operations need only the bearer token (public).
+    Write operations require a session cookie with ct0 CSRF token.
+    """
+
+    def __init__(self, cookie: str = ""):
+        self.cookie = cookie
+        self._session = requests.Session()
+        self._ct0 = self._extract_ct0(cookie) if cookie else ""
+        self._session.headers.update({
+            "User-Agent": USER_AGENT,
+            "Authorization": f"Bearer {urllib.parse.unquote(BEARER_TOKEN)}",
+            "X-Twitter-Active-User": "yes",
+            "X-Twitter-Client-Language": "en",
+        })
+        if cookie:
+            self._session.headers["Cookie"] = cookie
+        if self._ct0:
+            self._session.headers["X-Csrf-Token"] = self._ct0
+            self._session.headers["X-Twitter-Auth-Type"] = "OAuth2Session"
+
+    @classmethod
+    def create(cls) -> "XClient":
+        cookie = os.environ.get("SIG_X_COOKIE", "")
+        return cls(cookie)
+
+    @staticmethod
+    def _extract_ct0(cookie: str) -> str:
+        match = re.search(r"ct0=([^;]+)", cookie)
+        return match.group(1) if match else ""
+
+    def require_cookie(self):
+        if not self.cookie or not self._ct0:
+            raise XApiError("AUTH_REQUIRED", "This operation requires an X session cookie with ct0. Run: sig login https://x.com/")
+
+    # -- GraphQL helpers ---------------------------------------------------
+
+    def graphql_get(self, operation: str, variables: dict, features: dict | None = None, field_toggles: dict | None = None) -> dict:
+        query_id = QUERY_IDS.get(operation, "")
+        params: dict[str, str] = {"variables": json.dumps(variables)}
+        if features:
+            params["features"] = json.dumps(features)
+        if field_toggles:
+            params["fieldToggles"] = json.dumps(field_toggles)
+        url = f"{GRAPHQL_BASE}/{query_id}/{operation}"
+        return self._get(url, params=params)
+
+    def graphql_post(self, operation: str, variables: dict, features: dict | None = None) -> dict:
+        self.require_cookie()
+        query_id = QUERY_IDS.get(operation, "")
+        url = f"{GRAPHQL_BASE}/{query_id}/{operation}"
+        payload: dict = {"variables": variables, "queryId": query_id}
+        if features:
+            payload["features"] = features
+        return self._post_json(url, payload)
+
+    # -- HTTP transport ----------------------------------------------------
+
+    def _get(self, url: str, params: dict | None = None) -> dict:
+        resp = self._session.get(url, params=params, timeout=TIMEOUT)
+        if resp.status_code == 429:
+            retry_after = int(resp.headers.get("Retry-After", "5"))
+            time.sleep(retry_after)
+            resp = self._session.get(url, params=params, timeout=TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+
+    def _post_json(self, url: str, payload: dict) -> dict:
+        resp = self._session.post(url, json=payload, timeout=TIMEOUT)
+        if resp.status_code == 429:
+            retry_after = int(resp.headers.get("Retry-After", "5"))
+            time.sleep(retry_after)
+            resp = self._session.post(url, json=payload, timeout=TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+
+    # -- REST helpers (for follow/unfollow) --------------------------------
+
+    def rest_post(self, path: str, data: dict | None = None) -> dict:
+        self.require_cookie()
+        url = f"https://x.com{path}"
+        resp = self._session.post(url, data=data, timeout=TIMEOUT)
+        if resp.status_code == 429:
+            retry_after = int(resp.headers.get("Retry-After", "5"))
+            time.sleep(retry_after)
+            resp = self._session.post(url, data=data, timeout=TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# URL / ID helpers
+# ---------------------------------------------------------------------------
+
+
+def resolve_tweet_id(raw: str) -> str:
+    """Extract a tweet ID from a URL or bare ID."""
+    match = re.search(r"/status/(\d+)", raw)
+    if match:
+        return match.group(1)
+    return raw.strip()
+
+
+def resolve_username(raw: str) -> str:
+    """Normalize a username (strip @ and URL prefix)."""
+    raw = raw.strip()
+    match = re.search(r"x\.com/([A-Za-z0-9_]+)", raw)
+    if match:
+        return match.group(1)
+    match = re.search(r"twitter\.com/([A-Za-z0-9_]+)", raw)
+    if match:
+        return match.group(1)
+    return raw.lstrip("@")
+
+
+# ---------------------------------------------------------------------------
+# Response parsers
+# ---------------------------------------------------------------------------
+
+
+def extract_media(legacy: dict) -> dict:
+    media = (legacy.get("extended_entities") or {}).get("media") or (legacy.get("entities") or {}).get("media")
+    if not media:
+        return {"has_media": False, "media_urls": []}
+    urls = []
+    for m in media:
+        if not m:
+            continue
+        if m.get("type") in ("video", "animated_gif"):
+            variants = (m.get("video_info") or {}).get("variants") or []
+            mp4 = next((v for v in variants if v.get("content_type") == "video/mp4"), None)
+            url = (mp4 or {}).get("url") or m.get("media_url_https")
+            if url:
+                urls.append(url)
+        else:
+            if m.get("media_url_https"):
+                urls.append(m["media_url_https"])
+    return {"has_media": len(urls) > 0, "media_urls": urls}
+
+
+def parse_tweet(result: dict, seen: set | None = None) -> dict | None:
+    if not result:
+        return None
+    tw = result.get("tweet") or result
+    legacy = tw.get("legacy") or {}
+    rest_id = tw.get("rest_id")
+    if not rest_id:
+        return None
+    if seen is not None:
+        if rest_id in seen:
+            return None
+        seen.add(rest_id)
+    user = (tw.get("core") or {}).get("user_results", {}).get("result") or {}
+    user_legacy = user.get("legacy") or {}
+    user_core = user.get("core") or {}
+    screen_name = user_legacy.get("screen_name") or user_core.get("screen_name") or "unknown"
+    display_name = user_legacy.get("name") or user_core.get("name") or ""
+    note_text = ((tw.get("note_tweet") or {}).get("note_tweet_results") or {}).get("result", {}).get("text")
+    is_retweet = bool(legacy.get("retweeted_status_result") or (legacy.get("full_text") or "").startswith("RT @"))
+    return {
+        "id": rest_id,
+        "author": screen_name,
+        "name": display_name,
+        "text": note_text or legacy.get("full_text") or "",
+        "likes": legacy.get("favorite_count") or 0,
+        "retweets": legacy.get("retweet_count") or 0,
+        "replies": legacy.get("reply_count") or 0,
+        "views": int((tw.get("views") or {}).get("count") or 0),
+        "is_retweet": is_retweet,
+        "created_at": legacy.get("created_at") or "",
+        "url": f"https://x.com/{screen_name}/status/{rest_id}",
+        "in_reply_to": legacy.get("in_reply_to_status_id_str"),
+        **extract_media(legacy),
+    }
+
+
+def parse_user(result: dict) -> dict | None:
+    if not result:
+        return None
+    legacy = result.get("legacy") or {}
+    expanded_url = ""
+    url_entities = (legacy.get("entities") or {}).get("url", {}).get("urls") or []
+    if url_entities:
+        expanded_url = url_entities[0].get("expanded_url") or ""
+    return {
+        "screen_name": legacy.get("screen_name") or "",
+        "name": legacy.get("name") or "",
+        "bio": legacy.get("description") or "",
+        "location": legacy.get("location") or "",
+        "url": expanded_url,
+        "followers": legacy.get("followers_count") or 0,
+        "following": legacy.get("friends_count") or 0,
+        "tweets": legacy.get("statuses_count") or 0,
+        "likes": legacy.get("favourites_count") or 0,
+        "verified": result.get("is_blue_verified") or legacy.get("verified") or False,
+        "created_at": legacy.get("created_at") or "",
+        "id": result.get("rest_id") or "",
+    }
+
+
+def parse_timeline_tweets(instructions: list, seen: set | None = None) -> tuple[list[dict], str | None]:
+    """Parse tweets and cursor from timeline instructions."""
+    if seen is None:
+        seen = set()
+    tweets: list[dict] = []
+    next_cursor: str | None = None
+
+    for inst in instructions:
+        if inst.get("type") == "TimelinePinEntry":
+            continue
+        for entry in inst.get("entries") or []:
+            content = entry.get("content") or {}
+            entry_type = content.get("entryType") or content.get("__typename") or ""
+            if entry_type == "TimelineTimelineCursor":
+                if content.get("cursorType") in ("Bottom", "ShowMore"):
+                    next_cursor = content.get("value")
+                continue
+            entry_id = entry.get("entryId") or ""
+            if entry_id.startswith("cursor-bottom-") or entry_id.startswith("cursor-showMore-"):
+                next_cursor = content.get("value") or (content.get("itemContent") or {}).get("value") or next_cursor
+                continue
+            tweet_result = (content.get("itemContent") or {}).get("tweet_results", {}).get("result")
+            tw = parse_tweet(tweet_result, seen)
+            if tw:
+                tweets.append(tw)
+                continue
+            for item in content.get("items") or []:
+                nested_result = ((item.get("item") or {}).get("itemContent") or {}).get("tweet_results", {}).get("result")
+                ntw = parse_tweet(nested_result, seen)
+                if ntw:
+                    tweets.append(ntw)
+
+    return tweets, next_cursor

--- a/skills/x/scripts/x_client.py
+++ b/skills/x/scripts/x_client.py
@@ -29,19 +29,19 @@ TIMEOUT = 20
 # ---------------------------------------------------------------------------
 
 QUERY_IDS = {
-    "UserByScreenName": "qRednkZG-rn1P6b48NINmQ",
-    "UserTweets": "Y59DTUMfcKmUAATiT2SlTw",
-    "TweetDetail": "nBS-WpgA6ZG0CyNHD517JQ",
-    "SearchTimeline": "MJnbGFOB_MF-5ywMj2FdTg",
-    "Followers": "rRXFSG5vR6drKr5M37YOTw",
-    "Following": "iSicc7LrzWGBgDPL0tM_TQ",
-    "CreateTweet": "bDE2rBtZb3uyrczSZ_pI9g",
-    "FavoriteTweet": "lI07N6OaolGPl9u_Z1FxcA",
+    "UserByScreenName": "IGgvgiOx4QZndDHuD3x9TQ",
+    "UserTweets": "naBcZ4al-iTCFBYGOAMzBQ",
+    "TweetDetail": "QrLp7AR-eMyamw8D1N9l6A",
+    "SearchTimeline": "XN_HccZ9SU-miQVvwTAlFQ",
+    "Followers": "xOdl9jiaOqwHUm68qsq6Hg",
+    "Following": "lQxnNSmlJkQHod0yzbVYDg",
+    "CreateTweet": "c50A_puUoQGK_4SXseYz3A",
+    "FavoriteTweet": "lI07N6Otwv1PhnEgXILM7A",
     "UnfavoriteTweet": "ZYKSe-w7KEslx3JhSIk5LA",
-    "CreateRetweet": "ojPdsZsimiJrUGLR1sjUtA",
-    "DeleteRetweet": "iQtK4dl5hBmXewYZuEOKVw",
-    "CreateBookmark": "aaDnft_gKxX4OWoR900UMQ",
-    "DeleteBookmark": "Wlmlj2-xISz1HUqEPgNxVQ",
+    "CreateRetweet": "mbRO74GrOvSfRcJnlMapnQ",
+    "DeleteRetweet": "ZyZigVsNiFO6v1dEks1eWg",
+    "CreateBookmark": "aoDbu3RHznuiSkQ9aNM67Q",
+    "DeleteBookmark": "Wlmlj2-xzyS1GN3a6cj-mQ",
 }
 
 # ---------------------------------------------------------------------------

--- a/skills/x/scripts/x_client.py
+++ b/skills/x/scripts/x_client.py
@@ -25,10 +25,10 @@ USER_AGENT = "sigcli-skill/1.0"
 TIMEOUT = 20
 
 # ---------------------------------------------------------------------------
-# Query IDs (fallback defaults — may need periodic updates)
+# Query IDs (fallback defaults — auto-refreshed from X's JS bundles)
 # ---------------------------------------------------------------------------
 
-QUERY_IDS = {
+DEFAULT_QUERY_IDS = {
     "UserByScreenName": "IGgvgiOx4QZndDHuD3x9TQ",
     "UserTweets": "naBcZ4al-iTCFBYGOAMzBQ",
     "TweetDetail": "QrLp7AR-eMyamw8D1N9l6A",
@@ -43,6 +43,50 @@ QUERY_IDS = {
     "CreateBookmark": "aoDbu3RHznuiSkQ9aNM67Q",
     "DeleteBookmark": "Wlmlj2-xzyS1GN3a6cj-mQ",
 }
+
+_cached_query_ids: dict[str, str] = {}
+_cache_ts: float = 0.0
+_CACHE_TTL = 3600  # 1 hour
+
+
+def _fetch_query_ids_from_bundles(session: requests.Session) -> dict[str, str]:
+    """Fetch fresh GraphQL query IDs from X's JS bundles."""
+    try:
+        resp = session.get("https://x.com/", timeout=TIMEOUT)
+        script_urls = re.findall(r"https://abs\.twimg\.com/responsive-web/client-web[^\"\s]+\.js", resp.text)
+        found: dict[str, str] = {}
+        operations = list(DEFAULT_QUERY_IDS.keys())
+        for url in script_urls[:15]:
+            if len(found) == len(operations):
+                break
+            try:
+                r = session.get(url, timeout=TIMEOUT)
+                for op in operations:
+                    if op not in found:
+                        m = re.search(rf'queryId:"([^"]+)",operationName:"{op}"', r.text)
+                        if m:
+                            found[op] = m.group(1)
+            except Exception:
+                continue
+        return found
+    except Exception:
+        return {}
+
+
+def get_query_ids(session: requests.Session) -> dict[str, str]:
+    """Return query IDs, auto-refreshing from X's JS bundles when stale."""
+    global _cached_query_ids, _cache_ts
+    if _cached_query_ids and (time.time() - _cache_ts) < _CACHE_TTL:
+        return _cached_query_ids
+    fresh = _fetch_query_ids_from_bundles(session)
+    if fresh:
+        merged = {**DEFAULT_QUERY_IDS, **fresh}
+        _cached_query_ids = merged
+        _cache_ts = time.time()
+        return merged
+    if _cached_query_ids:
+        return _cached_query_ids
+    return DEFAULT_QUERY_IDS
 
 # ---------------------------------------------------------------------------
 # Feature flags (required by most GraphQL endpoints)
@@ -166,8 +210,13 @@ class XClient:
 
     # -- GraphQL helpers ---------------------------------------------------
 
+    def _query_id(self, operation: str) -> str:
+        """Get the query ID for an operation, auto-refreshing if stale."""
+        ids = get_query_ids(self._session)
+        return ids.get(operation, DEFAULT_QUERY_IDS.get(operation, ""))
+
     def graphql_get(self, operation: str, variables: dict, features: dict | None = None, field_toggles: dict | None = None) -> dict:
-        query_id = QUERY_IDS.get(operation, "")
+        query_id = self._query_id(operation)
         params: dict[str, str] = {"variables": json.dumps(variables)}
         if features:
             params["features"] = json.dumps(features)
@@ -178,7 +227,7 @@ class XClient:
 
     def graphql_post(self, operation: str, variables: dict, features: dict | None = None) -> dict:
         self.require_cookie()
-        query_id = QUERY_IDS.get(operation, "")
+        query_id = self._query_id(operation)
         url = f"{GRAPHQL_BASE}/{query_id}/{operation}"
         payload: dict = {"variables": variables, "queryId": query_id}
         if features:

--- a/skills/x/scripts/x_follow.py
+++ b/skills/x/scripts/x_follow.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Follow or unfollow a user on X (Twitter)."""
+
+import argparse
+import json
+import sys
+
+import requests
+from x_client import FEATURES_USER, XApiError, XClient, resolve_username
+
+
+def _get_user_id(client: XClient, username: str) -> str:
+    variables = {"screen_name": username, "withSafetyModeUserFields": True}
+    data = client.graphql_get("UserByScreenName", variables, features=FEATURES_USER)
+    result = (data.get("data") or {}).get("user", {}).get("result")
+    if not result:
+        raise XApiError("NOT_FOUND", f"User @{username} not found")
+    user_id = result.get("rest_id")
+    if not user_id:
+        raise XApiError("PARSE_ERROR", f"Could not resolve ID for @{username}")
+    return user_id
+
+
+def follow_user(cookie: str, username: str, undo: bool = False) -> dict:
+    """Follow or unfollow a user."""
+    client = XClient(cookie)
+    client.require_cookie()
+
+    user_id = _get_user_id(client, username)
+
+    if undo:
+        path = "/i/api/1.1/friendships/destroy.json"
+    else:
+        path = "/i/api/1.1/friendships/create.json"
+
+    client.rest_post(path, data={"user_id": user_id})
+
+    action = "unfollowed" if undo else "followed"
+    return {
+        "success": True,
+        "username": username,
+        "user_id": user_id,
+        "action": action,
+        "message": f"Successfully {action} @{username}",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Follow or unfollow a user on X")
+    parser.add_argument("--cookie", required=True, help="X session cookie")
+    parser.add_argument("--username", required=True, help="Screen name (without @)")
+    parser.add_argument("--undo", action="store_true", help="Unfollow instead of follow")
+    args = parser.parse_args()
+
+    try:
+        username = resolve_username(args.username)
+        result = follow_user(args.cookie, username, args.undo)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except XApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/x/scripts/x_followers.py
+++ b/skills/x/scripts/x_followers.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Get followers or following list for an X (Twitter) user."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import requests
+from x_client import FEATURES_TIMELINE, FEATURES_USER, XApiError, XClient, resolve_username
+
+
+def _get_user_id(client: XClient, username: str) -> str:
+    variables = {"screen_name": username, "withSafetyModeUserFields": True}
+    data = client.graphql_get("UserByScreenName", variables, features=FEATURES_USER)
+    result = (data.get("data") or {}).get("user", {}).get("result")
+    if not result:
+        raise XApiError("NOT_FOUND", f"User @{username} not found")
+    user_id = result.get("rest_id")
+    if not user_id:
+        raise XApiError("PARSE_ERROR", f"Could not resolve ID for @{username}")
+    return user_id
+
+
+def _parse_user_entries(instructions: list, seen: set) -> tuple[list[dict], str | None]:
+    users: list[dict] = []
+    next_cursor: str | None = None
+    for inst in instructions:
+        for entry in inst.get("entries") or []:
+            entry_id = entry.get("entryId") or ""
+            content = entry.get("content") or {}
+            if entry_id.startswith("cursor-bottom-"):
+                next_cursor = content.get("value") or (content.get("itemContent") or {}).get("value")
+                continue
+            if not entry_id.startswith("user-"):
+                continue
+            item = (content.get("itemContent") or {}).get("user_results", {}).get("result")
+            if not item or item.get("__typename") != "User":
+                continue
+            core = item.get("core") or {}
+            legacy = item.get("legacy") or {}
+            screen_name = core.get("screen_name") or legacy.get("screen_name") or "unknown"
+            if screen_name in seen:
+                continue
+            seen.add(screen_name)
+            users.append({
+                "screen_name": screen_name,
+                "name": core.get("name") or legacy.get("name") or "",
+                "bio": legacy.get("description") or (item.get("profile_bio") or {}).get("description") or "",
+                "followers": legacy.get("followers_count") or legacy.get("normal_followers_count") or 0,
+            })
+    return users, next_cursor
+
+
+def get_followers(client: XClient, username: str, limit: int = 50, mode: str = "followers") -> dict:
+    """Fetch followers or following for a user."""
+    client.require_cookie()
+    user_id = _get_user_id(client, username)
+    operation = "Followers" if mode == "followers" else "Following"
+    seen: set = set()
+    all_users: list = []
+    cursor = None
+
+    for _ in range(5):
+        if len(all_users) >= limit:
+            break
+        variables: dict = {
+            "userId": user_id,
+            "count": min(50, limit - len(all_users) + 10),
+            "includePromotedContent": False,
+        }
+        if cursor:
+            variables["cursor"] = cursor
+        data = client.graphql_get(operation, variables, features=FEATURES_TIMELINE)
+        instructions = (
+            (((data.get("data") or {}).get("user") or {}).get("result") or {}).get("timeline", {}).get("timeline", {}).get("instructions") or []
+        )
+        users, next_cursor = _parse_user_entries(instructions, seen)
+        all_users.extend(users)
+        if not next_cursor or next_cursor == cursor:
+            break
+        cursor = next_cursor
+
+    return {
+        "username": username,
+        "mode": mode,
+        "count": len(all_users[:limit]),
+        "users": all_users[:limit],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get followers or following for an X user")
+    parser.add_argument("--username", required=True, help="Screen name (without @)")
+    parser.add_argument("--limit", type=int, default=50, help="Max users to return (default: 50)")
+    parser.add_argument("--mode", default="followers", choices=["followers", "following"], help="List type (default: followers)")
+    args = parser.parse_args()
+
+    try:
+        client = XClient.create()
+        username = resolve_username(args.username)
+        result = get_followers(client, username, args.limit, args.mode)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except XApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/x/scripts/x_like.py
+++ b/skills/x/scripts/x_like.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Like or unlike a tweet on X (Twitter)."""
+
+import argparse
+import json
+import sys
+
+import requests
+from x_client import XApiError, XClient, resolve_tweet_id
+
+
+def like_tweet(cookie: str, tweet_id: str, undo: bool = False) -> dict:
+    """Like or unlike a tweet."""
+    client = XClient(cookie)
+    client.require_cookie()
+
+    operation = "UnfavoriteTweet" if undo else "FavoriteTweet"
+    variables = {"tweet_id": tweet_id}
+    client.graphql_post(operation, variables)
+
+    action = "unliked" if undo else "liked"
+    return {
+        "success": True,
+        "tweet_id": tweet_id,
+        "action": action,
+        "message": f"Tweet {action} successfully",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Like or unlike a tweet on X")
+    parser.add_argument("--cookie", required=True, help="X session cookie")
+    parser.add_argument("--id", required=True, help="Tweet ID or URL")
+    parser.add_argument("--undo", action="store_true", help="Unlike instead of like")
+    args = parser.parse_args()
+
+    try:
+        tweet_id = resolve_tweet_id(args.id)
+        result = like_tweet(args.cookie, tweet_id, args.undo)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except XApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/x/scripts/x_post.py
+++ b/skills/x/scripts/x_post.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Create a tweet on X (Twitter)."""
+
+import argparse
+import json
+import sys
+
+import requests
+from x_client import FEATURES_TIMELINE, XApiError, XClient
+
+
+def create_tweet(cookie: str, text: str, reply_to: str = "") -> dict:
+    """Post a new tweet or reply."""
+    client = XClient(cookie)
+    client.require_cookie()
+
+    variables: dict = {
+        "tweet_text": text,
+        "dark_request": False,
+        "media": {"media_entities": [], "possibly_sensitive": False},
+        "semantic_annotation_ids": [],
+    }
+    if reply_to:
+        variables["reply"] = {
+            "in_reply_to_tweet_id": reply_to,
+            "exclude_reply_user_ids": [],
+        }
+
+    data = client.graphql_post("CreateTweet", variables, features=FEATURES_TIMELINE)
+    result = (data.get("data") or {}).get("create_tweet", {}).get("tweet_results", {}).get("result")
+    if not result:
+        raise XApiError("POST_FAILED", "Tweet creation failed — check response or try again")
+
+    tweet_id = result.get("rest_id") or ""
+    return {
+        "success": True,
+        "tweet_id": tweet_id,
+        "text": text,
+        "url": f"https://x.com/i/status/{tweet_id}" if tweet_id else "",
+        "message": "Tweet posted successfully",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create a tweet on X")
+    parser.add_argument("--cookie", required=True, help="X session cookie")
+    parser.add_argument("--text", required=True, help="Tweet text content")
+    parser.add_argument("--reply-to", default="", help="Tweet ID to reply to (optional)")
+    args = parser.parse_args()
+
+    try:
+        result = create_tweet(args.cookie, args.text, args.reply_to)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except XApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/x/scripts/x_retweet.py
+++ b/skills/x/scripts/x_retweet.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Retweet or undo retweet on X (Twitter)."""
+
+import argparse
+import json
+import sys
+
+import requests
+from x_client import XApiError, XClient, resolve_tweet_id
+
+
+def retweet(cookie: str, tweet_id: str, undo: bool = False) -> dict:
+    """Retweet or undo a retweet."""
+    client = XClient(cookie)
+    client.require_cookie()
+
+    if undo:
+        variables = {"source_tweet_id": tweet_id}
+        client.graphql_post("DeleteRetweet", variables)
+    else:
+        variables = {"tweet_id": tweet_id, "dark_request": False}
+        client.graphql_post("CreateRetweet", variables)
+
+    action = "unretweeted" if undo else "retweeted"
+    return {
+        "success": True,
+        "tweet_id": tweet_id,
+        "action": action,
+        "message": f"Tweet {action} successfully",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Retweet or undo retweet on X")
+    parser.add_argument("--cookie", required=True, help="X session cookie")
+    parser.add_argument("--id", required=True, help="Tweet ID or URL")
+    parser.add_argument("--undo", action="store_true", help="Undo retweet")
+    args = parser.parse_args()
+
+    try:
+        tweet_id = resolve_tweet_id(args.id)
+        result = retweet(args.cookie, tweet_id, args.undo)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except XApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/x/scripts/x_search.py
+++ b/skills/x/scripts/x_search.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Search tweets on X (Twitter)."""
+
+import argparse
+import json
+import sys
+
+import requests
+from x_client import FEATURES_TIMELINE, XApiError, XClient, parse_timeline_tweets
+
+
+def search_tweets(client: XClient, query: str, limit: int = 20, product: str = "Latest") -> dict:
+    """Search for tweets matching a query."""
+    variables = {
+        "rawQuery": query,
+        "count": min(limit, 50),
+        "querySource": "typed_query",
+        "product": product,
+    }
+    data = client.graphql_get("SearchTimeline", variables, features=FEATURES_TIMELINE)
+    instructions = (
+        ((data.get("data") or {}).get("search_by_raw_query") or {}).get("search_timeline", {}).get("timeline", {}).get("instructions") or []
+    )
+    seen: set = set()
+    tweets, _ = parse_timeline_tweets(instructions, seen)
+    return {
+        "query": query,
+        "product": product,
+        "count": len(tweets[:limit]),
+        "tweets": tweets[:limit],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Search tweets on X")
+    parser.add_argument("--query", required=True, help="Search query")
+    parser.add_argument("--limit", type=int, default=20, help="Max results (default: 20)")
+    parser.add_argument("--type", default="latest", choices=["latest", "top"], help="Result type (default: latest)")
+    args = parser.parse_args()
+
+    try:
+        client = XClient.create()
+        product = "Top" if args.type == "top" else "Latest"
+        result = search_tweets(client, args.query, args.limit, product)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except XApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/x/scripts/x_trending.py
+++ b/skills/x/scripts/x_trending.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Get trending topics from X (Twitter)."""
+
+import argparse
+import json
+import sys
+
+import requests
+from x_client import XApiError, XClient
+
+
+def get_trending(client: XClient, limit: int = 20) -> dict:
+    """Fetch trending topics via the guide API."""
+    client.require_cookie()
+    url = "https://x.com/i/api/2/guide.json"
+    params = {"include_page_configuration": "true"}
+    data = client._get(url, params=params)
+
+    instructions = (data.get("timeline") or {}).get("instructions") or []
+    trends: list[dict] = []
+    for inst in instructions:
+        entries = inst.get("addEntries", {}).get("entries") or inst.get("entries") or []
+        for entry in entries:
+            module = (entry.get("content") or {}).get("timelineModule")
+            if not module:
+                continue
+            for item in module.get("items") or []:
+                trend = ((item.get("item") or {}).get("content") or {}).get("trend")
+                if not trend:
+                    continue
+                tweet_count = trend.get("tweetCount")
+                category = ((trend.get("trendMetadata") or {}).get("domainContext")) or ""
+                trends.append({
+                    "rank": len(trends) + 1,
+                    "topic": trend.get("name") or "",
+                    "tweets": str(tweet_count) if tweet_count else "N/A",
+                    "category": category,
+                })
+
+    return {
+        "count": len(trends[:limit]),
+        "trends": trends[:limit],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get trending topics on X")
+    parser.add_argument("--limit", type=int, default=20, help="Number of trends (default: 20)")
+    args = parser.parse_args()
+
+    try:
+        client = XClient.create()
+        result = get_trending(client, args.limit)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except XApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/x/scripts/x_tweet.py
+++ b/skills/x/scripts/x_tweet.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Get a single tweet with its thread/replies from X (Twitter)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import requests
+from x_client import FEATURES_TWEET_DETAIL, FIELD_TOGGLES_TWEET_DETAIL, XApiError, XClient, parse_timeline_tweets, resolve_tweet_id
+
+
+def get_tweet(client: XClient, tweet_id: str, limit: int = 50) -> dict:
+    """Fetch a tweet and its conversation thread."""
+    seen: set = set()
+    all_tweets: list = []
+    cursor = None
+
+    for _ in range(5):
+        variables: dict = {
+            "focalTweetId": tweet_id,
+            "referrer": "tweet",
+            "with_rux_injections": False,
+            "includePromotedContent": False,
+            "rankingMode": "Recency",
+            "withCommunity": True,
+            "withQuickPromoteEligibilityTweetFields": True,
+            "withBirdwatchNotes": True,
+            "withVoice": True,
+        }
+        if cursor:
+            variables["cursor"] = cursor
+        data = client.graphql_get("TweetDetail", variables, features=FEATURES_TWEET_DETAIL, field_toggles=FIELD_TOGGLES_TWEET_DETAIL)
+        instructions = (
+            (data.get("data") or {}).get("threaded_conversation_with_injections_v2", {}).get("instructions")
+            or ((data.get("data") or {}).get("tweetResult", {}).get("result", {}).get("timeline", {}).get("instructions"))
+            or []
+        )
+        tweets, next_cursor = parse_timeline_tweets(instructions, seen)
+        all_tweets.extend(tweets)
+        if not next_cursor or next_cursor == cursor:
+            break
+        cursor = next_cursor
+
+    return {
+        "tweet_id": tweet_id,
+        "count": len(all_tweets[:limit]),
+        "tweets": all_tweets[:limit],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get a tweet with its thread")
+    parser.add_argument("--id", required=True, help="Tweet ID or URL")
+    parser.add_argument("--limit", type=int, default=50, help="Max tweets in thread (default: 50)")
+    args = parser.parse_args()
+
+    try:
+        client = XClient.create()
+        tweet_id = resolve_tweet_id(args.id)
+        result = get_tweet(client, tweet_id, args.limit)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except XApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/x/scripts/x_tweets.py
+++ b/skills/x/scripts/x_tweets.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Get a user's recent tweets from X (Twitter)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import requests
+from x_client import FEATURES_TIMELINE, FEATURES_USER, XApiError, XClient, parse_timeline_tweets, resolve_username
+
+
+def get_user_id(client: XClient, username: str) -> str:
+    variables = {"screen_name": username, "withSafetyModeUserFields": True}
+    data = client.graphql_get("UserByScreenName", variables, features=FEATURES_USER)
+    result = (data.get("data") or {}).get("user", {}).get("result")
+    if not result:
+        raise XApiError("NOT_FOUND", f"User @{username} not found")
+    user_id = result.get("rest_id")
+    if not user_id:
+        raise XApiError("PARSE_ERROR", f"Could not resolve ID for @{username}")
+    return user_id
+
+
+def get_user_tweets(client: XClient, username: str, limit: int = 20) -> dict:
+    """Fetch a user's recent tweets."""
+    user_id = get_user_id(client, username)
+    seen: set = set()
+    all_tweets: list = []
+    cursor = None
+
+    for _ in range(5):
+        if len(all_tweets) >= limit:
+            break
+        fetch_count = min(100, limit - len(all_tweets) + 10)
+        variables: dict = {
+            "userId": user_id,
+            "count": fetch_count,
+            "includePromotedContent": False,
+            "withQuickPromoteEligibilityTweetFields": True,
+            "withVoice": True,
+        }
+        if cursor:
+            variables["cursor"] = cursor
+        data = client.graphql_get("UserTweets", variables, features=FEATURES_TIMELINE)
+        instructions = (
+            (((data.get("data") or {}).get("user") or {}).get("result") or {}).get("timeline_v2", {}).get("timeline", {}).get("instructions")
+            or (((data.get("data") or {}).get("user") or {}).get("result") or {}).get("timeline", {}).get("timeline", {}).get("instructions")
+            or []
+        )
+        tweets, next_cursor = parse_timeline_tweets(instructions, seen)
+        all_tweets.extend(tweets)
+        if not next_cursor or next_cursor == cursor:
+            break
+        cursor = next_cursor
+
+    return {
+        "username": username,
+        "user_id": user_id,
+        "count": len(all_tweets[:limit]),
+        "tweets": all_tweets[:limit],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get a user's recent tweets")
+    parser.add_argument("--username", required=True, help="Screen name (with or without @)")
+    parser.add_argument("--limit", type=int, default=20, help="Max tweets to return (default: 20)")
+    args = parser.parse_args()
+
+    try:
+        client = XClient.create()
+        username = resolve_username(args.username)
+        result = get_user_tweets(client, username, args.limit)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except XApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/x/scripts/x_user.py
+++ b/skills/x/scripts/x_user.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Get an X (Twitter) user profile."""
+
+import argparse
+import json
+import sys
+
+import requests
+from x_client import FEATURES_USER, XApiError, XClient, parse_user, resolve_username
+
+
+def get_user(client: XClient, username: str) -> dict:
+    """Fetch a user profile by screen name."""
+    variables = {"screen_name": username, "withSafetyModeUserFields": True}
+    data = client.graphql_get("UserByScreenName", variables, features=FEATURES_USER)
+    result = (data.get("data") or {}).get("user", {}).get("result")
+    if not result:
+        raise XApiError("NOT_FOUND", f"User @{username} not found")
+    user = parse_user(result)
+    if not user:
+        raise XApiError("PARSE_ERROR", f"Could not parse user @{username}")
+    return user
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get an X user profile")
+    parser.add_argument("--username", required=True, help="Screen name (without @)")
+    args = parser.parse_args()
+
+    try:
+        client = XClient.create()
+        username = resolve_username(args.username)
+        result = get_user(client, username)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except XApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/x/tests/test_x_bookmark.py
+++ b/skills/x/tests/test_x_bookmark.py
@@ -1,0 +1,48 @@
+"""Tests for x/scripts/x_bookmark.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("x", "x_bookmark")
+client_mod = load_script("x", "x_client")
+
+COOKIE = "ct0=testcsrf123; auth_token=testabc"
+
+
+@responses.activate
+def test_bookmark_tweet_success():
+    """bookmark_tweet returns success for bookmark action."""
+    responses.post(
+        url=re.compile(r".+/CreateBookmark"),
+        json={"data": {"tweet_bookmark_put": "Done"}},
+        status=200,
+    )
+    result = mod.bookmark_tweet(COOKIE, "12345")
+    assert result["success"] is True
+    assert result["action"] == "bookmarked"
+    assert result["tweet_id"] == "12345"
+
+
+@responses.activate
+def test_unbookmark_tweet_success():
+    """bookmark_tweet with undo returns success for unbookmark action."""
+    responses.post(
+        url=re.compile(r".+/DeleteBookmark"),
+        json={"data": {"tweet_bookmark_delete": "Done"}},
+        status=200,
+    )
+    result = mod.bookmark_tweet(COOKIE, "12345", undo=True)
+    assert result["success"] is True
+    assert result["action"] == "unbookmarked"
+
+
+def test_bookmark_requires_auth():
+    """bookmark_tweet raises XApiError without cookie."""
+    try:
+        mod.bookmark_tweet("", "12345")
+        assert False, "Expected XApiError"
+    except client_mod.XApiError as e:
+        assert e.code == "AUTH_REQUIRED"

--- a/skills/x/tests/test_x_follow.py
+++ b/skills/x/tests/test_x_follow.py
@@ -1,0 +1,54 @@
+"""Tests for x/scripts/x_follow.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("x", "x_follow")
+client_mod = load_script("x", "x_client")
+
+COOKIE = "ct0=testcsrf123; auth_token=testabc"
+
+_USER_RESPONSE = {
+    "data": {
+        "user": {
+            "result": {
+                "rest_id": "44196397",
+                "legacy": {"screen_name": "elonmusk"},
+            },
+        },
+    },
+}
+
+
+@responses.activate
+def test_follow_user_success():
+    """follow_user returns success for follow action."""
+    responses.get(url=re.compile(r".+/UserByScreenName"), json=_USER_RESPONSE, status=200)
+    responses.post(url=re.compile(r".+/friendships/create\.json"), json={"id": 44196397}, status=200)
+    result = mod.follow_user(COOKIE, "elonmusk")
+    assert result["success"] is True
+    assert result["action"] == "followed"
+    assert result["username"] == "elonmusk"
+    assert result["user_id"] == "44196397"
+
+
+@responses.activate
+def test_unfollow_user_success():
+    """follow_user with undo returns success for unfollow action."""
+    responses.get(url=re.compile(r".+/UserByScreenName"), json=_USER_RESPONSE, status=200)
+    responses.post(url=re.compile(r".+/friendships/destroy\.json"), json={"id": 44196397}, status=200)
+    result = mod.follow_user(COOKIE, "elonmusk", undo=True)
+    assert result["success"] is True
+    assert result["action"] == "unfollowed"
+
+
+def test_follow_requires_auth():
+    """follow_user raises XApiError without cookie."""
+    try:
+        mod.follow_user("", "elonmusk")
+        assert False, "Expected XApiError"
+    except client_mod.XApiError as e:
+        assert e.code == "AUTH_REQUIRED"

--- a/skills/x/tests/test_x_followers.py
+++ b/skills/x/tests/test_x_followers.py
@@ -1,0 +1,118 @@
+"""Tests for x/scripts/x_followers.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("x", "x_followers")
+client_mod = load_script("x", "x_client")
+
+_USER_RESPONSE = {
+    "data": {
+        "user": {
+            "result": {
+                "rest_id": "123",
+                "legacy": {"screen_name": "testuser"},
+            },
+        },
+    },
+}
+
+_FOLLOWERS_RESPONSE = {
+    "data": {
+        "user": {
+            "result": {
+                "timeline": {
+                    "timeline": {
+                        "instructions": [
+                            {
+                                "type": "TimelineAddEntries",
+                                "entries": [
+                                    {
+                                        "entryId": "user-111",
+                                        "content": {
+                                            "itemContent": {
+                                                "user_results": {
+                                                    "result": {
+                                                        "__typename": "User",
+                                                        "core": {"screen_name": "follower1", "name": "Follower One"},
+                                                        "legacy": {
+                                                            "screen_name": "follower1",
+                                                            "name": "Follower One",
+                                                            "description": "I follow you",
+                                                            "followers_count": 100,
+                                                        },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                    {
+                                        "entryId": "user-222",
+                                        "content": {
+                                            "itemContent": {
+                                                "user_results": {
+                                                    "result": {
+                                                        "__typename": "User",
+                                                        "core": {"screen_name": "follower2", "name": "Follower Two"},
+                                                        "legacy": {
+                                                            "screen_name": "follower2",
+                                                            "name": "Follower Two",
+                                                            "description": "Another follower",
+                                                            "followers_count": 200,
+                                                        },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                    {
+                                        "entryId": "cursor-bottom-abc",
+                                        "content": {"value": "cursor-abc"},
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+    },
+}
+
+
+@responses.activate
+def test_get_followers_returns_list():
+    """get_followers returns formatted followers list."""
+    responses.get(url=re.compile(r".+/UserByScreenName"), json=_USER_RESPONSE, status=200)
+    responses.get(url=re.compile(r".+/Followers"), json=_FOLLOWERS_RESPONSE, status=200)
+    client = client_mod.XClient(cookie="ct0=abc123; auth_token=xyz")
+    result = mod.get_followers(client, "testuser", limit=50, mode="followers")
+    assert result["username"] == "testuser"
+    assert result["mode"] == "followers"
+    assert result["count"] == 2
+    assert result["users"][0]["screen_name"] == "follower1"
+    assert result["users"][1]["followers"] == 200
+
+
+@responses.activate
+def test_get_followers_respects_limit():
+    """get_followers respects the limit parameter."""
+    responses.get(url=re.compile(r".+/UserByScreenName"), json=_USER_RESPONSE, status=200)
+    responses.get(url=re.compile(r".+/Followers"), json=_FOLLOWERS_RESPONSE, status=200)
+    client = client_mod.XClient(cookie="ct0=abc123; auth_token=xyz")
+    result = mod.get_followers(client, "testuser", limit=1)
+    assert result["count"] == 1
+    assert len(result["users"]) == 1
+
+
+def test_get_followers_requires_auth():
+    """get_followers raises XApiError without cookie."""
+    client = client_mod.XClient()
+    try:
+        mod.get_followers(client, "testuser")
+        assert False, "Expected XApiError"
+    except client_mod.XApiError as e:
+        assert e.code == "AUTH_REQUIRED"

--- a/skills/x/tests/test_x_like.py
+++ b/skills/x/tests/test_x_like.py
@@ -1,0 +1,48 @@
+"""Tests for x/scripts/x_like.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("x", "x_like")
+client_mod = load_script("x", "x_client")
+
+COOKIE = "ct0=testcsrf123; auth_token=testabc"
+
+
+@responses.activate
+def test_like_tweet_success():
+    """like_tweet returns success for like action."""
+    responses.post(
+        url=re.compile(r".+/FavoriteTweet"),
+        json={"data": {"favorite_tweet": "Done"}},
+        status=200,
+    )
+    result = mod.like_tweet(COOKIE, "12345")
+    assert result["success"] is True
+    assert result["action"] == "liked"
+    assert result["tweet_id"] == "12345"
+
+
+@responses.activate
+def test_unlike_tweet_success():
+    """like_tweet with undo returns success for unlike action."""
+    responses.post(
+        url=re.compile(r".+/UnfavoriteTweet"),
+        json={"data": {"unfavorite_tweet": "Done"}},
+        status=200,
+    )
+    result = mod.like_tweet(COOKIE, "12345", undo=True)
+    assert result["success"] is True
+    assert result["action"] == "unliked"
+
+
+def test_like_requires_auth():
+    """like_tweet raises XApiError without cookie."""
+    try:
+        mod.like_tweet("", "12345")
+        assert False, "Expected XApiError"
+    except client_mod.XApiError as e:
+        assert e.code == "AUTH_REQUIRED"

--- a/skills/x/tests/test_x_post.py
+++ b/skills/x/tests/test_x_post.py
@@ -1,0 +1,79 @@
+"""Tests for x/scripts/x_post.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("x", "x_post")
+client_mod = load_script("x", "x_client")
+
+COOKIE = "ct0=testcsrf123; auth_token=testabc"
+
+
+@responses.activate
+def test_create_tweet_success():
+    """create_tweet returns success with tweet ID."""
+    responses.post(
+        url=re.compile(r".+/CreateTweet"),
+        json={
+            "data": {
+                "create_tweet": {
+                    "tweet_results": {
+                        "result": {"rest_id": "12345678"},
+                    },
+                },
+            },
+        },
+        status=200,
+    )
+    result = mod.create_tweet(COOKIE, "Hello from sigcli!")
+    assert result["success"] is True
+    assert result["tweet_id"] == "12345678"
+    assert result["text"] == "Hello from sigcli!"
+
+
+@responses.activate
+def test_create_tweet_with_reply():
+    """create_tweet sets reply variables when reply_to is provided."""
+    responses.post(
+        url=re.compile(r".+/CreateTweet"),
+        json={
+            "data": {
+                "create_tweet": {
+                    "tweet_results": {
+                        "result": {"rest_id": "99999"},
+                    },
+                },
+            },
+        },
+        status=200,
+    )
+    result = mod.create_tweet(COOKIE, "Reply!", reply_to="12345")
+    assert result["success"] is True
+    assert result["tweet_id"] == "99999"
+
+
+@responses.activate
+def test_create_tweet_failure():
+    """create_tweet raises XApiError when response has no result."""
+    responses.post(
+        url=re.compile(r".+/CreateTweet"),
+        json={"data": {"create_tweet": {"tweet_results": {}}}},
+        status=200,
+    )
+    try:
+        mod.create_tweet(COOKIE, "fail tweet")
+        assert False, "Expected XApiError"
+    except client_mod.XApiError as e:
+        assert e.code == "POST_FAILED"
+
+
+def test_create_tweet_requires_auth():
+    """create_tweet raises XApiError without cookie."""
+    try:
+        mod.create_tweet("", "no auth")
+        assert False, "Expected XApiError"
+    except client_mod.XApiError as e:
+        assert e.code == "AUTH_REQUIRED"

--- a/skills/x/tests/test_x_retweet.py
+++ b/skills/x/tests/test_x_retweet.py
@@ -1,0 +1,48 @@
+"""Tests for x/scripts/x_retweet.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("x", "x_retweet")
+client_mod = load_script("x", "x_client")
+
+COOKIE = "ct0=testcsrf123; auth_token=testabc"
+
+
+@responses.activate
+def test_retweet_success():
+    """retweet returns success for retweet action."""
+    responses.post(
+        url=re.compile(r".+/CreateRetweet"),
+        json={"data": {"create_retweet": {"retweet_results": {"result": {"rest_id": "99"}}}}},
+        status=200,
+    )
+    result = mod.retweet(COOKIE, "12345")
+    assert result["success"] is True
+    assert result["action"] == "retweeted"
+    assert result["tweet_id"] == "12345"
+
+
+@responses.activate
+def test_undo_retweet_success():
+    """retweet with undo returns success for unretweet action."""
+    responses.post(
+        url=re.compile(r".+/DeleteRetweet"),
+        json={"data": {"unretweet": {"source_tweet_results": {"result": {"rest_id": "12345"}}}}},
+        status=200,
+    )
+    result = mod.retweet(COOKIE, "12345", undo=True)
+    assert result["success"] is True
+    assert result["action"] == "unretweeted"
+
+
+def test_retweet_requires_auth():
+    """retweet raises XApiError without cookie."""
+    try:
+        mod.retweet("", "12345")
+        assert False, "Expected XApiError"
+    except client_mod.XApiError as e:
+        assert e.code == "AUTH_REQUIRED"

--- a/skills/x/tests/test_x_search.py
+++ b/skills/x/tests/test_x_search.py
@@ -1,0 +1,116 @@
+"""Tests for x/scripts/x_search.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("x", "x_search")
+client_mod = load_script("x", "x_client")
+
+_SEARCH_RESPONSE = {
+    "data": {
+        "search_by_raw_query": {
+            "search_timeline": {
+                "timeline": {
+                    "instructions": [
+                        {
+                            "type": "TimelineAddEntries",
+                            "entries": [
+                                {
+                                    "entryId": "tweet-100",
+                                    "content": {
+                                        "itemContent": {
+                                            "tweet_results": {
+                                                "result": {
+                                                    "rest_id": "100",
+                                                    "core": {
+                                                        "user_results": {
+                                                            "result": {
+                                                                "legacy": {"screen_name": "dev1", "name": "Dev One"},
+                                                            },
+                                                        },
+                                                    },
+                                                    "legacy": {
+                                                        "full_text": "Claude is amazing for coding",
+                                                        "favorite_count": 50,
+                                                        "retweet_count": 10,
+                                                        "reply_count": 3,
+                                                        "created_at": "Mon Jan 01 12:00:00 +0000 2024",
+                                                    },
+                                                    "views": {"count": "1000"},
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                                {
+                                    "entryId": "tweet-200",
+                                    "content": {
+                                        "itemContent": {
+                                            "tweet_results": {
+                                                "result": {
+                                                    "rest_id": "200",
+                                                    "core": {
+                                                        "user_results": {
+                                                            "result": {
+                                                                "legacy": {"screen_name": "dev2", "name": "Dev Two"},
+                                                            },
+                                                        },
+                                                    },
+                                                    "legacy": {
+                                                        "full_text": "AI coding assistants are the future",
+                                                        "favorite_count": 25,
+                                                        "retweet_count": 5,
+                                                        "reply_count": 1,
+                                                        "created_at": "Tue Jan 02 12:00:00 +0000 2024",
+                                                    },
+                                                    "views": {"count": "500"},
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+            },
+        },
+    },
+}
+
+
+@responses.activate
+def test_search_tweets_returns_results():
+    """search_tweets returns formatted search results."""
+    responses.get(url=re.compile(r".+/SearchTimeline"), json=_SEARCH_RESPONSE, status=200)
+    client = client_mod.XClient()
+    result = mod.search_tweets(client, "claude code", limit=20)
+    assert result["query"] == "claude code"
+    assert result["product"] == "Latest"
+    assert result["count"] == 2
+    assert result["tweets"][0]["text"] == "Claude is amazing for coding"
+    assert result["tweets"][0]["author"] == "dev1"
+
+
+@responses.activate
+def test_search_tweets_empty():
+    """search_tweets returns empty for no results."""
+    empty = {"data": {"search_by_raw_query": {"search_timeline": {"timeline": {"instructions": []}}}}}
+    responses.get(url=re.compile(r".+/SearchTimeline"), json=empty, status=200)
+    client = client_mod.XClient()
+    result = mod.search_tweets(client, "xyznonexistent", limit=20)
+    assert result["count"] == 0
+    assert result["tweets"] == []
+
+
+@responses.activate
+def test_search_tweets_respects_limit():
+    """search_tweets respects the limit parameter."""
+    responses.get(url=re.compile(r".+/SearchTimeline"), json=_SEARCH_RESPONSE, status=200)
+    client = client_mod.XClient()
+    result = mod.search_tweets(client, "claude", limit=1)
+    assert result["count"] == 1
+    assert len(result["tweets"]) == 1

--- a/skills/x/tests/test_x_trending.py
+++ b/skills/x/tests/test_x_trending.py
@@ -1,0 +1,109 @@
+"""Tests for x/scripts/x_trending.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("x", "x_trending")
+client_mod = load_script("x", "x_client")
+
+_GUIDE_RESPONSE = {
+    "timeline": {
+        "instructions": [
+            {
+                "addEntries": {
+                    "entries": [
+                        {
+                            "content": {
+                                "timelineModule": {
+                                    "items": [
+                                        {
+                                            "item": {
+                                                "content": {
+                                                    "trend": {
+                                                        "name": "#AI",
+                                                        "tweetCount": 150000,
+                                                        "trendMetadata": {"domainContext": "Technology"},
+                                                    },
+                                                },
+                                            },
+                                        },
+                                        {
+                                            "item": {
+                                                "content": {
+                                                    "trend": {
+                                                        "name": "#Python",
+                                                        "tweetCount": 80000,
+                                                        "trendMetadata": {"domainContext": "Technology"},
+                                                    },
+                                                },
+                                            },
+                                        },
+                                        {
+                                            "item": {
+                                                "content": {
+                                                    "trend": {
+                                                        "name": "Breaking News",
+                                                        "tweetCount": None,
+                                                        "trendMetadata": {"domainContext": "News"},
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+        ],
+    },
+}
+
+
+@responses.activate
+def test_get_trending_returns_topics():
+    """get_trending returns formatted trending topics."""
+    responses.get(url=re.compile(r"https://x\.com/i/api/2/guide\.json"), json=_GUIDE_RESPONSE, status=200)
+    client = client_mod.XClient(cookie="ct0=abc123; auth_token=xyz")
+    result = mod.get_trending(client, limit=20)
+    assert result["count"] == 3
+    assert result["trends"][0]["rank"] == 1
+    assert result["trends"][0]["topic"] == "#AI"
+    assert result["trends"][0]["tweets"] == "150000"
+    assert result["trends"][0]["category"] == "Technology"
+    assert result["trends"][2]["tweets"] == "N/A"
+
+
+@responses.activate
+def test_get_trending_respects_limit():
+    """get_trending respects the limit parameter."""
+    responses.get(url=re.compile(r"https://x\.com/i/api/2/guide\.json"), json=_GUIDE_RESPONSE, status=200)
+    client = client_mod.XClient(cookie="ct0=abc123; auth_token=xyz")
+    result = mod.get_trending(client, limit=1)
+    assert result["count"] == 1
+    assert len(result["trends"]) == 1
+
+
+@responses.activate
+def test_get_trending_empty():
+    """get_trending returns empty for no trends."""
+    empty = {"timeline": {"instructions": []}}
+    responses.get(url=re.compile(r"https://x\.com/i/api/2/guide\.json"), json=empty, status=200)
+    client = client_mod.XClient(cookie="ct0=abc123; auth_token=xyz")
+    result = mod.get_trending(client, limit=20)
+    assert result["count"] == 0
+    assert result["trends"] == []
+
+
+def test_get_trending_requires_auth():
+    """get_trending raises XApiError without cookie."""
+    client = client_mod.XClient()
+    try:
+        mod.get_trending(client)
+        assert False, "Expected XApiError"
+    except client_mod.XApiError as e:
+        assert e.code == "AUTH_REQUIRED"

--- a/skills/x/tests/test_x_tweet.py
+++ b/skills/x/tests/test_x_tweet.py
@@ -1,0 +1,154 @@
+"""Tests for x/scripts/x_tweet.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("x", "x_tweet")
+client_mod = load_script("x", "x_client")
+
+_TWEET_DETAIL = {
+    "data": {
+        "threaded_conversation_with_injections_v2": {
+            "instructions": [
+                {
+                    "type": "TimelineAddEntries",
+                    "entries": [
+                        {
+                            "entryId": "tweet-999",
+                            "content": {
+                                "itemContent": {
+                                    "tweet_results": {
+                                        "result": {
+                                            "rest_id": "999",
+                                            "core": {
+                                                "user_results": {
+                                                    "result": {
+                                                        "legacy": {"screen_name": "author1", "name": "Author One"},
+                                                    },
+                                                },
+                                            },
+                                            "legacy": {
+                                                "full_text": "Original tweet",
+                                                "favorite_count": 100,
+                                                "retweet_count": 20,
+                                                "reply_count": 5,
+                                                "created_at": "Mon Jan 01 12:00:00 +0000 2024",
+                                            },
+                                            "views": {"count": "5000"},
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                        {
+                            "entryId": "conversationthread-999",
+                            "content": {
+                                "items": [
+                                    {
+                                        "item": {
+                                            "itemContent": {
+                                                "tweet_results": {
+                                                    "result": {
+                                                        "rest_id": "1000",
+                                                        "core": {
+                                                            "user_results": {
+                                                                "result": {
+                                                                    "legacy": {"screen_name": "replier", "name": "Replier"},
+                                                                },
+                                                            },
+                                                        },
+                                                        "legacy": {
+                                                            "full_text": "Great tweet!",
+                                                            "favorite_count": 5,
+                                                            "retweet_count": 0,
+                                                            "reply_count": 0,
+                                                            "in_reply_to_status_id_str": "999",
+                                                            "created_at": "Mon Jan 01 13:00:00 +0000 2024",
+                                                        },
+                                                        "views": {"count": "200"},
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+    },
+}
+
+
+@responses.activate
+def test_get_tweet_returns_thread():
+    """get_tweet returns the tweet and its replies."""
+    responses.get(url=re.compile(r".+/TweetDetail"), json=_TWEET_DETAIL, status=200)
+    client = client_mod.XClient()
+    result = mod.get_tweet(client, "999", limit=50)
+    assert result["tweet_id"] == "999"
+    assert result["count"] == 2
+    assert result["tweets"][0]["text"] == "Original tweet"
+    assert result["tweets"][0]["likes"] == 100
+    assert result["tweets"][1]["text"] == "Great tweet!"
+    assert result["tweets"][1]["in_reply_to"] == "999"
+
+
+@responses.activate
+def test_get_tweet_single():
+    """get_tweet works with a single tweet and no replies."""
+    single = {
+        "data": {
+            "threaded_conversation_with_injections_v2": {
+                "instructions": [
+                    {
+                        "type": "TimelineAddEntries",
+                        "entries": [
+                            {
+                                "entryId": "tweet-555",
+                                "content": {
+                                    "itemContent": {
+                                        "tweet_results": {
+                                            "result": {
+                                                "rest_id": "555",
+                                                "core": {
+                                                    "user_results": {
+                                                        "result": {"legacy": {"screen_name": "solo", "name": "Solo"}},
+                                                    },
+                                                },
+                                                "legacy": {
+                                                    "full_text": "Just a tweet",
+                                                    "favorite_count": 1,
+                                                    "retweet_count": 0,
+                                                    "reply_count": 0,
+                                                    "created_at": "Tue Jan 02 10:00:00 +0000 2024",
+                                                },
+                                                "views": {"count": "50"},
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+    }
+    responses.get(url=re.compile(r".+/TweetDetail"), json=single, status=200)
+    client = client_mod.XClient()
+    result = mod.get_tweet(client, "555")
+    assert result["count"] == 1
+    assert result["tweets"][0]["id"] == "555"
+
+
+@responses.activate
+def test_get_tweet_from_url():
+    """resolve_tweet_id extracts ID from a full URL."""
+    assert client_mod.resolve_tweet_id("https://x.com/user/status/12345") == "12345"
+    assert client_mod.resolve_tweet_id("12345") == "12345"

--- a/skills/x/tests/test_x_tweets.py
+++ b/skills/x/tests/test_x_tweets.py
@@ -1,0 +1,150 @@
+"""Tests for x/scripts/x_tweets.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("x", "x_tweets")
+client_mod = load_script("x", "x_client")
+
+_USER_BY_SCREEN_NAME = {
+    "data": {
+        "user": {
+            "result": {
+                "rest_id": "44196397",
+                "legacy": {"screen_name": "testuser"},
+            },
+        },
+    },
+}
+
+_USER_TWEETS = {
+    "data": {
+        "user": {
+            "result": {
+                "timeline_v2": {
+                    "timeline": {
+                        "instructions": [
+                            {
+                                "type": "TimelineAddEntries",
+                                "entries": [
+                                    {
+                                        "entryId": "tweet-1",
+                                        "content": {
+                                            "itemContent": {
+                                                "tweet_results": {
+                                                    "result": {
+                                                        "rest_id": "111",
+                                                        "core": {
+                                                            "user_results": {
+                                                                "result": {
+                                                                    "legacy": {"screen_name": "testuser", "name": "Test User"},
+                                                                },
+                                                            },
+                                                        },
+                                                        "legacy": {
+                                                            "full_text": "Hello world",
+                                                            "favorite_count": 10,
+                                                            "retweet_count": 2,
+                                                            "reply_count": 1,
+                                                            "created_at": "Mon Jan 01 12:00:00 +0000 2024",
+                                                        },
+                                                        "views": {"count": "500"},
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                    {
+                                        "entryId": "tweet-2",
+                                        "content": {
+                                            "itemContent": {
+                                                "tweet_results": {
+                                                    "result": {
+                                                        "rest_id": "222",
+                                                        "core": {
+                                                            "user_results": {
+                                                                "result": {
+                                                                    "legacy": {"screen_name": "testuser", "name": "Test User"},
+                                                                },
+                                                            },
+                                                        },
+                                                        "legacy": {
+                                                            "full_text": "Second tweet",
+                                                            "favorite_count": 5,
+                                                            "retweet_count": 0,
+                                                            "reply_count": 0,
+                                                            "created_at": "Mon Jan 02 12:00:00 +0000 2024",
+                                                        },
+                                                        "views": {"count": "100"},
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                    {
+                                        "entryId": "cursor-bottom-abc",
+                                        "content": {"value": "cursor-abc-123"},
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+    },
+}
+
+
+@responses.activate
+def test_get_user_tweets_returns_list():
+    """get_user_tweets returns formatted tweet list."""
+    responses.get(url=re.compile(r".+/UserByScreenName"), json=_USER_BY_SCREEN_NAME, status=200)
+    responses.get(url=re.compile(r".+/UserTweets"), json=_USER_TWEETS, status=200)
+    client = client_mod.XClient()
+    result = mod.get_user_tweets(client, "testuser", limit=20)
+    assert result["username"] == "testuser"
+    assert result["user_id"] == "44196397"
+    assert result["count"] == 2
+    assert len(result["tweets"]) == 2
+    assert result["tweets"][0]["text"] == "Hello world"
+    assert result["tweets"][0]["likes"] == 10
+    assert result["tweets"][1]["text"] == "Second tweet"
+
+
+@responses.activate
+def test_get_user_tweets_empty():
+    """get_user_tweets handles users with no tweets."""
+    empty_timeline = {
+        "data": {
+            "user": {
+                "result": {
+                    "timeline_v2": {
+                        "timeline": {
+                            "instructions": [{"type": "TimelineAddEntries", "entries": []}],
+                        },
+                    },
+                },
+            },
+        },
+    }
+    responses.get(url=re.compile(r".+/UserByScreenName"), json=_USER_BY_SCREEN_NAME, status=200)
+    responses.get(url=re.compile(r".+/UserTweets"), json=empty_timeline, status=200)
+    client = client_mod.XClient()
+    result = mod.get_user_tweets(client, "testuser", limit=20)
+    assert result["count"] == 0
+    assert result["tweets"] == []
+
+
+@responses.activate
+def test_get_user_tweets_respects_limit():
+    """get_user_tweets respects the limit parameter."""
+    responses.get(url=re.compile(r".+/UserByScreenName"), json=_USER_BY_SCREEN_NAME, status=200)
+    responses.get(url=re.compile(r".+/UserTweets"), json=_USER_TWEETS, status=200)
+    client = client_mod.XClient()
+    result = mod.get_user_tweets(client, "testuser", limit=1)
+    assert result["count"] == 1
+    assert len(result["tweets"]) == 1

--- a/skills/x/tests/test_x_user.py
+++ b/skills/x/tests/test_x_user.py
@@ -1,0 +1,111 @@
+"""Tests for x/scripts/x_user.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("x", "x_user")
+client_mod = load_script("x", "x_client")
+
+_USER_RESPONSE = {
+    "data": {
+        "user": {
+            "result": {
+                "__typename": "User",
+                "rest_id": "44196397",
+                "is_blue_verified": True,
+                "legacy": {
+                    "screen_name": "elonmusk",
+                    "name": "Elon Musk",
+                    "description": "Mars & Cars",
+                    "location": "Austin, TX",
+                    "followers_count": 180000000,
+                    "friends_count": 500,
+                    "statuses_count": 40000,
+                    "favourites_count": 30000,
+                    "verified": False,
+                    "created_at": "Tue Jun 02 20:12:29 +0000 2009",
+                    "entities": {
+                        "url": {
+                            "urls": [{"expanded_url": "https://tesla.com"}],
+                        },
+                    },
+                },
+            },
+        },
+    },
+}
+
+
+@responses.activate
+def test_get_user_returns_profile():
+    """get_user returns correctly formatted user profile."""
+    responses.get(
+        url=re.compile(r"https://x\.com/i/api/graphql/.+/UserByScreenName"),
+        json=_USER_RESPONSE,
+        status=200,
+    )
+    client = client_mod.XClient()
+    result = mod.get_user(client, "elonmusk")
+    assert result["screen_name"] == "elonmusk"
+    assert result["name"] == "Elon Musk"
+    assert result["followers"] == 180000000
+    assert result["verified"] is True
+    assert result["url"] == "https://tesla.com"
+
+
+@responses.activate
+def test_get_user_not_found():
+    """get_user raises XApiError for missing user."""
+    responses.get(
+        url=re.compile(r"https://x\.com/i/api/graphql/.+/UserByScreenName"),
+        json={"data": {"user": {}}},
+        status=200,
+    )
+    client = client_mod.XClient()
+    try:
+        mod.get_user(client, "nonexistentuser12345")
+        assert False, "Expected XApiError"
+    except client_mod.XApiError as e:
+        assert e.code == "NOT_FOUND"
+
+
+@responses.activate
+def test_get_user_without_url():
+    """get_user handles users with no URL entity."""
+    resp = {
+        "data": {
+            "user": {
+                "result": {
+                    "__typename": "User",
+                    "rest_id": "123",
+                    "is_blue_verified": False,
+                    "legacy": {
+                        "screen_name": "testuser",
+                        "name": "Test",
+                        "description": "",
+                        "location": "",
+                        "followers_count": 10,
+                        "friends_count": 5,
+                        "statuses_count": 100,
+                        "favourites_count": 50,
+                        "verified": False,
+                        "created_at": "Mon Jan 01 00:00:00 +0000 2020",
+                        "entities": {},
+                    },
+                },
+            },
+        },
+    }
+    responses.get(
+        url=re.compile(r"https://x\.com/i/api/graphql/.+/UserByScreenName"),
+        json=resp,
+        status=200,
+    )
+    client = client_mod.XClient()
+    result = mod.get_user(client, "testuser")
+    assert result["screen_name"] == "testuser"
+    assert result["url"] == ""
+    assert result["verified"] is False


### PR DESCRIPTION
## Summary
- Add complete X (Twitter) skill with GraphQL-based read and write operations
- **Read scripts**: user profile, tweets timeline, tweet detail/thread, search, trending topics, followers/following
- **Write scripts**: post tweet, like/unlike, retweet/unretweet, follow/unfollow, bookmark/unbookmark
- Shared `x_client.py` with bearer auth, CSRF handling, rate-limit retries, and response parsers
- 35 tests covering all scripts (all passing)
- SKILL.md with full documentation, auth setup, CLI args, safety notes, and workflow examples

## Test plan
- [x] `ruff check x/` passes with no errors
- [x] `pytest x/tests/ -v` — 35 tests all passing
- [x] SKILL.md formatted with prettier
- [ ] CI checks pass