### PR TITLE
feat(bilibili): add Bilibili skill with read/write support

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sigcli/cli",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "General-purpose authentication CLI with pluggable strategies and browser adapters",
     "main": "dist/index.js",
     "type": "module",

--- a/skills/bilibili/SKILL.md
+++ b/skills/bilibili/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: bilibili
+description: 'Interact with Bilibili (B站) — browse trending videos, view video details, read comments, search videos and users, view user profiles, like, coin, and favorite videos. Use this skill whenever the user mentions Bilibili, B站, wants to browse Bilibili content, search Bilibili videos, read Bilibili comments, look up Bilibili users, or interact with Bilibili content. Also trigger when the user pastes a Bilibili URL (e.g. bilibili.com/video/BV...) or mentions a BV ID.'
+---
+
+# Bilibili
+
+Browse trending videos, view video details, read comments, search content, view user profiles, and interact with Bilibili (B站).
+
+## Authentication
+
+**Read operations** work without authentication via Bilibili's public web API. No credentials needed.
+
+**Write operations** (like, coin, favorite) require a **session cookie**. Use `sig run` to inject it:
+
+```bash
+sig run bilibili -- bash -c 'python3 scripts/bilibili_like.py --cookie "$SIG_BILIBILI_COOKIE" --aid 123456'
+```
+
+The default Signet provider is `bilibili`. The env var is `SIG_BILIBILI_COOKIE`.
+
+If a write script returns auth error, re-authenticate:
+
+```bash
+sig login https://www.bilibili.com/
+```
+
+**Signet provider config:**
+
+```yaml
+bilibili:
+    domains: ['www.bilibili.com', 'bilibili.com', 'api.bilibili.com']
+    entryUrl: https://www.bilibili.com/
+    strategy: cookie
+    config:
+        ttl: '7d'
+        requiredCookies: ['SESSDATA', 'bili_jct']
+```
+
+## Scripts Reference
+
+All scripts are in this skill's `scripts/` directory. Run via Bash tool.
+
+### Read Operations
+
+| Script                 | Purpose              | Auth     |
+| ---------------------- | -------------------- | -------- |
+| `bilibili_video.py`    | Video details by BV  | None     |
+| `bilibili_hot.py`      | Hot/trending videos  | None     |
+| `bilibili_popular.py`  | Popular videos       | None     |
+| `bilibili_ranking.py`  | Ranking by category  | None     |
+| `bilibili_search.py`   | Search videos/users  | None     |
+| `bilibili_comments.py` | Video comments       | None     |
+| `bilibili_user.py`     | User profile + vids  | None     |
+| `bilibili_dynamic.py`  | Dynamic feed (动态)  | Required |
+| `bilibili_me.py`       | Current user profile | Required |
+| `bilibili_history.py`  | Watch history        | Required |
+| `bilibili_subtitle.py` | Video subtitles      | None     |
+
+### Write Operations
+
+| Script                 | Purpose             | Auth     |
+| ---------------------- | ------------------- | -------- |
+| `bilibili_like.py`     | Like/unlike a video | Required |
+| `bilibili_coin.py`     | Give coins to video | Required |
+| `bilibili_favorite.py` | Favorite/unfavorite | Required |
+
+### bilibili_video.py
+
+```
+--bvid ID             Video BV ID (e.g. BV1xx411c7mD) (required)
+```
+
+### bilibili_hot.py
+
+```
+--limit N             Max videos to return (default: 20)
+--page N              Page number (default: 1)
+```
+
+### bilibili_popular.py
+
+```
+--limit N             Max videos to return (default: 20)
+--page N              Page number (default: 1)
+```
+
+### bilibili_ranking.py
+
+```
+--category NAME       Category: all, anime, music, dance, game, tech, knowledge, life, food, animal, car, fashion, entertainment, movie, tv (default: all)
+--limit N             Max videos to return (default: 20)
+```
+
+### bilibili_search.py
+
+```
+--keyword TEXT        Search keyword (required)
+--type TYPE           Search type: video, user (default: video)
+--page N              Page number (default: 1)
+--limit N             Max results (default: 20)
+```
+
+### bilibili_comments.py
+
+```
+--bvid ID             Video BV ID (required)
+--limit N             Max comments to return (default: 20)
+--page N              Page number (default: 1)
+```
+
+### bilibili_user.py
+
+```
+--mid N               User mid (numeric ID) (required)
+--include-videos      Include recent videos (flag)
+```
+
+### bilibili_dynamic.py
+
+```
+--cookie COOKIE       Bilibili session cookie (required)
+--limit N             Max items to return (default: 20)
+--offset TOKEN        Pagination offset from previous response
+```
+
+### bilibili_me.py
+
+```
+--cookie COOKIE       Bilibili session cookie (required)
+```
+
+### bilibili_history.py
+
+```
+--cookie COOKIE       Bilibili session cookie (required)
+--limit N             Max items to return (default: 20)
+--view-at N           Cursor from previous response for pagination
+```
+
+### bilibili_subtitle.py
+
+```
+--bvid ID             Video BV ID (required)
+--lang CODE           Subtitle language code (e.g. zh-CN, en-US, ai-zh). Default: first available
+--cookie COOKIE       Bilibili session cookie (may be needed for some videos)
+```
+
+### bilibili_like.py
+
+```
+--cookie COOKIE       Bilibili session cookie (required)
+--aid N               Video aid (numeric ID) (required)
+--undo                Unlike instead of like (flag)
+```
+
+### bilibili_coin.py
+
+```
+--cookie COOKIE       Bilibili session cookie (required)
+--aid N               Video aid (numeric ID) (required)
+--multiply N          Number of coins: 1 or 2 (default: 1)
+```
+
+### bilibili_favorite.py
+
+```
+--cookie COOKIE       Bilibili session cookie (required)
+--aid N               Video aid (numeric ID) (required)
+--folder-id N         Favorites folder ID (optional, defaults to first folder)
+--undo                Remove from favorites instead of adding (flag)
+```
+
+## Safety
+
+**Write operations are visible to the user's Bilibili account.** Like and favorite are reversible via `--undo`. Coins cannot be taken back once given.
+
+**Always confirm with the user before calling `bilibili_coin.py`** since coins are a limited, non-refundable currency on Bilibili.
+
+## Key Concepts
+
+**BV IDs** — Bilibili videos are identified by BV IDs (e.g. `BV1xx411c7mD`). Most read scripts accept BV IDs directly.
+
+**AIDs** — Numeric video IDs used by write operations. Get the `aid` from video details (`bilibili_video.py`).
+
+**WBI Signing** — Search and user profile endpoints require WBI parameter signing. The client handles this automatically.
+
+**CSRF Token** — Write operations need a `bili_jct` CSRF token extracted from the session cookie. The client extracts it automatically.
+
+**Categories** — Ranking supports categories: all (0), anime (1), music (3), dance (129), game (4), tech (188), knowledge (36), life (160), food (211), animal (217), car (223), fashion (155), entertainment (5), movie (181), tv (177).
+
+**Pagination** — List endpoints accept `--page` for page number and `--limit` for page size.
+
+## Error Handling
+
+| Error         | Cause                        | Fix                                 |
+| ------------- | ---------------------------- | ----------------------------------- |
+| HTTP_412      | Request blocked by anti-spam | Wait and retry, or use different IP |
+| HTTP_404      | Video/user not found         | Check the ID is correct             |
+| AUTH_REQUIRED | No cookie for write op       | Run `sig login` and retry           |
+| NO_CSRF       | No bili_jct in cookie        | Re-authenticate via `sig login`     |
+| API_ERROR     | Bilibili returned error code | Check error message for details     |
+
+## Workflow Examples
+
+### Browse hot videos
+
+1. `python3 scripts/bilibili_hot.py --limit 10`
+2. Next page: `python3 scripts/bilibili_hot.py --limit 10 --page 2`
+
+### Get video details
+
+1. `python3 scripts/bilibili_video.py --bvid BV1xx411c7mD`
+
+### Search for videos
+
+1. `python3 scripts/bilibili_search.py --keyword "machine learning" --limit 10`
+
+### Search for users
+
+1. `python3 scripts/bilibili_search.py --keyword "username" --type user`
+
+### Read video comments
+
+1. `python3 scripts/bilibili_comments.py --bvid BV1xx411c7mD --limit 20`
+
+### View ranking
+
+1. `python3 scripts/bilibili_ranking.py --category music --limit 10`
+
+### Like a video
+
+1. Get the aid: `python3 scripts/bilibili_video.py --bvid BV1xx411c7mD` (check the `aid` field)
+2. `sig run bilibili -- bash -c 'python3 scripts/bilibili_like.py --cookie "$SIG_BILIBILI_COOKIE" --aid 123456'`
+
+### Give coins
+
+1. **Confirm with user first — coins are non-refundable**
+2. `sig run bilibili -- bash -c 'python3 scripts/bilibili_coin.py --cookie "$SIG_BILIBILI_COOKIE" --aid 123456 --multiply 1'`
+
+### Add to favorites
+
+1. `sig run bilibili -- bash -c 'python3 scripts/bilibili_favorite.py --cookie "$SIG_BILIBILI_COOKIE" --aid 123456 --folder-id 100'`
+
+### View my profile
+
+1. `sig run bilibili -- bash -c 'python3 scripts/bilibili_me.py --cookie "$SIG_BILIBILI_COOKIE"'`
+
+### Browse dynamic feed
+
+1. `sig run bilibili -- bash -c 'python3 scripts/bilibili_dynamic.py --cookie "$SIG_BILIBILI_COOKIE" --limit 10'`
+2. Next page: `sig run bilibili -- bash -c 'python3 scripts/bilibili_dynamic.py --cookie "$SIG_BILIBILI_COOKIE" --offset TOKEN'`
+
+### View watch history
+
+1. `sig run bilibili -- bash -c 'python3 scripts/bilibili_history.py --cookie "$SIG_BILIBILI_COOKIE" --limit 20'`
+
+### Get video subtitles
+
+1. `python3 scripts/bilibili_subtitle.py --bvid BV1xx411c7mD`
+2. Choose language: `python3 scripts/bilibili_subtitle.py --bvid BV1xx411c7mD --lang en-US`

--- a/skills/bilibili/scripts/bilibili_client.py
+++ b/skills/bilibili/scripts/bilibili_client.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Shared Bilibili client for Bilibili skill scripts.
+
+Handles HTTP transport with WBI signing, CSRF extraction,
+and response normalization for Bilibili's web API.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import time
+import urllib.parse
+
+import requests
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+BILIBILI_API = "https://api.bilibili.com"
+USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+TIMEOUT = 15
+
+MIXIN_KEY_ENC_TAB = [
+    46, 47, 18, 2, 53, 8, 23, 32, 15, 50, 10, 31, 58, 3, 45, 35, 27, 43, 5, 49,
+    33, 9, 42, 19, 29, 28, 14, 39, 12, 38, 41, 13, 37, 48, 7, 16, 24, 55, 40,
+    61, 26, 17, 0, 1, 60, 51, 30, 4, 22, 25, 34, 6, 11, 56, 20, 36, 21, 44, 57,
+    59, 52, 54, 62, 63,
+]
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class BilibiliApiError(Exception):
+    """Raised when Bilibili returns an unexpected response."""
+
+    def __init__(self, code: str, message: str = ""):
+        self.code = code
+        self.message = message or code
+        super().__init__(self.message)
+
+
+def error_response(code: str, message: str) -> dict:
+    """Build a standard error dict for JSON output."""
+    return {"error": code, "message": message}
+
+
+# ---------------------------------------------------------------------------
+# WBI Signing
+# ---------------------------------------------------------------------------
+
+
+def _get_mixin_key(img_key: str, sub_key: str) -> str:
+    raw = img_key + sub_key
+    return "".join(raw[i] for i in MIXIN_KEY_ENC_TAB if i < len(raw))[:32]
+
+
+def _wbi_sign(params: dict, img_key: str, sub_key: str) -> dict:
+    mixin_key = _get_mixin_key(img_key, sub_key)
+    wts = str(int(time.time()))
+    all_params = {**params, "wts": wts}
+    sorted_params = {}
+    for key in sorted(all_params.keys()):
+        sorted_params[key] = re.sub(r"[!'()*]", "", str(all_params[key]))
+    query = urllib.parse.urlencode(sorted_params)
+    w_rid = hashlib.md5((query + mixin_key).encode()).hexdigest()
+    sorted_params["w_rid"] = w_rid
+    return sorted_params
+
+
+# ---------------------------------------------------------------------------
+# Bilibili API client
+# ---------------------------------------------------------------------------
+
+
+class BilibiliClient:
+    """HTTP client for Bilibili's web API with optional cookie auth."""
+
+    def __init__(self, cookie: str = ""):
+        self.cookie = cookie
+        self._session = requests.Session()
+        self._session.headers["User-Agent"] = USER_AGENT
+        self._session.headers["Referer"] = "https://www.bilibili.com"
+        if cookie:
+            self._session.headers["Cookie"] = cookie
+        self._img_key = ""
+        self._sub_key = ""
+        self._wbi_ts = 0.0
+
+    @classmethod
+    def create(cls) -> "BilibiliClient":
+        cookie = os.environ.get("SIG_BILIBILI_COOKIE", "")
+        return cls(cookie)
+
+    def _ensure_wbi_keys(self):
+        if self._img_key and (time.time() - self._wbi_ts) < 600:
+            return
+        resp = self._session.get(f"{BILIBILI_API}/x/web-interface/nav", timeout=TIMEOUT)
+        resp.raise_for_status()
+        data = resp.json().get("data", {})
+        wbi_img = data.get("wbi_img", {})
+        img_url = wbi_img.get("img_url", "")
+        sub_url = wbi_img.get("sub_url", "")
+        self._img_key = img_url.split("/")[-1].split(".")[0] if img_url else ""
+        self._sub_key = sub_url.split("/")[-1].split(".")[0] if sub_url else ""
+        self._wbi_ts = time.time()
+
+    def get(self, path: str, params: dict | None = None, signed: bool = False) -> dict:
+        """GET a Bilibili API endpoint. Optionally signs with WBI."""
+        params = dict(params or {})
+        if signed:
+            self._ensure_wbi_keys()
+            params = _wbi_sign(params, self._img_key, self._sub_key)
+        resp = self._session.get(f"{BILIBILI_API}{path}", params=params, timeout=TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+
+    def post(self, path: str, data: dict | None = None) -> dict:
+        """POST form-encoded data to a Bilibili API endpoint."""
+        self.require_cookie()
+        resp = self._session.post(f"{BILIBILI_API}{path}", data=data, timeout=TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_csrf(self) -> str:
+        """Extract CSRF token (bili_jct) from cookie string."""
+        self.require_cookie()
+        match = re.search(r"bili_jct=([^;]+)", self.cookie)
+        if not match:
+            raise BilibiliApiError("NO_CSRF", "Cannot extract bili_jct CSRF token from cookie. Re-authenticate with: sig login https://www.bilibili.com/")
+        return match.group(1)
+
+    def require_cookie(self):
+        if not self.cookie:
+            raise BilibiliApiError(
+                "AUTH_REQUIRED",
+                "This operation requires a Bilibili session cookie. Run: sig login https://www.bilibili.com/",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Response parsers
+# ---------------------------------------------------------------------------
+
+
+def parse_video(data: dict) -> dict:
+    """Normalize a Bilibili video data dict to output format."""
+    stat = data.get("stat", {})
+    owner = data.get("owner", {})
+    dur = data.get("duration", 0)
+    pub = data.get("pubdate", 0)
+    return {
+        "bvid": data.get("bvid", ""),
+        "aid": data.get("aid", 0),
+        "title": data.get("title", ""),
+        "author": owner.get("name", ""),
+        "author_mid": owner.get("mid", 0),
+        "description": data.get("desc", ""),
+        "duration": dur,
+        "duration_text": f"{dur // 60}m{dur % 60}s" if dur else "",
+        "thumbnail": data.get("pic", ""),
+        "publish_time": pub,
+        "view": stat.get("view", 0),
+        "like": stat.get("like", 0),
+        "coin": stat.get("coin", 0),
+        "favorite": stat.get("favorite", 0),
+        "share": stat.get("share", 0),
+        "reply": stat.get("reply", 0),
+        "danmaku": stat.get("danmaku", 0),
+    }
+
+
+def parse_comment(data: dict) -> dict:
+    """Normalize a Bilibili comment data dict."""
+    member = data.get("member", {})
+    content = data.get("content", {})
+    ctime = data.get("ctime", 0)
+    return {
+        "rpid": data.get("rpid", 0),
+        "author": member.get("uname", ""),
+        "author_mid": member.get("mid", 0),
+        "text": content.get("message", ""),
+        "like": data.get("like", 0),
+        "replies": data.get("rcount", 0),
+        "time": ctime,
+    }

--- a/skills/bilibili/scripts/bilibili_coin.py
+++ b/skills/bilibili/scripts/bilibili_coin.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Give coins to a Bilibili video."""
+
+import argparse
+import json
+import sys
+
+import requests
+from bilibili_client import BilibiliApiError, BilibiliClient
+
+
+def coin_video(client: BilibiliClient, aid: int, multiply: int = 1) -> dict:
+    """Give coins to a video by aid."""
+    csrf = client.get_csrf()
+    if multiply not in (1, 2):
+        raise BilibiliApiError("INVALID_PARAM", "multiply must be 1 or 2")
+    payload = client.post("/x/web-interface/coin/add", data={"aid": aid, "multiply": multiply, "csrf": csrf})
+    if payload.get("code") != 0:
+        raise BilibiliApiError("API_ERROR", f"Bilibili API error: {payload.get('message', 'unknown')} (code {payload.get('code')})")
+    return {
+        "success": True,
+        "aid": aid,
+        "multiply": multiply,
+        "message": f"Gave {multiply} coin(s) to video",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Give coins to a Bilibili video")
+    parser.add_argument("--cookie", required=True, help="Bilibili session cookie")
+    parser.add_argument("--aid", required=True, type=int, help="Video aid (numeric ID)")
+    parser.add_argument("--multiply", type=int, default=1, choices=[1, 2], help="Number of coins: 1 or 2 (default: 1)")
+    args = parser.parse_args()
+
+    try:
+        client = BilibiliClient(args.cookie)
+        result = coin_video(client, args.aid, args.multiply)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except BilibiliApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/bilibili/scripts/bilibili_comments.py
+++ b/skills/bilibili/scripts/bilibili_comments.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Get comments on a Bilibili video."""
+
+import argparse
+import json
+import sys
+
+import requests
+from bilibili_client import BilibiliApiError, BilibiliClient, parse_comment
+
+
+def get_comments(client: BilibiliClient, bvid: str, limit: int = 20, page: int = 1) -> dict:
+    """Fetch comments for a video by BV ID."""
+    view = client.get("/x/web-interface/view", params={"bvid": bvid})
+    if view.get("code") != 0:
+        raise BilibiliApiError("API_ERROR", f"Cannot resolve video: {view.get('message', 'unknown')}")
+    aid = view.get("data", {}).get("aid")
+    if not aid:
+        raise BilibiliApiError("API_ERROR", f"Cannot resolve aid for bvid: {bvid}")
+
+    payload = client.get("/x/v2/reply/main", params={"type": 1, "oid": aid, "mode": 3, "next": page - 1})
+    if payload.get("code") != 0:
+        raise BilibiliApiError("API_ERROR", f"Bilibili API error: {payload.get('message', 'unknown')} (code {payload.get('code')})")
+    replies = payload.get("data", {}).get("replies", []) or []
+    comments = [parse_comment(r) for r in replies[:limit]]
+    total = payload.get("data", {}).get("page", {}).get("count", 0)
+    return {
+        "bvid": bvid,
+        "aid": aid,
+        "total": total,
+        "page": page,
+        "count": len(comments),
+        "comments": comments,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get comments on a Bilibili video")
+    parser.add_argument("--bvid", required=True, help="Video BV ID (e.g. BV1xx411c7mD)")
+    parser.add_argument("--limit", type=int, default=20, help="Max comments to return (default: 20)")
+    parser.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
+    args = parser.parse_args()
+
+    try:
+        client = BilibiliClient.create()
+        result = get_comments(client, args.bvid, args.limit, args.page)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except BilibiliApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/bilibili/scripts/bilibili_dynamic.py
+++ b/skills/bilibili/scripts/bilibili_dynamic.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Get Bilibili dynamic feed (动态)."""
+
+import argparse
+import json
+import sys
+
+import requests
+from bilibili_client import BilibiliApiError, BilibiliClient
+
+
+def parse_dynamic(item: dict) -> dict:
+    modules = item.get("modules", {})
+    author = modules.get("module_author", {})
+    dynamic = modules.get("module_dynamic", {})
+    stat = modules.get("module_stat", {})
+
+    text = ""
+    desc = dynamic.get("desc")
+    if desc and desc.get("text"):
+        text = desc["text"]
+    major = dynamic.get("major")
+    if not text and major:
+        archive = major.get("archive", {})
+        if archive.get("title"):
+            text = archive["title"]
+
+    id_str = item.get("id_str", "")
+    return {
+        "id": id_str,
+        "type": item.get("type", ""),
+        "author": author.get("name", ""),
+        "author_mid": author.get("mid", 0),
+        "text": text,
+        "likes": stat.get("like", {}).get("count", 0),
+        "comments": stat.get("comment", {}).get("count", 0),
+        "forwards": stat.get("forward", {}).get("count", 0),
+        "time": author.get("pub_ts", 0),
+        "url": f"https://t.bilibili.com/{id_str}" if id_str else "",
+    }
+
+
+def get_dynamic_feed(client: BilibiliClient, limit: int = 20, offset: str = "") -> dict:
+    """Fetch the authenticated user's dynamic feed."""
+    client.require_cookie()
+    params = {"type": "all"}
+    if offset:
+        params["offset"] = offset
+    payload = client.get("/x/polymer/web-dynamic/v1/feed/all", params=params)
+    if payload.get("code") != 0:
+        raise BilibiliApiError("API_ERROR", f"Bilibili API error: {payload.get('message', 'unknown')} (code {payload.get('code')})")
+    data = payload.get("data", {})
+    items = data.get("items", [])
+    dynamics = [parse_dynamic(item) for item in items[:limit]]
+    return {
+        "count": len(dynamics),
+        "has_more": data.get("has_more", False),
+        "offset": data.get("offset", ""),
+        "dynamics": dynamics,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Bilibili dynamic feed")
+    parser.add_argument("--limit", type=int, default=20, help="Max items to return (default: 20)")
+    parser.add_argument("--offset", default="", help="Pagination offset from previous response")
+    parser.add_argument("--cookie", default="", help="Bilibili session cookie")
+    args = parser.parse_args()
+
+    try:
+        client = BilibiliClient(args.cookie) if args.cookie else BilibiliClient.create()
+        result = get_dynamic_feed(client, args.limit, args.offset)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except BilibiliApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/bilibili/scripts/bilibili_favorite.py
+++ b/skills/bilibili/scripts/bilibili_favorite.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Add or remove a Bilibili video from favorites."""
+
+import argparse
+import json
+import sys
+from typing import Optional
+
+import requests
+from bilibili_client import BilibiliApiError, BilibiliClient
+
+
+def favorite_video(client: BilibiliClient, aid: int, folder_id: Optional[int] = None, undo: bool = False) -> dict:
+    """Add or remove a video from a favorites folder."""
+    csrf = client.get_csrf()
+
+    if folder_id is None:
+        nav = client.get("/x/web-interface/nav")
+        mid = nav.get("data", {}).get("mid", 0)
+        if not mid:
+            raise BilibiliApiError("NO_USER", "Cannot determine user ID from session")
+        folders = client.get("/x/v3/fav/folder/created/list-all", params={"up_mid": mid, "type": 2})
+        folder_list = folders.get("data", {}).get("list") or []
+        if not folder_list:
+            raise BilibiliApiError("NO_FOLDER", "No favorites folder found. Create one on bilibili.com first.")
+        folder_id = folder_list[0]["id"]
+
+    data = {
+        "rid": aid,
+        "type": 2,
+        "csrf": csrf,
+    }
+    if undo:
+        data["del_media_ids"] = folder_id
+    else:
+        data["add_media_ids"] = folder_id
+    payload = client.post("/x/v3/fav/resource/deal", data=data)
+    if payload.get("code") != 0:
+        raise BilibiliApiError("API_ERROR", f"Bilibili API error: {payload.get('message', 'unknown')} (code {payload.get('code')})")
+    return {
+        "success": True,
+        "aid": aid,
+        "folder_id": folder_id,
+        "action": "unfavorite" if undo else "favorite",
+        "message": f"Video {'removed from' if undo else 'added to'} favorites folder {folder_id}",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Add or remove a Bilibili video from favorites")
+    parser.add_argument("--cookie", required=True, help="Bilibili session cookie")
+    parser.add_argument("--aid", required=True, type=int, help="Video aid (numeric ID)")
+    parser.add_argument("--folder-id", type=int, default=None, help="Favorites folder ID (default: first folder)")
+    parser.add_argument("--undo", action="store_true", help="Remove from favorites instead of adding")
+    args = parser.parse_args()
+
+    try:
+        client = BilibiliClient(args.cookie)
+        result = favorite_video(client, args.aid, args.folder_id, args.undo)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except BilibiliApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/bilibili/scripts/bilibili_history.py
+++ b/skills/bilibili/scripts/bilibili_history.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Get Bilibili watch history."""
+
+import argparse
+import json
+import sys
+
+import requests
+from bilibili_client import BilibiliApiError, BilibiliClient
+
+
+def _fmt_duration(seconds: int) -> str:
+    m = seconds // 60
+    s = seconds % 60
+    return f"{m}:{s:02d}"
+
+
+def parse_history_item(item: dict, rank: int) -> dict:
+    progress = item.get("progress", 0)
+    duration = item.get("duration", 0)
+    if progress < 0 or (duration > 0 and progress >= duration):
+        progress_text = "finished"
+    elif duration > 0:
+        pct = round(progress / duration * 100)
+        progress_text = f"{_fmt_duration(progress)}/{_fmt_duration(duration)} ({pct}%)"
+    else:
+        progress_text = ""
+
+    history = item.get("history", {})
+    bvid = history.get("bvid", "")
+    return {
+        "rank": rank,
+        "title": item.get("title", ""),
+        "author": item.get("author_name", ""),
+        "author_mid": item.get("author_mid", 0),
+        "bvid": bvid,
+        "progress": progress_text,
+        "duration": duration,
+        "view_at": item.get("view_at", 0),
+        "tag_name": item.get("tag_name", ""),
+        "url": f"https://www.bilibili.com/video/{bvid}" if bvid else "",
+    }
+
+
+def get_history(client: BilibiliClient, limit: int = 20, view_at: int = 0, business: str = "") -> dict:
+    """Fetch watch history with cursor-based pagination."""
+    client.require_cookie()
+    params = {"ps": min(limit, 30), "type": "archive"}
+    if view_at:
+        params["view_at"] = view_at
+    if business:
+        params["business"] = business
+    payload = client.get("/x/web-interface/history/cursor", params=params)
+    if payload.get("code") != 0:
+        raise BilibiliApiError("API_ERROR", f"Bilibili API error: {payload.get('message', 'unknown')} (code {payload.get('code')})")
+    data = payload.get("data", {})
+    items_raw = data.get("list", []) or []
+    items = [parse_history_item(item, i + 1) for i, item in enumerate(items_raw[:limit])]
+    cursor = data.get("cursor", {})
+    return {
+        "count": len(items),
+        "cursor_view_at": cursor.get("view_at", 0),
+        "cursor_business": cursor.get("business", ""),
+        "items": items,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Bilibili watch history")
+    parser.add_argument("--limit", type=int, default=20, help="Max items to return (default: 20)")
+    parser.add_argument("--view-at", type=int, default=0, help="Cursor: view_at from previous response for pagination")
+    parser.add_argument("--cookie", default="", help="Bilibili session cookie")
+    args = parser.parse_args()
+
+    try:
+        client = BilibiliClient(args.cookie) if args.cookie else BilibiliClient.create()
+        result = get_history(client, args.limit, args.view_at)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except BilibiliApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/bilibili/scripts/bilibili_hot.py
+++ b/skills/bilibili/scripts/bilibili_hot.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Get Bilibili hot/trending videos."""
+
+import argparse
+import json
+import sys
+
+import requests
+from bilibili_client import BilibiliApiError, BilibiliClient, parse_video
+
+
+def get_hot_videos(client: BilibiliClient, limit: int, page: int = 1) -> dict:
+    """Fetch hot/trending videos."""
+    payload = client.get("/x/web-interface/popular", params={"pn": page, "ps": limit})
+    if payload.get("code") != 0:
+        raise BilibiliApiError("API_ERROR", f"Bilibili API error: {payload.get('message', 'unknown')} (code {payload.get('code')})")
+    videos = [parse_video(item) for item in payload.get("data", {}).get("list", [])]
+    return {
+        "count": len(videos),
+        "page": page,
+        "videos": videos,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Bilibili hot/trending videos")
+    parser.add_argument("--limit", type=int, default=20, help="Max videos to return (default: 20)")
+    parser.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
+    args = parser.parse_args()
+
+    try:
+        client = BilibiliClient.create()
+        result = get_hot_videos(client, args.limit, args.page)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except BilibiliApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/bilibili/scripts/bilibili_like.py
+++ b/skills/bilibili/scripts/bilibili_like.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Like or unlike a Bilibili video."""
+
+import argparse
+import json
+import sys
+
+import requests
+from bilibili_client import BilibiliApiError, BilibiliClient
+
+
+def like_video(client: BilibiliClient, aid: int, undo: bool = False) -> dict:
+    """Like or unlike a video by aid."""
+    csrf = client.get_csrf()
+    like_val = 2 if undo else 1
+    payload = client.post("/x/web-interface/archive/like", data={"aid": aid, "like": like_val, "csrf": csrf})
+    if payload.get("code") != 0:
+        raise BilibiliApiError("API_ERROR", f"Bilibili API error: {payload.get('message', 'unknown')} (code {payload.get('code')})")
+    return {
+        "success": True,
+        "aid": aid,
+        "action": "unlike" if undo else "like",
+        "message": f"Video {'unliked' if undo else 'liked'} successfully",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Like or unlike a Bilibili video")
+    parser.add_argument("--cookie", required=True, help="Bilibili session cookie")
+    parser.add_argument("--aid", required=True, type=int, help="Video aid (numeric ID)")
+    parser.add_argument("--undo", action="store_true", help="Unlike instead of like")
+    args = parser.parse_args()
+
+    try:
+        client = BilibiliClient(args.cookie)
+        result = like_video(client, args.aid, args.undo)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except BilibiliApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/bilibili/scripts/bilibili_me.py
+++ b/skills/bilibili/scripts/bilibili_me.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Get current Bilibili user profile."""
+
+import argparse
+import json
+import sys
+
+import requests
+from bilibili_client import BilibiliApiError, BilibiliClient
+
+
+def get_me(client: BilibiliClient) -> dict:
+    """Fetch the authenticated user's profile via /x/web-interface/nav."""
+    client.require_cookie()
+    payload = client.get("/x/web-interface/nav")
+    if payload.get("code") != 0:
+        raise BilibiliApiError("API_ERROR", f"Bilibili API error: {payload.get('message', 'unknown')} (code {payload.get('code')})")
+    data = payload.get("data", {})
+    return {
+        "mid": data.get("mid", 0),
+        "name": data.get("uname", ""),
+        "face": data.get("face", ""),
+        "level": data.get("level_info", {}).get("current_level", 0),
+        "coins": data.get("money", 0),
+        "vip_type": data.get("vipType", 0),
+        "vip_label": data.get("vip", {}).get("label", {}).get("text", ""),
+        "is_login": data.get("isLogin", False),
+        "email_verified": data.get("email_verified", 0),
+        "phone_verified": data.get("mobile_verified", 0),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get current Bilibili user profile")
+    parser.add_argument("--cookie", default="", help="Bilibili session cookie")
+    args = parser.parse_args()
+
+    try:
+        client = BilibiliClient(args.cookie) if args.cookie else BilibiliClient.create()
+        result = get_me(client)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except BilibiliApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/bilibili/scripts/bilibili_popular.py
+++ b/skills/bilibili/scripts/bilibili_popular.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Get Bilibili popular videos (same as hot but with separate entry point for clarity)."""
+
+import argparse
+import json
+import sys
+
+import requests
+from bilibili_client import BilibiliApiError, BilibiliClient, parse_video
+
+
+def get_popular_videos(client: BilibiliClient, limit: int, page: int = 1) -> dict:
+    """Fetch popular videos."""
+    payload = client.get("/x/web-interface/popular", params={"pn": page, "ps": limit})
+    if payload.get("code") != 0:
+        raise BilibiliApiError("API_ERROR", f"Bilibili API error: {payload.get('message', 'unknown')} (code {payload.get('code')})")
+    videos = [parse_video(item) for item in payload.get("data", {}).get("list", [])]
+    no_more = payload.get("data", {}).get("no_more", False)
+    return {
+        "count": len(videos),
+        "page": page,
+        "no_more": no_more,
+        "videos": videos,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Bilibili popular videos")
+    parser.add_argument("--limit", type=int, default=20, help="Max videos to return (default: 20)")
+    parser.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
+    args = parser.parse_args()
+
+    try:
+        client = BilibiliClient.create()
+        result = get_popular_videos(client, args.limit, args.page)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except BilibiliApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/bilibili/scripts/bilibili_ranking.py
+++ b/skills/bilibili/scripts/bilibili_ranking.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Get Bilibili ranking videos by category."""
+
+import argparse
+import json
+import sys
+
+import requests
+from bilibili_client import BilibiliApiError, BilibiliClient, parse_video
+
+TID_MAP = {
+    "all": 0,
+    "anime": 1,
+    "music": 3,
+    "dance": 129,
+    "game": 4,
+    "tech": 188,
+    "knowledge": 36,
+    "life": 160,
+    "food": 211,
+    "animal": 217,
+    "car": 223,
+    "fashion": 155,
+    "entertainment": 5,
+    "movie": 181,
+    "tv": 177,
+}
+
+
+def get_ranking(client: BilibiliClient, category: str = "all", limit: int = 20) -> dict:
+    """Fetch ranking videos by category."""
+    tid = TID_MAP.get(category, 0)
+    payload = client.get("/x/web-interface/ranking/v2", params={"rid": tid, "type": "all"})
+    if payload.get("code") != 0:
+        raise BilibiliApiError("API_ERROR", f"Bilibili API error: {payload.get('message', 'unknown')} (code {payload.get('code')})")
+    items = payload.get("data", {}).get("list", [])
+    videos = [parse_video(item) for item in items[:limit]]
+    return {
+        "category": category,
+        "tid": tid,
+        "count": len(videos),
+        "videos": videos,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Bilibili ranking videos")
+    parser.add_argument("--category", default="all", help=f"Category: {', '.join(TID_MAP.keys())} (default: all)")
+    parser.add_argument("--limit", type=int, default=20, help="Max videos to return (default: 20)")
+    args = parser.parse_args()
+
+    try:
+        client = BilibiliClient.create()
+        result = get_ranking(client, args.category, args.limit)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except BilibiliApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/bilibili/scripts/bilibili_search.py
+++ b/skills/bilibili/scripts/bilibili_search.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Search Bilibili videos or users (requires WBI signing)."""
+
+import argparse
+import json
+import re
+import sys
+
+import requests
+from bilibili_client import BilibiliApiError, BilibiliClient
+
+
+def search_videos(client: BilibiliClient, keyword: str, page: int = 1, limit: int = 20) -> dict:
+    """Search for videos by keyword (WBI signed)."""
+    payload = client.get(
+        "/x/web-interface/wbi/search/type",
+        params={"search_type": "video", "keyword": keyword, "page": page},
+        signed=True,
+    )
+    if payload.get("code") != 0:
+        raise BilibiliApiError("API_ERROR", f"Bilibili API error: {payload.get('message', 'unknown')} (code {payload.get('code')})")
+    results = payload.get("data", {}).get("result", []) or []
+    videos = []
+    for item in results[:limit]:
+        title = re.sub(r"<[^>]+>", "", item.get("title", ""))
+        videos.append({
+            "bvid": item.get("bvid", ""),
+            "aid": item.get("aid", 0),
+            "title": title,
+            "author": item.get("author", ""),
+            "author_mid": item.get("mid", 0),
+            "description": item.get("description", ""),
+            "duration": item.get("duration", ""),
+            "thumbnail": item.get("pic", ""),
+            "view": item.get("play", 0),
+            "danmaku": item.get("danmaku", 0),
+        })
+    return {
+        "keyword": keyword,
+        "page": page,
+        "count": len(videos),
+        "videos": videos,
+    }
+
+
+def search_users(client: BilibiliClient, keyword: str, page: int = 1, limit: int = 20) -> dict:
+    """Search for users by keyword (WBI signed)."""
+    payload = client.get(
+        "/x/web-interface/wbi/search/type",
+        params={"search_type": "bili_user", "keyword": keyword, "page": page},
+        signed=True,
+    )
+    if payload.get("code") != 0:
+        raise BilibiliApiError("API_ERROR", f"Bilibili API error: {payload.get('message', 'unknown')} (code {payload.get('code')})")
+    results = payload.get("data", {}).get("result", []) or []
+    users = []
+    for item in results[:limit]:
+        users.append({
+            "mid": item.get("mid", 0),
+            "uname": re.sub(r"<[^>]+>", "", item.get("uname", "")),
+            "usign": item.get("usign", ""),
+            "fans": item.get("fans", 0),
+            "videos": item.get("videos", 0),
+            "level": item.get("level", 0),
+        })
+    return {
+        "keyword": keyword,
+        "page": page,
+        "count": len(users),
+        "users": users,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Search Bilibili videos or users")
+    parser.add_argument("--keyword", required=True, help="Search keyword")
+    parser.add_argument("--type", default="video", choices=["video", "user"], help="Search type (default: video)")
+    parser.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
+    parser.add_argument("--limit", type=int, default=20, help="Max results (default: 20)")
+    args = parser.parse_args()
+
+    try:
+        client = BilibiliClient.create()
+        if args.type == "user":
+            result = search_users(client, args.keyword, args.page, args.limit)
+        else:
+            result = search_videos(client, args.keyword, args.page, args.limit)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except BilibiliApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/bilibili/scripts/bilibili_subtitle.py
+++ b/skills/bilibili/scripts/bilibili_subtitle.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Get Bilibili video subtitles/captions."""
+
+import argparse
+import json
+import sys
+
+import requests
+from bilibili_client import BilibiliApiError, BilibiliClient
+
+
+def get_subtitle(client: BilibiliClient, bvid: str, lang: str = "") -> dict:
+    """Fetch subtitles for a video by BV ID.
+
+    1. Get video info to find the CID
+    2. Call /x/player/wbi/v2 (WBI-signed) to get subtitle list
+    3. Fetch the subtitle JSON from CDN
+    """
+    video_payload = client.get("/x/web-interface/view", params={"bvid": bvid})
+    if video_payload.get("code") != 0:
+        raise BilibiliApiError("API_ERROR", f"Video not found: {video_payload.get('message', 'unknown')}")
+    video_data = video_payload.get("data", {})
+    cid = video_data.get("cid", 0)
+    if not cid:
+        pages = video_data.get("pages", [])
+        if pages:
+            cid = pages[0].get("cid", 0)
+    if not cid:
+        raise BilibiliApiError("NO_CID", "Cannot determine CID for this video")
+
+    player_payload = client.get("/x/player/wbi/v2", params={"bvid": bvid, "cid": cid}, signed=True)
+    if player_payload.get("code") != 0:
+        raise BilibiliApiError("API_ERROR", f"Player API error: {player_payload.get('message', 'unknown')}")
+    player_data = player_payload.get("data", {})
+    subtitle_info = player_data.get("subtitle", {})
+    subtitles_list = subtitle_info.get("subtitles", [])
+
+    if not subtitles_list:
+        need_login = player_data.get("need_login_subtitle", False)
+        if need_login:
+            raise BilibiliApiError("AUTH_REQUIRED", "Subtitles require login for this video")
+        return {
+            "bvid": bvid,
+            "cid": cid,
+            "title": video_data.get("title", ""),
+            "subtitle_count": 0,
+            "available_languages": [],
+            "selected_language": "",
+            "items": [],
+        }
+
+    available = [{"lan": s.get("lan", ""), "lan_doc": s.get("lan_doc", "")} for s in subtitles_list]
+
+    target = subtitles_list[0]
+    if lang:
+        for s in subtitles_list:
+            if s.get("lan") == lang:
+                target = s
+                break
+
+    sub_url = target.get("subtitle_url", "")
+    if not sub_url:
+        raise BilibiliApiError("NO_SUBTITLE_URL", "Subtitle URL is empty — may be blocked by risk control")
+    if sub_url.startswith("//"):
+        sub_url = "https:" + sub_url
+
+    resp = requests.get(sub_url, timeout=15, headers={"User-Agent": "sigcli-skill/1.0"})
+    resp.raise_for_status()
+    sub_data = resp.json()
+    body = sub_data.get("body", [])
+
+    items = []
+    for i, entry in enumerate(body):
+        items.append({
+            "index": i + 1,
+            "from": round(entry.get("from", 0), 2),
+            "to": round(entry.get("to", 0), 2),
+            "content": entry.get("content", ""),
+        })
+
+    return {
+        "bvid": bvid,
+        "cid": cid,
+        "title": video_data.get("title", ""),
+        "subtitle_count": len(subtitles_list),
+        "available_languages": available,
+        "selected_language": target.get("lan", ""),
+        "items": items,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Bilibili video subtitles")
+    parser.add_argument("--bvid", required=True, help="Video BV ID (e.g., BV1xx411c7mD)")
+    parser.add_argument("--lang", default="", help="Subtitle language code (e.g., zh-CN, en-US, ai-zh). Default: first available")
+    parser.add_argument("--cookie", default="", help="Bilibili session cookie (may be needed for some videos)")
+    args = parser.parse_args()
+
+    try:
+        client = BilibiliClient(args.cookie) if args.cookie else BilibiliClient.create()
+        result = get_subtitle(client, args.bvid, args.lang)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except BilibiliApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/bilibili/scripts/bilibili_user.py
+++ b/skills/bilibili/scripts/bilibili_user.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Get Bilibili user profile and recent videos."""
+
+import argparse
+import json
+import sys
+
+import requests
+from bilibili_client import BilibiliApiError, BilibiliClient
+
+
+def get_user(client: BilibiliClient, mid: int, include_videos: bool = False) -> dict:
+    """Fetch user profile by mid."""
+    payload = client.get("/x/web-interface/card", params={"mid": mid, "photo": "true"})
+    if payload.get("code") != 0:
+        raise BilibiliApiError("API_ERROR", f"Bilibili API error: {payload.get('message', 'unknown')} (code {payload.get('code')})")
+    data = payload.get("data", {})
+    card = data.get("card", {})
+    result = {
+        "mid": card.get("mid", 0),
+        "name": card.get("name", ""),
+        "face": card.get("face", ""),
+        "sign": card.get("sign", ""),
+        "level": card.get("level_info", {}).get("current_level", 0),
+        "sex": card.get("sex", ""),
+        "fans": card.get("fans", 0),
+        "following": card.get("attention", 0),
+    }
+    if include_videos:
+        vlist = client.get("/x/space/wbi/arc/search", params={"mid": mid, "pn": 1, "ps": 10}, signed=True)
+        vdata = vlist.get("data", {}).get("list", {}).get("vlist", []) or []
+        result["recent_videos"] = [parse_video_from_space(v) for v in vdata[:10]]
+    return result
+
+
+def parse_video_from_space(item: dict) -> dict:
+    """Parse a video item from the space/arc/search response."""
+    return {
+        "bvid": item.get("bvid", ""),
+        "aid": item.get("aid", 0),
+        "title": item.get("title", ""),
+        "description": item.get("description", ""),
+        "duration": item.get("length", ""),
+        "thumbnail": item.get("pic", ""),
+        "view": item.get("play", 0),
+        "created": item.get("created", 0),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Bilibili user profile")
+    parser.add_argument("--mid", required=True, type=int, help="User mid (numeric ID)")
+    parser.add_argument("--include-videos", action="store_true", help="Include recent videos")
+    args = parser.parse_args()
+
+    try:
+        client = BilibiliClient.create()
+        result = get_user(client, args.mid, args.include_videos)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except BilibiliApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/bilibili/scripts/bilibili_video.py
+++ b/skills/bilibili/scripts/bilibili_video.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Get Bilibili video details by BV ID."""
+
+import argparse
+import json
+import sys
+
+import requests
+from bilibili_client import BilibiliApiError, BilibiliClient, parse_video
+
+
+def get_video(client: BilibiliClient, bvid: str) -> dict:
+    """Fetch video details by BV ID."""
+    payload = client.get("/x/web-interface/view", params={"bvid": bvid})
+    if payload.get("code") != 0:
+        raise BilibiliApiError("API_ERROR", f"Bilibili API error: {payload.get('message', 'unknown')} (code {payload.get('code')})")
+    return parse_video(payload.get("data", {}))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Bilibili video details")
+    parser.add_argument("--bvid", required=True, help="Video BV ID (e.g. BV1xx411c7mD)")
+    args = parser.parse_args()
+
+    try:
+        client = BilibiliClient.create()
+        result = get_video(client, args.bvid)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except BilibiliApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/bilibili/tests/test_bilibili_coin.py
+++ b/skills/bilibili/tests/test_bilibili_coin.py
@@ -1,0 +1,63 @@
+"""Tests for bilibili/scripts/bilibili_coin.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("bilibili", "bilibili_coin")
+client_mod = load_script("bilibili", "bilibili_client")
+
+
+@responses.activate
+def test_coin_video_success():
+    """coin_video returns success for valid coin."""
+    responses.post(
+        url=re.compile(r"https://api\.bilibili\.com/x/web-interface/coin/add"),
+        json={"code": 0, "message": "0"},
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient("SESSDATA=abc; bili_jct=csrf123")
+    result = mod.coin_video(client, 123456, multiply=1)
+
+    assert result["success"] is True
+    assert result["multiply"] == 1
+    assert result["aid"] == 123456
+
+
+@responses.activate
+def test_coin_video_two_coins():
+    """coin_video works with multiply=2."""
+    responses.post(
+        url=re.compile(r"https://api\.bilibili\.com/x/web-interface/coin/add"),
+        json={"code": 0, "message": "0"},
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient("SESSDATA=abc; bili_jct=csrf123")
+    result = mod.coin_video(client, 123456, multiply=2)
+
+    assert result["success"] is True
+    assert result["multiply"] == 2
+
+
+def test_coin_video_invalid_multiply():
+    """coin_video raises on invalid multiply value."""
+    client = client_mod.BilibiliClient("SESSDATA=abc; bili_jct=csrf123")
+    try:
+        mod.coin_video(client, 123456, multiply=3)
+        assert False, "Should have raised"
+    except client_mod.BilibiliApiError as e:
+        assert e.code == "INVALID_PARAM"
+
+
+def test_coin_video_no_cookie():
+    """coin_video raises when no cookie provided."""
+    client = client_mod.BilibiliClient()
+    try:
+        mod.coin_video(client, 123456)
+        assert False, "Should have raised"
+    except client_mod.BilibiliApiError as e:
+        assert e.code == "AUTH_REQUIRED"

--- a/skills/bilibili/tests/test_bilibili_comments.py
+++ b/skills/bilibili/tests/test_bilibili_comments.py
@@ -1,0 +1,110 @@
+"""Tests for bilibili/scripts/bilibili_comments.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("bilibili", "bilibili_comments")
+client_mod = load_script("bilibili", "bilibili_client")
+
+_VIEW_RESPONSE = {
+    "code": 0,
+    "data": {"aid": 123456, "bvid": "BV1test"},
+}
+
+_COMMENTS_RESPONSE = {
+    "code": 0,
+    "message": "0",
+    "data": {
+        "page": {"count": 100},
+        "replies": [
+            {
+                "rpid": 1001,
+                "member": {"mid": 50, "uname": "Commenter1"},
+                "content": {"message": "Great video!"},
+                "like": 20,
+                "rcount": 2,
+                "ctime": 1700000000,
+            },
+            {
+                "rpid": 1002,
+                "member": {"mid": 51, "uname": "Commenter2"},
+                "content": {"message": "Nice work"},
+                "like": 5,
+                "rcount": 0,
+                "ctime": 1700001000,
+            },
+        ],
+    },
+}
+
+
+@responses.activate
+def test_get_comments_returns_list():
+    """get_comments returns correctly formatted comment list."""
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/web-interface/view"), json=_VIEW_RESPONSE, status=200)
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/v2/reply"), json=_COMMENTS_RESPONSE, status=200)
+
+    client = client_mod.BilibiliClient()
+    result = mod.get_comments(client, "BV1test")
+
+    assert result["bvid"] == "BV1test"
+    assert result["aid"] == 123456
+    assert result["total"] == 100
+    assert result["count"] == 2
+    assert result["comments"][0]["author"] == "Commenter1"
+    assert result["comments"][0]["text"] == "Great video!"
+    assert result["comments"][0]["like"] == 20
+
+
+@responses.activate
+def test_get_comments_empty():
+    """get_comments returns empty list when no comments."""
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/web-interface/view"), json=_VIEW_RESPONSE, status=200)
+    responses.get(
+        url=re.compile(r"https://api\.bilibili\.com/x/v2/reply"),
+        json={"code": 0, "data": {"page": {"count": 0}, "replies": []}},
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient()
+    result = mod.get_comments(client, "BV1test")
+
+    assert result["count"] == 0
+    assert result["comments"] == []
+
+
+@responses.activate
+def test_get_comments_video_not_found():
+    """get_comments raises when video cannot be resolved."""
+    responses.get(
+        url=re.compile(r"https://api\.bilibili\.com/x/web-interface/view"),
+        json={"code": -404, "message": "Video not found"},
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient()
+    try:
+        mod.get_comments(client, "BVnotfound")
+        assert False, "Should have raised"
+    except client_mod.BilibiliApiError as e:
+        assert e.code == "API_ERROR"
+
+
+@responses.activate
+def test_get_comments_null_replies():
+    """get_comments handles null replies gracefully."""
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/web-interface/view"), json=_VIEW_RESPONSE, status=200)
+    responses.get(
+        url=re.compile(r"https://api\.bilibili\.com/x/v2/reply"),
+        json={"code": 0, "data": {"page": {"count": 0}, "replies": None}},
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient()
+    result = mod.get_comments(client, "BV1test")
+
+    assert result["count"] == 0
+    assert result["comments"] == []

--- a/skills/bilibili/tests/test_bilibili_dynamic.py
+++ b/skills/bilibili/tests/test_bilibili_dynamic.py
@@ -1,0 +1,87 @@
+"""Tests for bilibili/scripts/bilibili_dynamic.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("bilibili", "bilibili_dynamic")
+client_mod = load_script("bilibili", "bilibili_client")
+
+FAKE_COOKIE = "SESSDATA=fakesession; bili_jct=fakecsrf"
+
+_FEED_RESPONSE = {
+    "code": 0,
+    "data": {
+        "items": [
+            {
+                "id_str": "900000001",
+                "type": "DYNAMIC_TYPE_AV",
+                "modules": {
+                    "module_author": {"name": "TestUser", "mid": 123, "pub_ts": 1700000000},
+                    "module_dynamic": {
+                        "major": {"archive": {"title": "New Video Title"}},
+                    },
+                    "module_stat": {
+                        "like": {"count": 50},
+                        "comment": {"count": 10},
+                        "forward": {"count": 5},
+                    },
+                },
+            },
+            {
+                "id_str": "900000002",
+                "type": "DYNAMIC_TYPE_WORD",
+                "modules": {
+                    "module_author": {"name": "Author2", "mid": 456, "pub_ts": 1700001000},
+                    "module_dynamic": {
+                        "desc": {"text": "Hello this is a text dynamic"},
+                    },
+                    "module_stat": {
+                        "like": {"count": 20},
+                        "comment": {"count": 3},
+                        "forward": {"count": 0},
+                    },
+                },
+            },
+        ],
+        "has_more": True,
+        "offset": "900000002",
+    },
+}
+
+
+@responses.activate
+def test_get_dynamic_feed():
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/polymer/web-dynamic/v1/feed/all"), json=_FEED_RESPONSE, status=200)
+    client = client_mod.BilibiliClient(FAKE_COOKIE)
+    result = mod.get_dynamic_feed(client, limit=20)
+    assert result["count"] == 2
+    assert result["has_more"] is True
+    assert result["offset"] == "900000002"
+    d1 = result["dynamics"][0]
+    assert d1["id"] == "900000001"
+    assert d1["text"] == "New Video Title"
+    assert d1["likes"] == 50
+    d2 = result["dynamics"][1]
+    assert d2["text"] == "Hello this is a text dynamic"
+
+
+@responses.activate
+def test_get_dynamic_feed_empty():
+    empty = {"code": 0, "data": {"items": [], "has_more": False, "offset": ""}}
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/polymer/web-dynamic/v1/feed/all"), json=empty, status=200)
+    client = client_mod.BilibiliClient(FAKE_COOKIE)
+    result = mod.get_dynamic_feed(client, limit=10)
+    assert result["count"] == 0
+    assert result["dynamics"] == []
+
+
+def test_get_dynamic_feed_requires_auth():
+    client = client_mod.BilibiliClient("")
+    try:
+        mod.get_dynamic_feed(client)
+        assert False, "Should have raised"
+    except client_mod.BilibiliApiError as e:
+        assert e.code == "AUTH_REQUIRED"

--- a/skills/bilibili/tests/test_bilibili_favorite.py
+++ b/skills/bilibili/tests/test_bilibili_favorite.py
@@ -1,0 +1,70 @@
+"""Tests for bilibili/scripts/bilibili_favorite.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("bilibili", "bilibili_favorite")
+client_mod = load_script("bilibili", "bilibili_client")
+
+
+@responses.activate
+def test_favorite_video_success():
+    """favorite_video returns success for adding to favorites."""
+    responses.post(
+        url=re.compile(r"https://api\.bilibili\.com/x/v3/fav/resource/deal"),
+        json={"code": 0, "message": "0"},
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient("SESSDATA=abc; bili_jct=csrf123")
+    result = mod.favorite_video(client, 123456, 100)
+
+    assert result["success"] is True
+    assert result["action"] == "favorite"
+    assert result["folder_id"] == 100
+
+
+@responses.activate
+def test_unfavorite_video():
+    """favorite_video with undo removes from favorites."""
+    responses.post(
+        url=re.compile(r"https://api\.bilibili\.com/x/v3/fav/resource/deal"),
+        json={"code": 0, "message": "0"},
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient("SESSDATA=abc; bili_jct=csrf123")
+    result = mod.favorite_video(client, 123456, 100, undo=True)
+
+    assert result["success"] is True
+    assert result["action"] == "unfavorite"
+
+
+def test_favorite_video_no_cookie():
+    """favorite_video raises when no cookie provided."""
+    client = client_mod.BilibiliClient()
+    try:
+        mod.favorite_video(client, 123456, 100)
+        assert False, "Should have raised"
+    except client_mod.BilibiliApiError as e:
+        assert e.code == "AUTH_REQUIRED"
+
+
+@responses.activate
+def test_favorite_video_api_error():
+    """favorite_video raises on API error."""
+    responses.post(
+        url=re.compile(r"https://api\.bilibili\.com/x/v3/fav/resource/deal"),
+        json={"code": -403, "message": "Access denied"},
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient("SESSDATA=abc; bili_jct=csrf123")
+    try:
+        mod.favorite_video(client, 123456, 100)
+        assert False, "Should have raised"
+    except client_mod.BilibiliApiError as e:
+        assert e.code == "API_ERROR"

--- a/skills/bilibili/tests/test_bilibili_history.py
+++ b/skills/bilibili/tests/test_bilibili_history.py
@@ -1,0 +1,76 @@
+"""Tests for bilibili/scripts/bilibili_history.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("bilibili", "bilibili_history")
+client_mod = load_script("bilibili", "bilibili_client")
+
+FAKE_COOKIE = "SESSDATA=fakesession; bili_jct=fakecsrf"
+
+_HISTORY_RESPONSE = {
+    "code": 0,
+    "data": {
+        "cursor": {"view_at": 1700000000, "business": "archive"},
+        "list": [
+            {
+                "title": "Video One",
+                "author_name": "Author1",
+                "author_mid": 111,
+                "progress": 120,
+                "duration": 300,
+                "view_at": 1700000000,
+                "tag_name": "Technology",
+                "history": {"bvid": "BV1test1111"},
+            },
+            {
+                "title": "Video Two",
+                "author_name": "Author2",
+                "author_mid": 222,
+                "progress": -1,
+                "duration": 600,
+                "view_at": 1699999000,
+                "tag_name": "Music",
+                "history": {"bvid": "BV1test2222"},
+            },
+        ],
+    },
+}
+
+
+@responses.activate
+def test_get_history():
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/web-interface/history/cursor"), json=_HISTORY_RESPONSE, status=200)
+    client = client_mod.BilibiliClient(FAKE_COOKIE)
+    result = mod.get_history(client, limit=20)
+    assert result["count"] == 2
+    assert result["cursor_view_at"] == 1700000000
+    item1 = result["items"][0]
+    assert item1["rank"] == 1
+    assert item1["title"] == "Video One"
+    assert item1["bvid"] == "BV1test1111"
+    assert "40%" in item1["progress"]
+    item2 = result["items"][1]
+    assert item2["progress"] == "finished"
+
+
+@responses.activate
+def test_get_history_empty():
+    empty = {"code": 0, "data": {"cursor": {}, "list": []}}
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/web-interface/history/cursor"), json=empty, status=200)
+    client = client_mod.BilibiliClient(FAKE_COOKIE)
+    result = mod.get_history(client, limit=10)
+    assert result["count"] == 0
+    assert result["items"] == []
+
+
+def test_get_history_requires_auth():
+    client = client_mod.BilibiliClient("")
+    try:
+        mod.get_history(client)
+        assert False, "Should have raised"
+    except client_mod.BilibiliApiError as e:
+        assert e.code == "AUTH_REQUIRED"

--- a/skills/bilibili/tests/test_bilibili_hot.py
+++ b/skills/bilibili/tests/test_bilibili_hot.py
@@ -1,0 +1,93 @@
+"""Tests for bilibili/scripts/bilibili_hot.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("bilibili", "bilibili_hot")
+client_mod = load_script("bilibili", "bilibili_client")
+
+_HOT_RESPONSE = {
+    "code": 0,
+    "message": "0",
+    "data": {
+        "list": [
+            {
+                "bvid": "BV1abc",
+                "aid": 111,
+                "title": "Hot Video 1",
+                "desc": "desc1",
+                "pic": "https://pic1.jpg",
+                "duration": 120,
+                "pubdate": 1700000000,
+                "owner": {"mid": 1, "name": "Author1", "face": ""},
+                "stat": {"view": 5000, "like": 300, "coin": 100, "favorite": 50, "share": 20, "reply": 40, "danmaku": 15},
+            },
+            {
+                "bvid": "BV2def",
+                "aid": 222,
+                "title": "Hot Video 2",
+                "desc": "desc2",
+                "pic": "https://pic2.jpg",
+                "duration": 600,
+                "pubdate": 1700001000,
+                "owner": {"mid": 2, "name": "Author2", "face": ""},
+                "stat": {"view": 8000, "like": 600, "coin": 200, "favorite": 80, "share": 30, "reply": 60, "danmaku": 25},
+            },
+        ],
+    },
+}
+
+
+@responses.activate
+def test_get_hot_videos_returns_list():
+    """get_hot_videos returns correctly formatted video list."""
+    responses.get(
+        url=re.compile(r"https://api\.bilibili\.com/x/web-interface/popular"),
+        json=_HOT_RESPONSE,
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient()
+    result = mod.get_hot_videos(client, 20)
+
+    assert result["count"] == 2
+    assert result["page"] == 1
+    assert len(result["videos"]) == 2
+    assert result["videos"][0]["title"] == "Hot Video 1"
+    assert result["videos"][1]["view"] == 8000
+
+
+@responses.activate
+def test_get_hot_videos_empty():
+    """get_hot_videos returns empty list when no videos."""
+    responses.get(
+        url=re.compile(r"https://api\.bilibili\.com/x/web-interface/popular"),
+        json={"code": 0, "message": "0", "data": {"list": []}},
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient()
+    result = mod.get_hot_videos(client, 20)
+
+    assert result["count"] == 0
+    assert result["videos"] == []
+
+
+@responses.activate
+def test_get_hot_videos_api_error():
+    """get_hot_videos raises on API error."""
+    responses.get(
+        url=re.compile(r"https://api\.bilibili\.com/x/web-interface/popular"),
+        json={"code": -500, "message": "Server error"},
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient()
+    try:
+        mod.get_hot_videos(client, 20)
+        assert False, "Should have raised"
+    except client_mod.BilibiliApiError as e:
+        assert e.code == "API_ERROR"

--- a/skills/bilibili/tests/test_bilibili_like.py
+++ b/skills/bilibili/tests/test_bilibili_like.py
@@ -1,0 +1,63 @@
+"""Tests for bilibili/scripts/bilibili_like.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("bilibili", "bilibili_like")
+client_mod = load_script("bilibili", "bilibili_client")
+
+
+@responses.activate
+def test_like_video_success():
+    """like_video returns success for valid like."""
+    responses.post(
+        url=re.compile(r"https://api\.bilibili\.com/x/web-interface/archive/like"),
+        json={"code": 0, "message": "0"},
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient("SESSDATA=abc; bili_jct=csrf123")
+    result = mod.like_video(client, 123456)
+
+    assert result["success"] is True
+    assert result["action"] == "like"
+    assert result["aid"] == 123456
+
+
+@responses.activate
+def test_unlike_video():
+    """like_video with undo returns unlike action."""
+    responses.post(
+        url=re.compile(r"https://api\.bilibili\.com/x/web-interface/archive/like"),
+        json={"code": 0, "message": "0"},
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient("SESSDATA=abc; bili_jct=csrf123")
+    result = mod.like_video(client, 123456, undo=True)
+
+    assert result["success"] is True
+    assert result["action"] == "unlike"
+
+
+def test_like_video_no_cookie():
+    """like_video raises when no cookie provided."""
+    client = client_mod.BilibiliClient()
+    try:
+        mod.like_video(client, 123456)
+        assert False, "Should have raised"
+    except client_mod.BilibiliApiError as e:
+        assert e.code == "AUTH_REQUIRED"
+
+
+def test_like_video_no_csrf():
+    """like_video raises when cookie has no bili_jct."""
+    client = client_mod.BilibiliClient("SESSDATA=abc")
+    try:
+        mod.like_video(client, 123456)
+        assert False, "Should have raised"
+    except client_mod.BilibiliApiError as e:
+        assert e.code == "NO_CSRF"

--- a/skills/bilibili/tests/test_bilibili_me.py
+++ b/skills/bilibili/tests/test_bilibili_me.py
@@ -1,0 +1,61 @@
+"""Tests for bilibili/scripts/bilibili_me.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("bilibili", "bilibili_me")
+client_mod = load_script("bilibili", "bilibili_client")
+
+FAKE_COOKIE = "SESSDATA=fakesession; bili_jct=fakecsrf"
+
+_NAV_RESPONSE = {
+    "code": 0,
+    "data": {
+        "mid": 12345678,
+        "uname": "TestBiliUser",
+        "face": "https://i0.hdslb.com/bfs/face/test.jpg",
+        "level_info": {"current_level": 5},
+        "money": 233.0,
+        "vipType": 2,
+        "vip": {"label": {"text": "年度大会员"}},
+        "isLogin": True,
+        "email_verified": 1,
+        "mobile_verified": 1,
+        "wbi_img": {"img_url": "https://i0.hdslb.com/bfs/wbi/abc.png", "sub_url": "https://i0.hdslb.com/bfs/wbi/def.png"},
+    },
+}
+
+
+@responses.activate
+def test_get_me():
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/web-interface/nav"), json=_NAV_RESPONSE, status=200)
+    client = client_mod.BilibiliClient(FAKE_COOKIE)
+    result = mod.get_me(client)
+    assert result["mid"] == 12345678
+    assert result["name"] == "TestBiliUser"
+    assert result["level"] == 5
+    assert result["coins"] == 233.0
+    assert result["is_login"] is True
+
+
+@responses.activate
+def test_get_me_not_logged_in():
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/web-interface/nav"), json={"code": -101, "message": "账号未登录"}, status=200)
+    client = client_mod.BilibiliClient(FAKE_COOKIE)
+    try:
+        mod.get_me(client)
+        assert False, "Should have raised"
+    except client_mod.BilibiliApiError as e:
+        assert e.code == "API_ERROR"
+
+
+def test_get_me_requires_auth():
+    client = client_mod.BilibiliClient("")
+    try:
+        mod.get_me(client)
+        assert False, "Should have raised"
+    except client_mod.BilibiliApiError as e:
+        assert e.code == "AUTH_REQUIRED"

--- a/skills/bilibili/tests/test_bilibili_popular.py
+++ b/skills/bilibili/tests/test_bilibili_popular.py
@@ -1,0 +1,83 @@
+"""Tests for bilibili/scripts/bilibili_popular.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("bilibili", "bilibili_popular")
+client_mod = load_script("bilibili", "bilibili_client")
+
+_POPULAR_RESPONSE = {
+    "code": 0,
+    "message": "0",
+    "data": {
+        "list": [
+            {
+                "bvid": "BVpop1",
+                "aid": 333,
+                "title": "Popular Video",
+                "desc": "",
+                "pic": "",
+                "duration": 180,
+                "pubdate": 1700000000,
+                "owner": {"mid": 10, "name": "PopAuthor", "face": ""},
+                "stat": {"view": 20000, "like": 1000, "coin": 500, "favorite": 300, "share": 100, "reply": 200, "danmaku": 80},
+            },
+        ],
+        "no_more": False,
+    },
+}
+
+
+@responses.activate
+def test_get_popular_videos_returns_list():
+    """get_popular_videos returns correctly formatted list."""
+    responses.get(
+        url=re.compile(r"https://api\.bilibili\.com/x/web-interface/popular"),
+        json=_POPULAR_RESPONSE,
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient()
+    result = mod.get_popular_videos(client, 20)
+
+    assert result["count"] == 1
+    assert result["no_more"] is False
+    assert result["videos"][0]["title"] == "Popular Video"
+    assert result["videos"][0]["view"] == 20000
+
+
+@responses.activate
+def test_get_popular_videos_empty():
+    """get_popular_videos returns empty list."""
+    responses.get(
+        url=re.compile(r"https://api\.bilibili\.com/x/web-interface/popular"),
+        json={"code": 0, "message": "0", "data": {"list": [], "no_more": True}},
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient()
+    result = mod.get_popular_videos(client, 20)
+
+    assert result["count"] == 0
+    assert result["no_more"] is True
+    assert result["videos"] == []
+
+
+@responses.activate
+def test_get_popular_videos_api_error():
+    """get_popular_videos raises on API error."""
+    responses.get(
+        url=re.compile(r"https://api\.bilibili\.com/x/web-interface/popular"),
+        json={"code": -400, "message": "Bad request"},
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient()
+    try:
+        mod.get_popular_videos(client, 20)
+        assert False, "Should have raised"
+    except client_mod.BilibiliApiError:
+        pass

--- a/skills/bilibili/tests/test_bilibili_ranking.py
+++ b/skills/bilibili/tests/test_bilibili_ranking.py
@@ -1,0 +1,109 @@
+"""Tests for bilibili/scripts/bilibili_ranking.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("bilibili", "bilibili_ranking")
+client_mod = load_script("bilibili", "bilibili_client")
+
+_RANKING_RESPONSE = {
+    "code": 0,
+    "message": "0",
+    "data": {
+        "list": [
+            {
+                "bvid": "BVrank1",
+                "aid": 444,
+                "title": "Ranked Video 1",
+                "desc": "",
+                "pic": "",
+                "duration": 240,
+                "pubdate": 1700000000,
+                "owner": {"mid": 20, "name": "RankAuthor", "face": ""},
+                "stat": {"view": 50000, "like": 3000, "coin": 1000, "favorite": 500, "share": 200, "reply": 400, "danmaku": 150},
+            },
+            {
+                "bvid": "BVrank2",
+                "aid": 555,
+                "title": "Ranked Video 2",
+                "desc": "",
+                "pic": "",
+                "duration": 360,
+                "pubdate": 1700001000,
+                "owner": {"mid": 21, "name": "RankAuthor2", "face": ""},
+                "stat": {"view": 40000, "like": 2000, "coin": 800, "favorite": 400, "share": 150, "reply": 300, "danmaku": 100},
+            },
+        ],
+    },
+}
+
+
+@responses.activate
+def test_get_ranking_returns_list():
+    """get_ranking returns correctly formatted ranking list."""
+    responses.get(
+        url=re.compile(r"https://api\.bilibili\.com/x/web-interface/ranking/v2"),
+        json=_RANKING_RESPONSE,
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient()
+    result = mod.get_ranking(client, "all", 20)
+
+    assert result["category"] == "all"
+    assert result["tid"] == 0
+    assert result["count"] == 2
+    assert result["videos"][0]["title"] == "Ranked Video 1"
+    assert result["videos"][0]["view"] == 50000
+
+
+@responses.activate
+def test_get_ranking_respects_limit():
+    """get_ranking slices results to the given limit."""
+    responses.get(
+        url=re.compile(r"https://api\.bilibili\.com/x/web-interface/ranking/v2"),
+        json=_RANKING_RESPONSE,
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient()
+    result = mod.get_ranking(client, "all", 1)
+
+    assert result["count"] == 1
+    assert len(result["videos"]) == 1
+
+
+@responses.activate
+def test_get_ranking_api_error():
+    """get_ranking raises on API error."""
+    responses.get(
+        url=re.compile(r"https://api\.bilibili\.com/x/web-interface/ranking/v2"),
+        json={"code": -500, "message": "Server error"},
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient()
+    try:
+        mod.get_ranking(client, "all", 20)
+        assert False, "Should have raised"
+    except client_mod.BilibiliApiError:
+        pass
+
+
+@responses.activate
+def test_get_ranking_with_category():
+    """get_ranking resolves category name to tid."""
+    responses.get(
+        url=re.compile(r"https://api\.bilibili\.com/x/web-interface/ranking/v2"),
+        json=_RANKING_RESPONSE,
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient()
+    result = mod.get_ranking(client, "music", 20)
+
+    assert result["category"] == "music"
+    assert result["tid"] == 3

--- a/skills/bilibili/tests/test_bilibili_search.py
+++ b/skills/bilibili/tests/test_bilibili_search.py
@@ -1,0 +1,123 @@
+"""Tests for bilibili/scripts/bilibili_search.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("bilibili", "bilibili_search")
+client_mod = load_script("bilibili", "bilibili_client")
+
+_NAV_RESPONSE = {
+    "code": 0,
+    "data": {
+        "wbi_img": {
+            "img_url": "https://i0.hdslb.com/bfs/wbi/7cd084941338484aae1ad9425b84077c.png",
+            "sub_url": "https://i0.hdslb.com/bfs/wbi/4932caff0ff746eab6f01bf08b70ac45.png",
+        },
+    },
+}
+
+_SEARCH_VIDEO_RESPONSE = {
+    "code": 0,
+    "message": "0",
+    "data": {
+        "result": [
+            {
+                "bvid": "BVsearch1",
+                "aid": 666,
+                "title": "<em class=\"keyword\">Test</em> Search Result",
+                "author": "SearchAuthor",
+                "mid": 30,
+                "description": "A search result",
+                "duration": "5:30",
+                "pic": "https://pic.jpg",
+                "play": 15000,
+                "danmaku": 45,
+            },
+        ],
+    },
+}
+
+_SEARCH_USER_RESPONSE = {
+    "code": 0,
+    "message": "0",
+    "data": {
+        "result": [
+            {
+                "mid": 100,
+                "uname": "<em class=\"keyword\">Test</em>User",
+                "usign": "A test user",
+                "fans": 5000,
+                "videos": 42,
+                "level": 5,
+            },
+        ],
+    },
+}
+
+
+@responses.activate
+def test_search_videos_strips_html():
+    """search_videos strips HTML tags from title."""
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/web-interface/nav"), json=_NAV_RESPONSE, status=200)
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/web-interface/wbi/search/type"), json=_SEARCH_VIDEO_RESPONSE, status=200)
+
+    client = client_mod.BilibiliClient()
+    result = mod.search_videos(client, "Test")
+
+    assert result["keyword"] == "Test"
+    assert result["count"] == 1
+    assert result["videos"][0]["title"] == "Test Search Result"
+    assert result["videos"][0]["bvid"] == "BVsearch1"
+    assert result["videos"][0]["view"] == 15000
+
+
+@responses.activate
+def test_search_videos_empty():
+    """search_videos returns empty list when no results."""
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/web-interface/nav"), json=_NAV_RESPONSE, status=200)
+    responses.get(
+        url=re.compile(r"https://api\.bilibili\.com/x/web-interface/wbi/search/type"),
+        json={"code": 0, "message": "0", "data": {"result": []}},
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient()
+    result = mod.search_videos(client, "nonexistent")
+
+    assert result["count"] == 0
+    assert result["videos"] == []
+
+
+@responses.activate
+def test_search_users():
+    """search_users returns correctly formatted user list."""
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/web-interface/nav"), json=_NAV_RESPONSE, status=200)
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/web-interface/wbi/search/type"), json=_SEARCH_USER_RESPONSE, status=200)
+
+    client = client_mod.BilibiliClient()
+    result = mod.search_users(client, "Test")
+
+    assert result["count"] == 1
+    assert result["users"][0]["uname"] == "TestUser"
+    assert result["users"][0]["fans"] == 5000
+
+
+@responses.activate
+def test_search_videos_api_error():
+    """search_videos raises on API error."""
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/web-interface/nav"), json=_NAV_RESPONSE, status=200)
+    responses.get(
+        url=re.compile(r"https://api\.bilibili\.com/x/web-interface/wbi/search/type"),
+        json={"code": -412, "message": "Request blocked"},
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient()
+    try:
+        mod.search_videos(client, "blocked")
+        assert False, "Should have raised"
+    except client_mod.BilibiliApiError as e:
+        assert e.code == "API_ERROR"

--- a/skills/bilibili/tests/test_bilibili_subtitle.py
+++ b/skills/bilibili/tests/test_bilibili_subtitle.py
@@ -1,0 +1,99 @@
+"""Tests for bilibili/scripts/bilibili_subtitle.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("bilibili", "bilibili_subtitle")
+client_mod = load_script("bilibili", "bilibili_client")
+
+_VIDEO_RESPONSE = {
+    "code": 0,
+    "data": {
+        "bvid": "BV1test1111",
+        "cid": 99999,
+        "title": "Test Video With Subs",
+        "pages": [{"cid": 99999}],
+    },
+}
+
+_NAV_RESPONSE = {
+    "code": 0,
+    "data": {"wbi_img": {"img_url": "https://i0.hdslb.com/bfs/wbi/abc.png", "sub_url": "https://i0.hdslb.com/bfs/wbi/def.png"}},
+}
+
+_PLAYER_RESPONSE = {
+    "code": 0,
+    "data": {
+        "subtitle": {
+            "subtitles": [
+                {"lan": "zh-CN", "lan_doc": "中文（中国）", "subtitle_url": "//aisubtitle.hdslb.com/bfs/ai/12345.json"},
+                {"lan": "en-US", "lan_doc": "English", "subtitle_url": "//aisubtitle.hdslb.com/bfs/ai/67890.json"},
+            ]
+        }
+    },
+}
+
+_SUBTITLE_CDN = {
+    "body": [
+        {"from": 0.0, "to": 2.5, "content": "Hello"},
+        {"from": 2.5, "to": 5.0, "content": "World"},
+    ]
+}
+
+
+@responses.activate
+def test_get_subtitle():
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/web-interface/view"), json=_VIDEO_RESPONSE, status=200)
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/web-interface/nav"), json=_NAV_RESPONSE, status=200)
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/player/wbi/v2"), json=_PLAYER_RESPONSE, status=200)
+    responses.get(url=re.compile(r"https://aisubtitle\.hdslb\.com"), json=_SUBTITLE_CDN, status=200)
+
+    client = client_mod.BilibiliClient()
+    result = mod.get_subtitle(client, "BV1test1111")
+    assert result["bvid"] == "BV1test1111"
+    assert result["subtitle_count"] == 2
+    assert result["selected_language"] == "zh-CN"
+    assert len(result["items"]) == 2
+    assert result["items"][0]["content"] == "Hello"
+    assert result["items"][1]["content"] == "World"
+    assert len(result["available_languages"]) == 2
+
+
+@responses.activate
+def test_get_subtitle_select_language():
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/web-interface/view"), json=_VIDEO_RESPONSE, status=200)
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/web-interface/nav"), json=_NAV_RESPONSE, status=200)
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/player/wbi/v2"), json=_PLAYER_RESPONSE, status=200)
+    responses.get(url=re.compile(r"https://aisubtitle\.hdslb\.com"), json=_SUBTITLE_CDN, status=200)
+
+    client = client_mod.BilibiliClient()
+    result = mod.get_subtitle(client, "BV1test1111", lang="en-US")
+    assert result["selected_language"] == "en-US"
+
+
+@responses.activate
+def test_get_subtitle_no_subtitles():
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/web-interface/view"), json=_VIDEO_RESPONSE, status=200)
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/web-interface/nav"), json=_NAV_RESPONSE, status=200)
+    no_subs = {"code": 0, "data": {"subtitle": {"subtitles": []}}}
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/player/wbi/v2"), json=no_subs, status=200)
+
+    client = client_mod.BilibiliClient()
+    result = mod.get_subtitle(client, "BV1test1111")
+    assert result["subtitle_count"] == 0
+    assert result["items"] == []
+
+
+@responses.activate
+def test_get_subtitle_video_not_found():
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/web-interface/view"), json={"code": -404, "message": "啥都木有"}, status=200)
+
+    client = client_mod.BilibiliClient()
+    try:
+        mod.get_subtitle(client, "BV1nonexist")
+        assert False, "Should have raised"
+    except client_mod.BilibiliApiError as e:
+        assert e.code == "API_ERROR"

--- a/skills/bilibili/tests/test_bilibili_user.py
+++ b/skills/bilibili/tests/test_bilibili_user.py
@@ -1,0 +1,99 @@
+"""Tests for bilibili/scripts/bilibili_user.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("bilibili", "bilibili_user")
+client_mod = load_script("bilibili", "bilibili_client")
+
+_NAV_RESPONSE = {
+    "code": 0,
+    "data": {
+        "wbi_img": {
+            "img_url": "https://i0.hdslb.com/bfs/wbi/7cd084941338484aae1ad9425b84077c.png",
+            "sub_url": "https://i0.hdslb.com/bfs/wbi/4932caff0ff746eab6f01bf08b70ac45.png",
+        },
+    },
+}
+
+_CARD_RESPONSE = {
+    "code": 0,
+    "data": {
+        "card": {
+            "mid": "12345",
+            "name": "TestUser",
+            "face": "https://face.jpg",
+            "sign": "Hello world",
+            "level_info": {"current_level": 6},
+            "sex": "male",
+            "fans": 10000,
+            "attention": 200,
+        },
+    },
+}
+
+
+@responses.activate
+def test_get_user_returns_profile():
+    """get_user returns correctly formatted user profile."""
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/web-interface/card"), json=_CARD_RESPONSE, status=200)
+
+    client = client_mod.BilibiliClient()
+    result = mod.get_user(client, 12345)
+
+    assert result["mid"] == "12345"
+    assert result["name"] == "TestUser"
+    assert result["level"] == 6
+    assert result["fans"] == 10000
+    assert "recent_videos" not in result
+
+
+@responses.activate
+def test_get_user_api_error():
+    """get_user raises on API error."""
+    responses.get(
+        url=re.compile(r"https://api\.bilibili\.com/x/web-interface/card"),
+        json={"code": -404, "message": "User not found"},
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient()
+    try:
+        mod.get_user(client, 99999)
+        assert False, "Should have raised"
+    except client_mod.BilibiliApiError as e:
+        assert e.code == "API_ERROR"
+
+
+@responses.activate
+def test_get_user_with_videos():
+    """get_user includes recent videos when requested."""
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/web-interface/card"), json=_CARD_RESPONSE, status=200)
+    responses.get(url=re.compile(r"https://api\.bilibili\.com/x/web-interface/nav"), json=_NAV_RESPONSE, status=200)
+    responses.get(
+        url=re.compile(r"https://api\.bilibili\.com/x/space/wbi/arc/search"),
+        json={
+            "code": 0,
+            "data": {
+                "list": {
+                    "vlist": [
+                        {
+                            "bvid": "BVuser1", "aid": 777, "title": "User Video", "description": "",
+                            "length": "3:20", "pic": "", "play": 5000, "created": 1700000000,
+                        },
+                    ],
+                },
+            },
+        },
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient()
+    result = mod.get_user(client, 12345, include_videos=True)
+
+    assert result["name"] == "TestUser"
+    assert len(result["recent_videos"]) == 1
+    assert result["recent_videos"][0]["title"] == "User Video"

--- a/skills/bilibili/tests/test_bilibili_video.py
+++ b/skills/bilibili/tests/test_bilibili_video.py
@@ -1,0 +1,86 @@
+"""Tests for bilibili/scripts/bilibili_video.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("bilibili", "bilibili_video")
+client_mod = load_script("bilibili", "bilibili_client")
+
+_VIDEO_RESPONSE = {
+    "code": 0,
+    "message": "0",
+    "data": {
+        "bvid": "BV1xx411c7mD",
+        "aid": 123456,
+        "title": "Test Video Title",
+        "desc": "A test video description",
+        "pic": "https://i0.hdslb.com/bfs/archive/test.jpg",
+        "duration": 300,
+        "pubdate": 1700000000,
+        "owner": {"mid": 789, "name": "TestAuthor", "face": "https://face.jpg"},
+        "stat": {"view": 10000, "like": 500, "coin": 200, "favorite": 100, "share": 50, "reply": 80, "danmaku": 30},
+        "videos": 1,
+    },
+}
+
+
+@responses.activate
+def test_get_video_returns_parsed_data():
+    """get_video returns correctly parsed video data."""
+    responses.get(
+        url=re.compile(r"https://api\.bilibili\.com/x/web-interface/view"),
+        json=_VIDEO_RESPONSE,
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient()
+    result = mod.get_video(client, "BV1xx411c7mD")
+
+    assert result["bvid"] == "BV1xx411c7mD"
+    assert result["aid"] == 123456
+    assert result["title"] == "Test Video Title"
+    assert result["author"] == "TestAuthor"
+    assert result["author_mid"] == 789
+    assert result["view"] == 10000
+    assert result["like"] == 500
+    assert result["duration"] == 300
+    assert result["duration_text"] == "5m0s"
+
+
+@responses.activate
+def test_get_video_api_error():
+    """get_video raises BilibiliApiError on non-zero code."""
+    responses.get(
+        url=re.compile(r"https://api\.bilibili\.com/x/web-interface/view"),
+        json={"code": -400, "message": "Invalid bvid"},
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient()
+    try:
+        mod.get_video(client, "BVinvalid")
+        assert False, "Should have raised"
+    except client_mod.BilibiliApiError as e:
+        assert e.code == "API_ERROR"
+        assert "Invalid bvid" in e.message
+
+
+@responses.activate
+def test_get_video_missing_stats():
+    """get_video handles missing stat fields gracefully."""
+    data = dict(_VIDEO_RESPONSE)
+    data["data"] = {**data["data"], "stat": {}}
+    responses.get(
+        url=re.compile(r"https://api\.bilibili\.com/x/web-interface/view"),
+        json=data,
+        status=200,
+    )
+
+    client = client_mod.BilibiliClient()
+    result = mod.get_video(client, "BV1xx411c7mD")
+
+    assert result["view"] == 0
+    assert result["like"] == 0

--- a/skills/install.sh
+++ b/skills/install.sh
@@ -12,7 +12,7 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ALL_SKILLS="sigcli-auth outlook msteams slack v2ex zhihu reddit"
+ALL_SKILLS="sigcli-auth outlook msteams slack v2ex zhihu reddit bilibili"
 
 # --- Agent detection ---
 

--- a/skills/pyproject.toml
+++ b/skills/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = ["requests>=2.28.0", "beautifulsoup4>=4.12.0"]
 dev = ["pytest>=8.0", "responses>=0.25.0", "ruff>=0.4.0"]
 
 [tool.pytest.ini_options]
-testpaths = ["outlook/tests", "msteams/tests", "slack/tests", "v2ex/tests", "zhihu/tests", "reddit/tests"]
+testpaths = ["outlook/tests", "msteams/tests", "slack/tests", "v2ex/tests", "zhihu/tests", "reddit/tests", "bilibili/tests"]
 pythonpath = ["."]
 addopts = "-v --tb=short"
 


### PR DESCRIPTION
## Summary

- Add new Bilibili (B站) skill with **14 scripts** covering read and write operations
- **11 read scripts**: video detail, hot/trending, popular, ranking by category, search (video + user), comments, user profile, dynamic feed, current user profile, watch history, subtitles
- **3 write scripts**: like/unlike, coin, favorite/unfavorite — all using cookie-based auth with automatic CSRF extraction from `bili_jct`
- **1 shared client** (`bilibili_client.py`): WBI parameter signing, CSRF token extraction, rate-limit retry
- 49 tests, all passing
- Updated `install.sh` and `pyproject.toml` to include the new skill

### Fixes applied during live testing

- **Comments**: use `/x/v2/reply/main` instead of `/x/v2/reply` (old endpoint returns empty results)
- **User profile**: use `/x/web-interface/card` instead of `/x/space/wbi/acc/info` (avoids anti-crawler error -352 without cookie)
- **Favorite**: `--folder-id` is now optional — auto-detects user's default favorites folder

### Signet provider config

```yaml
bilibili:
    domains: ['www.bilibili.com', 'bilibili.com', 'api.bilibili.com']
    entryUrl: https://www.bilibili.com/
    strategy: cookie
    config:
      ttl: '7d'
      requiredCookies: ['SESSDATA', 'bili_jct']
```

## Test plan

- [x] `python3 -m pytest bilibili/tests/ -v` — 49/49 tests pass
- [x] Live: `bilibili_hot.py`, `bilibili_popular.py`, `bilibili_ranking.py` return videos
- [x] Live: `bilibili_search.py --keyword "Python"` returns results
- [x] Live: `bilibili_video.py --bvid BV1GJ411x7h7` returns video detail
- [x] Live: `bilibili_comments.py --bvid BV1GJ411x7h7` returns comments
- [x] Live: `bilibili_user.py --mid 546195` returns user profile
- [x] Live: `bilibili_me.py` returns authenticated user profile
- [x] Live: `bilibili_dynamic.py` returns dynamic feed
- [x] Live: `bilibili_history.py` returns watch history
- [x] Live: `bilibili_like.py` + `--undo` (like/unlike verified)
- [x] Live: `bilibili_coin.py --multiply 1` (1 coin spent)
- [x] Live: `bilibili_favorite.py` + `--undo` (favorite/unfavorite, auto folder-id)