### PR TITLE
feat(linkedin): add LinkedIn skill

### DIFF
--- a/skills/linkedin/SKILL.md
+++ b/skills/linkedin/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: linkedin
+description: 'Interact with LinkedIn — view your profile, browse other profiles, read the feed, search jobs/posts/people, get job details, create posts, like/unlike posts, comment, send connection requests, and follow/unfollow users. Use this skill whenever the user mentions LinkedIn, wants to search for jobs or people, read their LinkedIn feed, view a profile, get job details, create a post, like or comment on content, send a connection request, or follow someone. Also trigger when the user pastes a LinkedIn URL (e.g. linkedin.com/in/..., linkedin.com/jobs/view/...) or mentions LinkedIn networking.'
+---
+
+# LinkedIn
+
+View profiles, browse the feed, search jobs/posts/people, get job details, create posts, like/unlike, comment, send connections, and follow/unfollow on LinkedIn.
+
+## Authentication
+
+**All operations** require a LinkedIn session cookie containing `JSESSIONID` and `li_at`. Use `sig run` to inject it:
+
+```bash
+sig run linkedin -- bash -c 'python3 scripts/linkedin_me.py --cookie "$SIG_LINKEDIN_COOKIE"'
+```
+
+The default Signet provider is `linkedin`. The env var is `SIG_LINKEDIN_COOKIE`.
+
+> **Note:** If `sig login` creates the provider as `www-linkedin` (from the domain), the env var will be `SIG_WWW_LINKEDIN_COOKIE`. You can rename it: `sig rename www-linkedin linkedin`.
+
+If a script returns auth error, re-authenticate:
+
+```bash
+sig login https://www.linkedin.com/login
+```
+
+> **Login caution:** Headless browser automation may trigger LinkedIn security challenges (CAPTCHA, phone verification, or temporary account restrictions). LinkedIn actively detects automated logins. If `sig login` fails, use the manual cookie method below.
+
+**Manual cookie setup (recommended):**
+
+1. Open https://www.linkedin.com/ and log in normally in Chrome
+2. DevTools (F12) → Application → Cookies → `https://www.linkedin.com`
+3. Find `JSESSIONID` (starts with `"ajax:..."`) and `li_at` (long session token)
+4. Construct the cookie string: `JSESSIONID="ajax:xxxxx"; li_at=yyyyy`
+5. Run: `sig login https://www.linkedin.com/login --cookie 'JSESSIONID="ajax:xxxxx"; li_at=yyyyy'`
+
+**Signet provider config:**
+
+```yaml
+linkedin:
+    domains: ['www.linkedin.com', 'linkedin.com']
+    entryUrl: https://www.linkedin.com/login
+    strategy: cookie
+    config:
+        ttl: '30d'
+        requiredCookies: ['JSESSIONID', 'li_at']
+```
+
+## Scripts Reference
+
+All scripts are in this skill's `scripts/` directory. Run via Bash tool.
+
+### Read Operations
+
+| Script                      | Purpose              | Auth     |
+| --------------------------- | -------------------- | -------- |
+| `linkedin_me.py`            | Current user profile | Required |
+| `linkedin_profile.py`       | User profile by name | Required |
+| `linkedin_feed.py`          | Home feed posts      | Required |
+| `linkedin_search_jobs.py`   | Search job listings  | Required |
+| `linkedin_search_posts.py`  | Search posts         | Required |
+| `linkedin_search_people.py` | Search people        | Required |
+| `linkedin_job.py`           | Job posting details  | Required |
+
+### Write Operations
+
+| Script                | Purpose                 | Auth     |
+| --------------------- | ----------------------- | -------- |
+| `linkedin_post.py`    | Create a post           | Required |
+| `linkedin_like.py`    | Like/unlike a post      | Required |
+| `linkedin_comment.py` | Comment on a post       | Required |
+| `linkedin_connect.py` | Send connection request | Required |
+| `linkedin_follow.py`  | Follow/unfollow a user  | Required |
+
+### linkedin_me.py
+
+```
+--cookie COOKIE      LinkedIn session cookie (optional, uses SIG_LINKEDIN_COOKIE)
+```
+
+### linkedin_profile.py
+
+```
+--username TEXT       LinkedIn username or profile URL (required)
+--cookie COOKIE      LinkedIn session cookie (optional)
+```
+
+### linkedin_feed.py
+
+```
+--limit N            Max posts (default: 10)
+--cookie COOKIE      LinkedIn session cookie (optional)
+```
+
+### linkedin_search_jobs.py
+
+```
+--query TEXT          Job search keywords (required)
+--location TEXT       Location filter (optional)
+--limit N            Max results (default: 10)
+--start N            Offset for pagination (default: 0)
+--experience TEXT     Experience level codes (comma-sep: 1=intern,2=entry,3=assoc,4=mid,5=dir,6=exec)
+--job-type TEXT       Job type codes (F=full,P=part,C=contract,T=temp,V=volunteer,I=intern)
+--date-posted TEXT    Date filter (r86400=24h, r604800=week, r2592000=month)
+--remote TEXT         Workplace type (1=onsite, 2=remote, 3=hybrid)
+--cookie COOKIE      LinkedIn session cookie (optional)
+```
+
+### linkedin_search_posts.py
+
+```
+--query TEXT          Search keywords (required)
+--limit N            Max results (default: 10)
+--cookie COOKIE      LinkedIn session cookie (optional)
+```
+
+### linkedin_search_people.py
+
+```
+--query TEXT          Search keywords (required)
+--limit N            Max results (default: 10)
+--start N            Offset for pagination (default: 0)
+--cookie COOKIE      LinkedIn session cookie (optional)
+```
+
+### linkedin_job.py
+
+```
+--id TEXT             Job ID or LinkedIn job URL (required)
+--cookie COOKIE      LinkedIn session cookie (optional)
+```
+
+### linkedin_post.py
+
+```
+--cookie COOKIE      LinkedIn session cookie (required)
+--text TEXT           Post text content (required)
+```
+
+### linkedin_like.py
+
+```
+--cookie COOKIE      LinkedIn session cookie (required)
+--urn TEXT            Post URN, e.g. urn:li:activity:1234567890 (required)
+--undo               Unlike instead of like
+```
+
+### linkedin_comment.py
+
+```
+--cookie COOKIE      LinkedIn session cookie (required)
+--urn TEXT            Post URN to comment on (required)
+--text TEXT           Comment text (required)
+```
+
+### linkedin_connect.py
+
+```
+--cookie COOKIE      LinkedIn session cookie (required)
+--urn TEXT            Profile URN, e.g. urn:li:fsd_profile:ACoAA... (required)
+--message TEXT        Custom connection message (optional)
+```
+
+### linkedin_follow.py
+
+```
+--cookie COOKIE      LinkedIn session cookie (required)
+--urn TEXT            User URN, e.g. urn:li:fsd_profile:ACoAA... (required)
+--undo               Unfollow instead of follow
+```
+
+## Safety
+
+**LinkedIn is a professional network.** Actions taken here are visible to your professional contacts and can affect your reputation. Always confirm with the user before executing write operations:
+
+- **Creating posts** — confirm the text content before publishing
+- **Sending connection requests** — confirm the target person and optional message
+- **Commenting on posts** — confirm the comment text before posting
+- **Liking/unliking** — these are reversible (`--undo`), but still confirm first
+- **Following/unfollowing** — these are reversible (`--undo`), but still confirm first
+
+## Key Concepts
+
+**Profile identifiers** — `linkedin_profile.py` accepts a LinkedIn username (`janedoe`), a full profile URL (`https://www.linkedin.com/in/janedoe`), or an `@`-prefixed handle. URLs are resolved automatically.
+
+**Job identifiers** — `linkedin_job.py` accepts a numeric job ID (`12345678`) or a full LinkedIn job URL (`https://www.linkedin.com/jobs/view/12345678`). The ID is extracted automatically.
+
+**URNs** — Write operations (like, comment, connect, follow) use LinkedIn URN identifiers. Post URNs look like `urn:li:activity:7100000000000000001`. Profile URNs look like `urn:li:fsd_profile:ACoAAA123456`. You can find these in the output of read operations.
+
+**Voyager API** — All operations use LinkedIn's internal Voyager API (`/voyager/api/`), which is the same API the LinkedIn website uses. Authentication is via JSESSIONID CSRF token and li_at session cookie.
+
+**Post search** — `linkedin_search_posts.py` parses RSC-embedded HTML from the search results page rather than a JSON API. Results may be less structured than other endpoints.
+
+## Known Limitations
+
+- **Rate limiting** — LinkedIn aggressively rate-limits API calls. The client retries once on HTTP 429 with the `Retry-After` delay, but sustained heavy usage may result in temporary blocks.
+- **Search post parsing** — Post search relies on HTML scraping of RSC payloads, which may break if LinkedIn changes their frontend markup.
+- **No pagination for feed** — The feed endpoint returns a single page of results up to the limit.
+- **Connection requests** — Require the target's profile URN, not their username. Use `linkedin_search_people.py` or `linkedin_profile.py` to find URNs first.
+- **Session expiry** — LinkedIn sessions typically last 30 days but may expire sooner if LinkedIn detects unusual activity.
+- **No media uploads** — `linkedin_post.py` creates text-only posts. Image/video posts are not supported.
+
+## Error Handling
+
+| Error         | Cause                           | Fix                                      |
+| ------------- | ------------------------------- | ---------------------------------------- |
+| AUTH_REQUIRED | No cookie or missing JSESSIONID | Run `sig login` or set cookie manually   |
+| AUTH_EXPIRED  | Session cookie expired (401)    | Re-authenticate via `sig login`          |
+| NOT_FOUND     | Profile or resource not found   | Check the username or ID is correct      |
+| HTTP_429      | Rate limited by LinkedIn        | Wait and retry; reduce request frequency |
+| HTTP_403      | Forbidden or restricted         | Check account status; may need re-login  |
+
+## Workflow Examples
+
+### View your own profile
+
+1. `sig run linkedin -- bash -c 'python3 scripts/linkedin_me.py --cookie "$SIG_LINKEDIN_COOKIE"'`
+
+### Look up someone's profile
+
+1. `sig run linkedin -- bash -c 'python3 scripts/linkedin_profile.py --cookie "$SIG_LINKEDIN_COOKIE" --username janedoe'`
+2. Or with URL: `sig run linkedin -- bash -c 'python3 scripts/linkedin_profile.py --cookie "$SIG_LINKEDIN_COOKIE" --username "https://www.linkedin.com/in/janedoe"'`
+
+### Browse your feed
+
+1. `sig run linkedin -- bash -c 'python3 scripts/linkedin_feed.py --cookie "$SIG_LINKEDIN_COOKIE" --limit 5'`
+
+### Search for jobs
+
+1. `sig run linkedin -- bash -c 'python3 scripts/linkedin_search_jobs.py --cookie "$SIG_LINKEDIN_COOKIE" --query "python developer" --location "San Francisco" --limit 10'`
+2. With filters: `sig run linkedin -- bash -c 'python3 scripts/linkedin_search_jobs.py --cookie "$SIG_LINKEDIN_COOKIE" --query "data engineer" --remote 2 --experience 4'`
+
+### Search for posts
+
+1. `sig run linkedin -- bash -c 'python3 scripts/linkedin_search_posts.py --cookie "$SIG_LINKEDIN_COOKIE" --query "machine learning" --limit 5'`
+
+### Search for people
+
+1. `sig run linkedin -- bash -c 'python3 scripts/linkedin_search_people.py --cookie "$SIG_LINKEDIN_COOKIE" --query "software engineer at google" --limit 10'`
+
+### Get job details
+
+1. `sig run linkedin -- bash -c 'python3 scripts/linkedin_job.py --cookie "$SIG_LINKEDIN_COOKIE" --id 12345678'`
+2. Or with URL: `sig run linkedin -- bash -c 'python3 scripts/linkedin_job.py --cookie "$SIG_LINKEDIN_COOKIE" --id "https://www.linkedin.com/jobs/view/12345678"'`
+
+### Create a post
+
+1. `sig run linkedin -- bash -c 'python3 scripts/linkedin_post.py --cookie "$SIG_LINKEDIN_COOKIE" --text "Excited to share my latest project!"'`
+
+### Like a post
+
+1. `sig run linkedin -- bash -c 'python3 scripts/linkedin_like.py --cookie "$SIG_LINKEDIN_COOKIE" --urn "urn:li:activity:7100000000000000001"'`
+
+### Unlike a post
+
+1. `sig run linkedin -- bash -c 'python3 scripts/linkedin_like.py --cookie "$SIG_LINKEDIN_COOKIE" --urn "urn:li:activity:7100000000000000001" --undo'`
+
+### Comment on a post
+
+1. `sig run linkedin -- bash -c 'python3 scripts/linkedin_comment.py --cookie "$SIG_LINKEDIN_COOKIE" --urn "urn:li:activity:7100000000000000001" --text "Great insight!"'`
+
+### Send a connection request
+
+1. `sig run linkedin -- bash -c 'python3 scripts/linkedin_connect.py --cookie "$SIG_LINKEDIN_COOKIE" --urn "urn:li:fsd_profile:ACoAAA123456"'`
+2. With message: `sig run linkedin -- bash -c 'python3 scripts/linkedin_connect.py --cookie "$SIG_LINKEDIN_COOKIE" --urn "urn:li:fsd_profile:ACoAAA123456" --message "Hi, I enjoyed your talk!"'`
+
+### Follow a user
+
+1. `sig run linkedin -- bash -c 'python3 scripts/linkedin_follow.py --cookie "$SIG_LINKEDIN_COOKIE" --urn "urn:li:fsd_profile:ACoAAA123456"'`
+
+### Unfollow a user
+
+1. `sig run linkedin -- bash -c 'python3 scripts/linkedin_follow.py --cookie "$SIG_LINKEDIN_COOKIE" --urn "urn:li:fsd_profile:ACoAAA123456" --undo'`

--- a/skills/linkedin/scripts/linkedin_client.py
+++ b/skills/linkedin/scripts/linkedin_client.py
@@ -129,17 +129,24 @@ def resolve_job_id(raw: str) -> str:
     return raw.strip()
 
 
-def parse_profile(data: dict) -> dict:
+def parse_profile(data: dict, target_username: str = "") -> dict:
+    included = data.get("included", [])
     elements = data.get("elements", [])
-    if not elements:
-        included = data.get("included", [])
+    p = None
+    if target_username:
+        for item in included:
+            if item.get("publicIdentifier") == target_username:
+                p = item
+                break
+    if not p and elements:
+        p = elements[0]
+    if not p:
         for item in included:
             if item.get("$type", "").endswith("Profile") or item.get("firstName"):
-                elements = [item]
+                p = item
                 break
-    if not elements:
+    if not p:
         return {}
-    p = elements[0]
     mp = p.get("miniProfile") or p
     first = (p.get("multiLocaleFirstName") or {}).get("en_US") or mp.get("firstName", "")
     last = (p.get("multiLocaleLastName") or {}).get("en_US") or mp.get("lastName", "")

--- a/skills/linkedin/scripts/linkedin_client.py
+++ b/skills/linkedin/scripts/linkedin_client.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Shared LinkedIn client for LinkedIn skill scripts.
+
+Handles HTTP transport with JSESSIONID CSRF auth,
+Voyager API requests, and response normalization.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+
+import requests
+
+LINKEDIN_BASE = "https://www.linkedin.com"
+VOYAGER_BASE = "https://www.linkedin.com/voyager/api"
+USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+TIMEOUT = 15
+
+
+class LinkedInApiError(Exception):
+    def __init__(self, code: str, message: str = ""):
+        self.code = code
+        self.message = message or code
+        super().__init__(self.message)
+
+
+def error_response(code: str, message: str) -> dict:
+    return {"error": code, "message": message}
+
+
+class LinkedInClient:
+    """HTTP client for LinkedIn's Voyager API with cookie auth."""
+
+    def __init__(self, cookie: str = ""):
+        self.cookie = cookie
+        self._session = requests.Session()
+        self._session.headers.update({
+            "User-Agent": USER_AGENT,
+            "Accept": "application/vnd.linkedin.normalized+json+2.1",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Referer": "https://www.linkedin.com/",
+        })
+        if cookie:
+            self._session.headers["Cookie"] = cookie
+        self._csrf = self._extract_csrf(cookie) if cookie else ""
+        if self._csrf:
+            self._session.headers["csrf-token"] = self._csrf
+            self._session.headers["x-restli-protocol-version"] = "2.0.0"
+            self._session.headers["x-li-lang"] = "en_US"
+
+    @classmethod
+    def create(cls) -> "LinkedInClient":
+        cookie = os.environ.get("SIG_LINKEDIN_COOKIE", "")
+        return cls(cookie)
+
+    @staticmethod
+    def _extract_csrf(cookie: str) -> str:
+        match = re.search(r'JSESSIONID="?([^";]+)"?', cookie)
+        return match.group(1) if match else ""
+
+    def require_cookie(self):
+        if not self.cookie or not self._csrf:
+            raise LinkedInApiError(
+                "AUTH_REQUIRED",
+                "This operation requires a LinkedIn session cookie with JSESSIONID. Run: sig login https://www.linkedin.com/login",
+            )
+
+    def voyager_get(self, path: str, params: dict | None = None) -> dict:
+        self.require_cookie()
+        url = f"{VOYAGER_BASE}{path}"
+        resp = self._session.get(url, params=params, timeout=TIMEOUT)
+        if resp.status_code == 429:
+            retry_after = int(resp.headers.get("Retry-After", "5"))
+            time.sleep(retry_after)
+            resp = self._session.get(url, params=params, timeout=TIMEOUT)
+        if resp.status_code == 401:
+            raise LinkedInApiError("AUTH_EXPIRED", "LinkedIn session expired. Run: sig login https://www.linkedin.com/login")
+        resp.raise_for_status()
+        return resp.json()
+
+    def voyager_post(self, path: str, json_data: dict | None = None) -> dict:
+        self.require_cookie()
+        url = f"{VOYAGER_BASE}{path}"
+        resp = self._session.post(url, json=json_data, timeout=TIMEOUT)
+        if resp.status_code == 429:
+            retry_after = int(resp.headers.get("Retry-After", "5"))
+            time.sleep(retry_after)
+            resp = self._session.post(url, json=json_data, timeout=TIMEOUT)
+        if resp.status_code == 401:
+            raise LinkedInApiError("AUTH_EXPIRED", "LinkedIn session expired. Run: sig login https://www.linkedin.com/login")
+        resp.raise_for_status()
+        if not resp.text:
+            return {}
+        return resp.json()
+
+    def web_get(self, path: str, params: dict | None = None) -> str:
+        """GET a LinkedIn web page and return HTML."""
+        self.require_cookie()
+        url = f"{LINKEDIN_BASE}{path}"
+        headers = {"Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"}
+        resp = self._session.get(url, params=params, headers=headers, timeout=TIMEOUT)
+        resp.raise_for_status()
+        return resp.text
+
+
+def resolve_profile_id(raw: str) -> str:
+    match = re.search(r"linkedin\.com/in/([^/?#]+)", raw)
+    if match:
+        return match.group(1).rstrip("/")
+    return raw.strip().lstrip("@")
+
+
+def resolve_job_id(raw: str) -> str:
+    match = re.search(r"linkedin\.com/jobs/view/(\d+)", raw)
+    if match:
+        return match.group(1)
+    match = re.search(r"(\d{8,})", raw)
+    if match:
+        return match.group(1)
+    return raw.strip()
+
+
+def parse_profile(data: dict) -> dict:
+    elements = data.get("elements", [])
+    if not elements:
+        included = data.get("included", [])
+        for item in included:
+            if item.get("$type", "").endswith("Profile") or item.get("firstName"):
+                elements = [item]
+                break
+    if not elements:
+        return {}
+    p = elements[0]
+    mp = p.get("miniProfile") or p
+    first = (p.get("multiLocaleFirstName") or {}).get("en_US") or mp.get("firstName", "")
+    last = (p.get("multiLocaleLastName") or {}).get("en_US") or mp.get("lastName", "")
+    headline = (p.get("multiLocaleHeadline") or {}).get("en_US") or mp.get("headline") or p.get("headline", "")
+    location = (p.get("geoLocation") or {}).get("geo", {}).get("defaultLocalizedName") or p.get("geoLocationName", "")
+    industry = ((p.get("industryV2") or {}).get("name") or {}).get("locale", {}).get("en_US", "")
+    public_id = mp.get("publicIdentifier") or p.get("publicIdentifier", "")
+    return {
+        "firstName": first,
+        "lastName": last,
+        "headline": headline,
+        "location": location,
+        "industry": industry,
+        "publicIdentifier": public_id,
+        "profileUrl": f"https://www.linkedin.com/in/{public_id}" if public_id else "",
+    }
+
+
+def parse_job_card(element: dict) -> dict | None:
+    card = (element.get("jobCardUnion") or {}).get("jobPostingCard")
+    if not card:
+        return None
+    job_id = ""
+    for urn_field in [card.get("jobPostingUrn"), (card.get("jobPosting") or {}).get("entityUrn"), card.get("entityUrn")]:
+        if urn_field:
+            m = re.search(r"(\d+)", str(urn_field))
+            if m:
+                job_id = m.group(1)
+                break
+    listed_item = next((i for i in (card.get("footerItems") or []) if i.get("type") == "LISTED_DATE" and i.get("timeAt")), None)
+    listed = ""
+    if listed_item:
+        ts = listed_item["timeAt"] / 1000
+        listed = time.strftime("%Y-%m-%d", time.gmtime(ts))
+    return {
+        "jobId": job_id,
+        "title": card.get("jobPostingTitle") or (card.get("title") or {}).get("text", ""),
+        "company": (card.get("primaryDescription") or {}).get("text", ""),
+        "location": (card.get("secondaryDescription") or {}).get("text", ""),
+        "salary": (card.get("tertiaryDescription") or {}).get("text", ""),
+        "listed": listed,
+        "url": f"https://www.linkedin.com/jobs/view/{job_id}" if job_id else "",
+    }
+
+
+def parse_feed_post(update: dict, included: list | None = None) -> dict:
+    actor = (update.get("actor") or {})
+    author = actor.get("name", {}).get("text", "") if isinstance(actor.get("name"), dict) else str(actor.get("name", ""))
+    actor_url = (actor.get("navigationContext") or {}).get("actionTarget", "")
+    commentary = (update.get("commentary") or {}).get("text", {}).get("text", "")
+    social = update.get("socialDetail") or {}
+    reactions = social.get("totalSocialActivityCounts", {}).get("numLikes", 0)
+    comments = social.get("totalSocialActivityCounts", {}).get("numComments", 0)
+    urn = update.get("updateUrn") or update.get("urn", "")
+    return {
+        "author": author,
+        "authorUrl": actor_url,
+        "text": commentary,
+        "reactions": reactions,
+        "comments": comments,
+        "urn": urn,
+        "url": f"https://www.linkedin.com/feed/update/{urn}" if urn else "",
+    }

--- a/skills/linkedin/scripts/linkedin_client.py
+++ b/skills/linkedin/scripts/linkedin_client.py
@@ -43,12 +43,19 @@ class LinkedInClient:
             "Referer": "https://www.linkedin.com/",
         })
         if cookie:
-            self._session.headers["Cookie"] = cookie
+            self._load_cookies(cookie)
         self._csrf = self._extract_csrf(cookie) if cookie else ""
         if self._csrf:
             self._session.headers["csrf-token"] = self._csrf
             self._session.headers["x-restli-protocol-version"] = "2.0.0"
             self._session.headers["x-li-lang"] = "en_US"
+
+    def _load_cookies(self, cookie_str: str):
+        """Parse cookie string into session cookie jar for proper Set-Cookie handling."""
+        for part in cookie_str.split("; "):
+            if "=" in part:
+                name, val = part.split("=", 1)
+                self._session.cookies.set(name.strip(), val.strip().strip('"'), domain=".www.linkedin.com")
 
     @classmethod
     def create(cls) -> "LinkedInClient":

--- a/skills/linkedin/scripts/linkedin_comment.py
+++ b/skills/linkedin/scripts/linkedin_comment.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Post a comment on a LinkedIn post."""
+
+import argparse
+import json
+import sys
+
+import requests
+from linkedin_client import LinkedInApiError, LinkedInClient
+
+
+def post_comment(client: LinkedInClient, urn: str, text: str) -> dict:
+    payload = {"threadUrn": urn, "commentaryV2": {"text": text, "attributes": []}}
+    data = client.voyager_post("/feed/comments", json_data=payload)
+    comment_urn = data.get("urn", "")
+    return {
+        "success": True,
+        "postUrn": urn,
+        "commentUrn": comment_urn,
+        "message": "Comment posted successfully",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Comment on a LinkedIn post")
+    parser.add_argument("--cookie", required=True, help="LinkedIn session cookie")
+    parser.add_argument("--urn", required=True, help="Post URN to comment on")
+    parser.add_argument("--text", required=True, help="Comment text")
+    args = parser.parse_args()
+    try:
+        client = LinkedInClient(args.cookie)
+        result = post_comment(client, args.urn, args.text)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except LinkedInApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/linkedin/scripts/linkedin_connect.py
+++ b/skills/linkedin/scripts/linkedin_connect.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Send a LinkedIn connection request."""
+
+import argparse
+import json
+import sys
+
+import requests
+from linkedin_client import LinkedInApiError, LinkedInClient
+
+
+def send_connection(client: LinkedInClient, profile_urn: str, message: str = "") -> dict:
+    payload = {"inviteeProfileUrn": profile_urn}
+    if message:
+        payload["customMessage"] = message
+    client.voyager_post("/voyagerRelationshipsDashMemberRelationships", json_data=payload)
+    return {"success": True, "profileUrn": profile_urn, "action": "connection_sent", "message": "Connection request sent"}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Send a LinkedIn connection request")
+    parser.add_argument("--cookie", required=True, help="LinkedIn session cookie")
+    parser.add_argument("--urn", required=True, help="Profile URN (e.g., urn:li:fsd_profile:ACoAA...)")
+    parser.add_argument("--message", default="", help="Custom connection message (optional)")
+    args = parser.parse_args()
+    try:
+        client = LinkedInClient(args.cookie)
+        result = send_connection(client, args.urn, args.message)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except LinkedInApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/linkedin/scripts/linkedin_feed.py
+++ b/skills/linkedin/scripts/linkedin_feed.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Get LinkedIn home feed posts."""
+
+import argparse
+import json
+import sys
+
+import requests
+from linkedin_client import LinkedInApiError, LinkedInClient, parse_feed_post
+
+
+def get_feed(client: LinkedInClient, limit: int = 10) -> dict:
+    params = {"q": "feedDashMainFeed", "count": min(limit, 50)}
+    data = client.voyager_get("/feed/updatesV2", params=params)
+    included = data.get("included", [])
+    elements = data.get("elements", [])
+    posts = []
+    for el in elements[:limit]:
+        value = el.get("value") or el
+        post = parse_feed_post(value, included)
+        if post.get("text") or post.get("author"):
+            posts.append(post)
+    return {"count": len(posts), "posts": posts}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get LinkedIn home feed")
+    parser.add_argument("--limit", type=int, default=10, help="Max posts (default: 10)")
+    parser.add_argument("--cookie", default="", help="LinkedIn session cookie")
+    args = parser.parse_args()
+    try:
+        client = LinkedInClient(args.cookie) if args.cookie else LinkedInClient.create()
+        result = get_feed(client, args.limit)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except LinkedInApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/linkedin/scripts/linkedin_feed.py
+++ b/skills/linkedin/scripts/linkedin_feed.py
@@ -10,16 +10,16 @@ from linkedin_client import LinkedInApiError, LinkedInClient, parse_feed_post
 
 
 def get_feed(client: LinkedInClient, limit: int = 10) -> dict:
-    params = {"q": "feedDashMainFeed", "count": min(limit, 50)}
-    data = client.voyager_get("/feed/updatesV2", params=params)
+    data = client.voyager_get("/voyagerFeedDashMainFeed", params={"q": "mainFeed", "count": min(limit, 50)})
     included = data.get("included", [])
-    elements = data.get("elements", [])
     posts = []
-    for el in elements[:limit]:
-        value = el.get("value") or el
-        post = parse_feed_post(value, included)
-        if post.get("text") or post.get("author"):
-            posts.append(post)
+    for item in included:
+        if item.get("$type", "").endswith("feed.Update"):
+            post = parse_feed_post(item, included)
+            if post.get("text") or post.get("author"):
+                posts.append(post)
+            if len(posts) >= limit:
+                break
     return {"count": len(posts), "posts": posts}
 
 

--- a/skills/linkedin/scripts/linkedin_follow.py
+++ b/skills/linkedin/scripts/linkedin_follow.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Follow or unfollow a LinkedIn user."""
+
+import argparse
+import json
+import sys
+
+import requests
+from linkedin_client import LinkedInApiError, LinkedInClient
+
+
+def follow_user(client: LinkedInClient, urn: str, undo: bool = False) -> dict:
+    if undo:
+        client.voyager_post("/feed/follows", json_data={"urn": urn, "followerAction": "UNFOLLOW"})
+        return {"success": True, "urn": urn, "action": "unfollowed", "message": "Unfollowed user"}
+    client.voyager_post("/feed/follows", json_data={"urn": urn, "followerAction": "FOLLOW"})
+    return {"success": True, "urn": urn, "action": "followed", "message": "Followed user"}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Follow or unfollow a LinkedIn user")
+    parser.add_argument("--cookie", required=True, help="LinkedIn session cookie")
+    parser.add_argument("--urn", required=True, help="User URN (e.g., urn:li:fsd_profile:ACoAA...)")
+    parser.add_argument("--undo", action="store_true", help="Unfollow instead of follow")
+    args = parser.parse_args()
+    try:
+        client = LinkedInClient(args.cookie)
+        result = follow_user(client, args.urn, args.undo)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except LinkedInApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/linkedin/scripts/linkedin_job.py
+++ b/skills/linkedin/scripts/linkedin_job.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Get LinkedIn job posting details."""
+
+import argparse
+import json
+import sys
+
+import requests
+from linkedin_client import LinkedInApiError, LinkedInClient, resolve_job_id
+
+
+def get_job(client: LinkedInClient, job_id: str) -> dict:
+    data = client.voyager_get(f"/jobs/jobPostings/{job_id}")
+    title = (data.get("title") or {}).get("text", "") if isinstance(data.get("title"), dict) else data.get("title", "")
+    company = (data.get("companyDetails") or {}).get("company", "")
+    if isinstance(company, dict):
+        company = company.get("name", "")
+    desc = (data.get("description") or {}).get("text", "") if isinstance(data.get("description"), dict) else data.get("description", "")
+    location = data.get("formattedLocation", "")
+    workplace = data.get("workplaceTypesResolutionResults", {})
+    workplace_type = ""
+    for wt in workplace.values():
+        workplace_type = (wt.get("localizedName", "") if isinstance(wt, dict) else "")
+        break
+    return {
+        "jobId": job_id,
+        "title": title,
+        "company": company,
+        "location": location,
+        "workplaceType": workplace_type,
+        "description": desc[:2000],
+        "listedAt": data.get("listedAt", 0),
+        "applies": data.get("applies", 0),
+        "views": data.get("views", 0),
+        "url": f"https://www.linkedin.com/jobs/view/{job_id}",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get LinkedIn job details")
+    parser.add_argument("--id", required=True, help="Job ID or LinkedIn job URL")
+    parser.add_argument("--cookie", default="", help="LinkedIn session cookie")
+    args = parser.parse_args()
+    try:
+        client = LinkedInClient(args.cookie) if args.cookie else LinkedInClient.create()
+        job_id = resolve_job_id(args.id)
+        result = get_job(client, job_id)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except LinkedInApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/linkedin/scripts/linkedin_like.py
+++ b/skills/linkedin/scripts/linkedin_like.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Like or unlike a LinkedIn post."""
+
+import argparse
+import json
+import sys
+
+import requests
+from linkedin_client import LinkedInApiError, LinkedInClient
+
+
+def like_post(client: LinkedInClient, urn: str, undo: bool = False) -> dict:
+    if undo:
+        client.voyager_post("/voyagerSocialDashReactions", json_data={"action": "UNREACT", "entityUrn": urn})
+        return {"success": True, "urn": urn, "action": "unliked", "message": "Post unliked"}
+    payload = {"entityUrn": urn, "reactionType": "LIKE"}
+    client.voyager_post("/voyagerSocialDashReactions", json_data=payload)
+    return {"success": True, "urn": urn, "action": "liked", "message": "Post liked"}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Like or unlike a LinkedIn post")
+    parser.add_argument("--cookie", required=True, help="LinkedIn session cookie")
+    parser.add_argument("--urn", required=True, help="Post URN (e.g., urn:li:activity:1234567890)")
+    parser.add_argument("--undo", action="store_true", help="Unlike instead of like")
+    args = parser.parse_args()
+    try:
+        client = LinkedInClient(args.cookie)
+        result = like_post(client, args.urn, args.undo)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except LinkedInApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/linkedin/scripts/linkedin_me.py
+++ b/skills/linkedin/scripts/linkedin_me.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Get current LinkedIn user profile."""
+
+import argparse
+import json
+import sys
+
+import requests
+from linkedin_client import LinkedInApiError, LinkedInClient
+
+
+def get_me(client: LinkedInClient) -> dict:
+    data = client.voyager_get("/me")
+    mp = data.get("miniProfile") or data
+    first = mp.get("firstName", "")
+    last = mp.get("lastName", "")
+    return {
+        "firstName": first,
+        "lastName": last,
+        "headline": mp.get("headline", ""),
+        "publicIdentifier": mp.get("publicIdentifier", ""),
+        "entityUrn": data.get("entityUrn", ""),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get current LinkedIn user profile")
+    parser.add_argument("--cookie", default="", help="LinkedIn session cookie")
+    args = parser.parse_args()
+    try:
+        client = LinkedInClient(args.cookie) if args.cookie else LinkedInClient.create()
+        result = get_me(client)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except LinkedInApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/linkedin/scripts/linkedin_me.py
+++ b/skills/linkedin/scripts/linkedin_me.py
@@ -11,15 +11,23 @@ from linkedin_client import LinkedInApiError, LinkedInClient
 
 def get_me(client: LinkedInClient) -> dict:
     data = client.voyager_get("/me")
-    mp = data.get("miniProfile") or data
-    first = mp.get("firstName", "")
-    last = mp.get("lastName", "")
+    me = data.get("data") or data
+    plain_id = me.get("plainId", 0)
+    mini_urn = me.get("*miniProfile", "")
+    included = data.get("included", [])
+    profile = {}
+    for item in included:
+        if item.get("lastName") or item.get("occupation"):
+            profile = item
+            break
     return {
-        "firstName": first,
-        "lastName": last,
-        "headline": mp.get("headline", ""),
-        "publicIdentifier": mp.get("publicIdentifier", ""),
-        "entityUrn": data.get("entityUrn", ""),
+        "id": plain_id,
+        "firstName": profile.get("firstName", ""),
+        "lastName": profile.get("lastName", ""),
+        "headline": profile.get("occupation", ""),
+        "publicIdentifier": profile.get("publicIdentifier", ""),
+        "entityUrn": profile.get("dashEntityUrn") or profile.get("objectUrn") or mini_urn,
+        "premium": me.get("premiumSubscriber", False),
     }
 
 

--- a/skills/linkedin/scripts/linkedin_post.py
+++ b/skills/linkedin/scripts/linkedin_post.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Create a LinkedIn post."""
+
+import argparse
+import json
+import sys
+
+import requests
+from linkedin_client import LinkedInApiError, LinkedInClient
+
+
+def create_post(client: LinkedInClient, text: str) -> dict:
+    payload = {
+        "visibleToConnectionsOnly": False,
+        "externalAudienceProviders": [],
+        "commentaryV2": {"text": text, "attributes": []},
+        "origin": "FEED",
+        "allowedCommentersScope": "ALL",
+        "mediaCategory": "NONE",
+    }
+    data = client.voyager_post("/contentcreation/normShares", json_data=payload)
+    urn = data.get("urn") or data.get("value", {}).get("urn", "")
+    return {
+        "success": True,
+        "urn": urn,
+        "url": f"https://www.linkedin.com/feed/update/{urn}" if urn else "",
+        "message": "Post created successfully",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create a LinkedIn post")
+    parser.add_argument("--cookie", required=True, help="LinkedIn session cookie")
+    parser.add_argument("--text", required=True, help="Post text content")
+    args = parser.parse_args()
+    try:
+        client = LinkedInClient(args.cookie)
+        result = create_post(client, args.text)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except LinkedInApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/linkedin/scripts/linkedin_post.py
+++ b/skills/linkedin/scripts/linkedin_post.py
@@ -19,12 +19,16 @@ def create_post(client: LinkedInClient, text: str) -> dict:
         "mediaCategory": "NONE",
     }
     data = client.voyager_post("/contentcreation/normShares", json_data=payload)
-    urn = data.get("urn") or data.get("value", {}).get("urn", "")
+    status = (data.get("data") or {}).get("status") or data.get("value") or data
+    urn = status.get("urn") or data.get("urn", "")
+    activity_urn = (status.get("*updateV2") or "").split("(")[-1].split(",")[0] if status.get("*updateV2") else ""
+    url = status.get("toastCtaUrl") or (f"https://www.linkedin.com/feed/update/{urn}" if urn else "")
     return {
         "success": True,
         "urn": urn,
-        "url": f"https://www.linkedin.com/feed/update/{urn}" if urn else "",
-        "message": "Post created successfully",
+        "activityUrn": activity_urn,
+        "url": url,
+        "message": status.get("mainToastText") or "Post created successfully",
     }
 
 

--- a/skills/linkedin/scripts/linkedin_profile.py
+++ b/skills/linkedin/scripts/linkedin_profile.py
@@ -14,7 +14,7 @@ DECORATION_ID = "com.linkedin.voyager.dash.deco.identity.profile.WebTopCardCore-
 def get_profile(client: LinkedInClient, username: str) -> dict:
     params = {"q": "memberIdentity", "memberIdentity": username, "decorationId": DECORATION_ID}
     data = client.voyager_get("/identity/dash/profiles", params=params)
-    profile = parse_profile(data)
+    profile = parse_profile(data, target_username=username)
     if not profile:
         raise LinkedInApiError("NOT_FOUND", f"Profile not found: {username}")
     return profile

--- a/skills/linkedin/scripts/linkedin_profile.py
+++ b/skills/linkedin/scripts/linkedin_profile.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Get a LinkedIn user profile by username."""
+
+import argparse
+import json
+import sys
+
+import requests
+from linkedin_client import LinkedInApiError, LinkedInClient, parse_profile, resolve_profile_id
+
+DECORATION_ID = "com.linkedin.voyager.dash.deco.identity.profile.WebTopCardCore-20"
+
+
+def get_profile(client: LinkedInClient, username: str) -> dict:
+    params = {"q": "memberIdentity", "memberIdentity": username, "decorationId": DECORATION_ID}
+    data = client.voyager_get("/identity/dash/profiles", params=params)
+    profile = parse_profile(data)
+    if not profile:
+        raise LinkedInApiError("NOT_FOUND", f"Profile not found: {username}")
+    return profile
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get a LinkedIn user profile")
+    parser.add_argument("--username", required=True, help="LinkedIn username or profile URL")
+    parser.add_argument("--cookie", default="", help="LinkedIn session cookie")
+    args = parser.parse_args()
+    try:
+        client = LinkedInClient(args.cookie) if args.cookie else LinkedInClient.create()
+        username = resolve_profile_id(args.username)
+        result = get_profile(client, username)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except LinkedInApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/linkedin/scripts/linkedin_search_jobs.py
+++ b/skills/linkedin/scripts/linkedin_search_jobs.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Search LinkedIn jobs via Voyager API."""
+
+import argparse
+import json
+import sys
+import urllib.parse
+
+import requests
+from linkedin_client import LinkedInApiError, LinkedInClient, parse_job_card
+
+DECORATION_ID = "com.linkedin.voyager.dash.deco.jobs.search.JobSearchCardsCollection-220"
+
+
+def _build_query(keywords: str, location: str = "", experience: str = "", job_type: str = "", date_posted: str = "", remote: str = "") -> str:
+    parts = ["origin:JOB_SEARCH_PAGE_OTHER_ENTRY", f"keywords:{keywords}"]
+    if location:
+        parts.append(f"locationUnion:(seoLocation:(location:{location}))")
+    filters = []
+    if experience:
+        filters.append(f"experience:List({experience})")
+    if job_type:
+        filters.append(f"jobType:List({job_type})")
+    if date_posted:
+        filters.append(f"timePostedRange:List({date_posted})")
+    if remote:
+        filters.append(f"workplaceType:List({remote})")
+    if filters:
+        parts.append(f"selectedFilters:({','.join(filters)})")
+    parts.append("spellCorrectionEnabled:true")
+    return "(" + ",".join(parts) + ")"
+
+
+def _encode_query(query: str) -> str:
+    encoded = urllib.parse.quote(query, safe="")
+    for old, new in [("%3A", ":"), ("%2C", ","), ("%28", "("), ("%29", ")")]:
+        encoded = encoded.replace(old, new)
+    return encoded
+
+
+def search_jobs(client: LinkedInClient, keywords: str, location: str = "", limit: int = 10, start: int = 0, **filters) -> dict:
+    query = _build_query(keywords, location, **filters)
+    url_path = f"/voyagerJobsDashJobCards?decorationId={DECORATION_ID}&count={min(limit, 25)}&q=jobSearch&query={_encode_query(query)}&start={start}"
+    data = client.voyager_get(url_path)
+    elements = data.get("elements", [])
+    jobs = []
+    for i, el in enumerate(elements):
+        job = parse_job_card(el)
+        if job:
+            job["rank"] = start + i + 1
+            jobs.append(job)
+    return {"query": keywords, "location": location, "count": len(jobs), "start": start, "jobs": jobs[:limit]}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Search LinkedIn jobs")
+    parser.add_argument("--query", required=True, help="Job search keywords")
+    parser.add_argument("--location", default="", help="Location")
+    parser.add_argument("--limit", type=int, default=10, help="Max results (default: 10)")
+    parser.add_argument("--start", type=int, default=0, help="Offset for pagination")
+    parser.add_argument("--experience", default="", help="Experience level codes (comma-sep: 1=intern,2=entry,3=assoc,4=mid,5=dir,6=exec)")
+    parser.add_argument("--job-type", default="", help="Job type codes (F=full,P=part,C=contract,T=temp,V=volunteer,I=intern)")
+    parser.add_argument("--date-posted", default="", help="Date filter (r86400=24h, r604800=week, r2592000=month)")
+    parser.add_argument("--remote", default="", help="Workplace type (1=onsite, 2=remote, 3=hybrid)")
+    parser.add_argument("--cookie", default="", help="LinkedIn session cookie")
+    args = parser.parse_args()
+    try:
+        client = LinkedInClient(args.cookie) if args.cookie else LinkedInClient.create()
+        result = search_jobs(client, args.query, args.location, args.limit, args.start,
+                             experience=args.experience, job_type=args.job_type, date_posted=args.date_posted, remote=args.remote)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except LinkedInApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/linkedin/scripts/linkedin_search_jobs.py
+++ b/skills/linkedin/scripts/linkedin_search_jobs.py
@@ -42,14 +42,20 @@ def search_jobs(client: LinkedInClient, keywords: str, location: str = "", limit
     query = _build_query(keywords, location, **filters)
     url_path = f"/voyagerJobsDashJobCards?decorationId={DECORATION_ID}&count={min(limit, 25)}&q=jobSearch&query={_encode_query(query)}&start={start}"
     data = client.voyager_get(url_path)
-    elements = data.get("elements", [])
     jobs = []
-    for i, el in enumerate(elements):
+    for el in data.get("elements", []):
         job = parse_job_card(el)
         if job:
-            job["rank"] = start + i + 1
             jobs.append(job)
-    return {"query": keywords, "location": location, "count": len(jobs), "start": start, "jobs": jobs[:limit]}
+    if not jobs:
+        for item in data.get("included", []):
+            if item.get("jobPostingTitle") or (item.get("$type", "").endswith("JobPostingCard")):
+                job = parse_job_card({"jobCardUnion": {"jobPostingCard": item}})
+                if job:
+                    jobs.append(job)
+    for i, job in enumerate(jobs[:limit]):
+        job["rank"] = start + i + 1
+    return {"query": keywords, "location": location, "count": len(jobs[:limit]), "start": start, "jobs": jobs[:limit]}
 
 
 def main():

--- a/skills/linkedin/scripts/linkedin_search_people.py
+++ b/skills/linkedin/scripts/linkedin_search_people.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Search LinkedIn people via Voyager API."""
+
+import argparse
+import json
+import re
+import sys
+
+import requests
+from linkedin_client import LinkedInApiError, LinkedInClient
+
+
+def search_people(client: LinkedInClient, keywords: str, limit: int = 10, start: int = 0) -> dict:
+    query = f"(keywords:{keywords},resultType:List(PEOPLE),origin:GLOBAL_SEARCH_HEADER)"
+    params = {"q": "all", "query": query, "count": min(limit, 25), "start": start,
+              "decorationId": "com.linkedin.voyager.dash.deco.search.SearchClusterCollection-187"}
+    data = client.voyager_get("/voyagerSearchDashClusters", params=params)
+    people = []
+    for element in data.get("elements", []):
+        items = element.get("items", [])
+        for item in items:
+            entity = (item.get("item") or {}).get("entityResult")
+            if not entity:
+                continue
+            title_text = (entity.get("title") or {}).get("text", "")
+            summary_text = (entity.get("primarySubtitle") or {}).get("text", "")
+            location_text = (entity.get("secondarySubtitle") or {}).get("text", "")
+            nav = (entity.get("navigationContext") or {}).get("url", "")
+            urn = entity.get("entityUrn", "")
+            public_id_match = re.search(r"/in/([^?/]+)", nav)
+            people.append({
+                "name": title_text,
+                "headline": summary_text,
+                "location": location_text,
+                "publicIdentifier": public_id_match.group(1) if public_id_match else "",
+                "profileUrl": nav.split("?")[0] if nav else "",
+                "urn": urn,
+            })
+            if len(people) >= limit:
+                break
+        if len(people) >= limit:
+            break
+    return {"query": keywords, "count": len(people), "start": start, "people": people}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Search LinkedIn people")
+    parser.add_argument("--query", required=True, help="Search keywords")
+    parser.add_argument("--limit", type=int, default=10, help="Max results (default: 10)")
+    parser.add_argument("--start", type=int, default=0, help="Offset for pagination")
+    parser.add_argument("--cookie", default="", help="LinkedIn session cookie")
+    args = parser.parse_args()
+    try:
+        client = LinkedInClient(args.cookie) if args.cookie else LinkedInClient.create()
+        result = search_people(client, args.query, args.limit, args.start)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except LinkedInApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/linkedin/scripts/linkedin_search_posts.py
+++ b/skills/linkedin/scripts/linkedin_search_posts.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Search LinkedIn posts via HTML page with RSC payload parsing."""
+
+import argparse
+import json
+import re
+import sys
+
+import requests
+from linkedin_client import LinkedInApiError, LinkedInClient
+
+
+def search_posts(client: LinkedInClient, query: str, limit: int = 10) -> dict:
+    html = client.web_get("/search/results/content/", params={"keywords": query})
+    posts = []
+    author_pattern = re.compile(r'\\"actorName\\":\\"([^"]+)\\"')
+    url_pattern = re.compile(r'\\"postSlugUrl\\":\\"(https:[^"]+)\\"')
+    text_pattern = re.compile(r'\\"children\\":\[null,\\"(.*?)\\"\]')
+    authors = author_pattern.findall(html)
+    urls = url_pattern.findall(html)
+    texts = text_pattern.findall(html)
+    count = min(len(authors), len(urls), limit)
+    for i in range(count):
+        text = texts[i] if i < len(texts) else ""
+        text = text.replace("\\\\u00a0", " ").replace("\\\\u2019", "’").replace("\\\\n", "\n")
+        post_url = urls[i].replace("\\/", "/") if i < len(urls) else ""
+        posts.append({
+            "rank": i + 1,
+            "author": authors[i].replace("\\\\u0026", "&") if i < len(authors) else "",
+            "text": text[:500],
+            "url": post_url,
+        })
+    return {"query": query, "count": len(posts), "posts": posts}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Search LinkedIn posts")
+    parser.add_argument("--query", required=True, help="Search keywords")
+    parser.add_argument("--limit", type=int, default=10, help="Max results (default: 10)")
+    parser.add_argument("--cookie", default="", help="LinkedIn session cookie")
+    args = parser.parse_args()
+    try:
+        client = LinkedInClient(args.cookie) if args.cookie else LinkedInClient.create()
+        result = search_posts(client, args.query, args.limit)
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    except LinkedInApiError as e:
+        json.dump({"error": e.code, "message": e.message}, sys.stdout, indent=2)
+    except requests.HTTPError as e:
+        json.dump({"error": "HTTP_" + str(e.response.status_code), "message": str(e)}, sys.stdout, indent=2)
+    except Exception as e:
+        json.dump({"error": "ERROR", "message": str(e)}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/linkedin/tests/test_linkedin_comment.py
+++ b/skills/linkedin/tests/test_linkedin_comment.py
@@ -1,0 +1,58 @@
+"""Tests for linkedin/scripts/linkedin_comment.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("linkedin", "linkedin_comment")
+client_mod = load_script("linkedin", "linkedin_client")
+
+FAKE_COOKIE = 'JSESSIONID="ajax:fakecsrf123"; li_at=fakesession'
+
+_POST_URN = "urn:li:activity:7100000000000000001"
+
+
+@responses.activate
+def test_post_comment_success():
+    """post_comment returns success with comment URN."""
+    responses.post(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/feed/comments"),
+        json={"urn": "urn:li:comment:(activity:7100000000000000001,7200000000000000001)"},
+        status=200,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.post_comment(client, _POST_URN, "Great insight!")
+
+    assert result["success"] is True
+    assert result["postUrn"] == _POST_URN
+    assert "comment" in result["commentUrn"]
+    assert result["message"] == "Comment posted successfully"
+
+
+@responses.activate
+def test_post_comment_empty_response():
+    """post_comment handles empty urn in response."""
+    responses.post(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/feed/comments"),
+        json={},
+        status=200,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.post_comment(client, _POST_URN, "Nice post")
+
+    assert result["success"] is True
+    assert result["commentUrn"] == ""
+
+
+def test_post_comment_requires_auth():
+    """post_comment raises AUTH_REQUIRED when no cookie is provided."""
+    client = client_mod.LinkedInClient("")
+    try:
+        mod.post_comment(client, _POST_URN, "test")
+        assert False, "Should have raised"
+    except client_mod.LinkedInApiError as e:
+        assert e.code == "AUTH_REQUIRED"

--- a/skills/linkedin/tests/test_linkedin_connect.py
+++ b/skills/linkedin/tests/test_linkedin_connect.py
@@ -1,0 +1,60 @@
+"""Tests for linkedin/scripts/linkedin_connect.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("linkedin", "linkedin_connect")
+client_mod = load_script("linkedin", "linkedin_client")
+
+FAKE_COOKIE = 'JSESSIONID="ajax:fakecsrf123"; li_at=fakesession'
+
+_PROFILE_URN = "urn:li:fsd_profile:ACoAAA123456"
+
+
+@responses.activate
+def test_send_connection_success():
+    """send_connection returns success."""
+    responses.post(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/voyagerRelationshipsDashMemberRelationships"),
+        json={},
+        status=200,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.send_connection(client, _PROFILE_URN)
+
+    assert result["success"] is True
+    assert result["action"] == "connection_sent"
+    assert result["profileUrn"] == _PROFILE_URN
+
+
+@responses.activate
+def test_send_connection_with_message():
+    """send_connection includes custom message in payload."""
+    responses.post(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/voyagerRelationshipsDashMemberRelationships"),
+        json={},
+        status=200,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.send_connection(client, _PROFILE_URN, message="Hi, let's connect!")
+
+    assert result["success"] is True
+    assert result["action"] == "connection_sent"
+    # Verify the request body included the custom message
+    body = responses.calls[0].request.body
+    assert "connect" in body.decode() if isinstance(body, bytes) else "connect" in body
+
+
+def test_send_connection_requires_auth():
+    """send_connection raises AUTH_REQUIRED when no cookie is provided."""
+    client = client_mod.LinkedInClient("")
+    try:
+        mod.send_connection(client, _PROFILE_URN)
+        assert False, "Should have raised"
+    except client_mod.LinkedInApiError as e:
+        assert e.code == "AUTH_REQUIRED"

--- a/skills/linkedin/tests/test_linkedin_feed.py
+++ b/skills/linkedin/tests/test_linkedin_feed.py
@@ -1,0 +1,90 @@
+"""Tests for linkedin/scripts/linkedin_feed.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("linkedin", "linkedin_feed")
+client_mod = load_script("linkedin", "linkedin_client")
+
+FAKE_COOKIE = 'JSESSIONID="ajax:fakecsrf123"; li_at=fakesession'
+
+_FEED_RESPONSE = {
+    "elements": [
+        {
+            "value": {
+                "actor": {
+                    "name": {"text": "Jane Doe"},
+                    "navigationContext": {"actionTarget": "https://www.linkedin.com/in/janedoe"},
+                },
+                "commentary": {"text": {"text": "Excited to share my latest project!"}},
+                "socialDetail": {
+                    "totalSocialActivityCounts": {"numLikes": 42, "numComments": 5},
+                },
+                "updateUrn": "urn:li:activity:7100000000000000001",
+            }
+        },
+        {
+            "value": {
+                "actor": {
+                    "name": {"text": "Bob Smith"},
+                    "navigationContext": {"actionTarget": "https://www.linkedin.com/in/bobsmith"},
+                },
+                "commentary": {"text": {"text": "Great article on AI trends."}},
+                "socialDetail": {
+                    "totalSocialActivityCounts": {"numLikes": 10, "numComments": 2},
+                },
+                "updateUrn": "urn:li:activity:7100000000000000002",
+            }
+        },
+    ],
+    "included": [],
+}
+
+
+@responses.activate
+def test_get_feed_returns_posts():
+    """get_feed returns formatted feed posts."""
+    responses.get(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/feed/updatesV2"),
+        json=_FEED_RESPONSE,
+        status=200,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.get_feed(client, limit=10)
+
+    assert result["count"] == 2
+    assert len(result["posts"]) == 2
+    assert result["posts"][0]["author"] == "Jane Doe"
+    assert result["posts"][0]["text"] == "Excited to share my latest project!"
+    assert result["posts"][0]["reactions"] == 42
+    assert result["posts"][0]["comments"] == 5
+
+
+@responses.activate
+def test_get_feed_empty():
+    """get_feed returns empty list when feed has no posts."""
+    responses.get(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/feed/updatesV2"),
+        json={"elements": [], "included": []},
+        status=200,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.get_feed(client, limit=10)
+
+    assert result["count"] == 0
+    assert result["posts"] == []
+
+
+def test_get_feed_requires_auth():
+    """get_feed raises AUTH_REQUIRED when no cookie is provided."""
+    client = client_mod.LinkedInClient("")
+    try:
+        mod.get_feed(client)
+        assert False, "Should have raised"
+    except client_mod.LinkedInApiError as e:
+        assert e.code == "AUTH_REQUIRED"

--- a/skills/linkedin/tests/test_linkedin_feed.py
+++ b/skills/linkedin/tests/test_linkedin_feed.py
@@ -12,35 +12,33 @@ client_mod = load_script("linkedin", "linkedin_client")
 FAKE_COOKIE = 'JSESSIONID="ajax:fakecsrf123"; li_at=fakesession'
 
 _FEED_RESPONSE = {
-    "elements": [
+    "data": {"metadata": {"paginationToken": "test"}},
+    "included": [
         {
-            "value": {
-                "actor": {
-                    "name": {"text": "Jane Doe"},
-                    "navigationContext": {"actionTarget": "https://www.linkedin.com/in/janedoe"},
-                },
-                "commentary": {"text": {"text": "Excited to share my latest project!"}},
-                "socialDetail": {
-                    "totalSocialActivityCounts": {"numLikes": 42, "numComments": 5},
-                },
-                "updateUrn": "urn:li:activity:7100000000000000001",
-            }
+            "$type": "com.linkedin.voyager.dash.feed.Update",
+            "actor": {
+                "name": {"text": "Jane Doe"},
+                "navigationContext": {"actionTarget": "https://www.linkedin.com/in/janedoe"},
+            },
+            "commentary": {"text": {"text": "Excited to share my latest project!"}},
+            "socialDetail": {
+                "totalSocialActivityCounts": {"numLikes": 42, "numComments": 5},
+            },
+            "updateUrn": "urn:li:activity:7100000000000000001",
         },
         {
-            "value": {
-                "actor": {
-                    "name": {"text": "Bob Smith"},
-                    "navigationContext": {"actionTarget": "https://www.linkedin.com/in/bobsmith"},
-                },
-                "commentary": {"text": {"text": "Great article on AI trends."}},
-                "socialDetail": {
-                    "totalSocialActivityCounts": {"numLikes": 10, "numComments": 2},
-                },
-                "updateUrn": "urn:li:activity:7100000000000000002",
-            }
+            "$type": "com.linkedin.voyager.dash.feed.Update",
+            "actor": {
+                "name": {"text": "Bob Smith"},
+                "navigationContext": {"actionTarget": "https://www.linkedin.com/in/bobsmith"},
+            },
+            "commentary": {"text": {"text": "Great article on AI trends."}},
+            "socialDetail": {
+                "totalSocialActivityCounts": {"numLikes": 10, "numComments": 2},
+            },
+            "updateUrn": "urn:li:activity:7100000000000000002",
         },
     ],
-    "included": [],
 }
 
 
@@ -48,7 +46,7 @@ _FEED_RESPONSE = {
 def test_get_feed_returns_posts():
     """get_feed returns formatted feed posts."""
     responses.get(
-        url=re.compile(r"https://www\.linkedin\.com/voyager/api/feed/updatesV2"),
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/voyagerFeedDashMainFeed"),
         json=_FEED_RESPONSE,
         status=200,
     )
@@ -68,8 +66,8 @@ def test_get_feed_returns_posts():
 def test_get_feed_empty():
     """get_feed returns empty list when feed has no posts."""
     responses.get(
-        url=re.compile(r"https://www\.linkedin\.com/voyager/api/feed/updatesV2"),
-        json={"elements": [], "included": []},
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/voyagerFeedDashMainFeed"),
+        json={"data": {}, "included": []},
         status=200,
     )
 

--- a/skills/linkedin/tests/test_linkedin_follow.py
+++ b/skills/linkedin/tests/test_linkedin_follow.py
@@ -1,0 +1,75 @@
+"""Tests for linkedin/scripts/linkedin_follow.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("linkedin", "linkedin_follow")
+client_mod = load_script("linkedin", "linkedin_client")
+
+FAKE_COOKIE = 'JSESSIONID="ajax:fakecsrf123"; li_at=fakesession'
+
+_USER_URN = "urn:li:fsd_profile:ACoAAA123456"
+
+
+@responses.activate
+def test_follow_user_success():
+    """follow_user follows a user and returns success."""
+    responses.post(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/feed/follows"),
+        json={},
+        status=200,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.follow_user(client, _USER_URN)
+
+    assert result["success"] is True
+    assert result["action"] == "followed"
+    assert result["urn"] == _USER_URN
+
+
+@responses.activate
+def test_unfollow_user_success():
+    """follow_user with undo=True unfollows a user."""
+    responses.post(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/feed/follows"),
+        json={},
+        status=200,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.follow_user(client, _USER_URN, undo=True)
+
+    assert result["success"] is True
+    assert result["action"] == "unfollowed"
+    assert result["urn"] == _USER_URN
+
+
+def test_follow_user_requires_auth():
+    """follow_user raises AUTH_REQUIRED when no cookie is provided."""
+    client = client_mod.LinkedInClient("")
+    try:
+        mod.follow_user(client, _USER_URN)
+        assert False, "Should have raised"
+    except client_mod.LinkedInApiError as e:
+        assert e.code == "AUTH_REQUIRED"
+
+
+@responses.activate
+def test_follow_user_expired_session():
+    """follow_user raises AUTH_EXPIRED on 401."""
+    responses.post(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/feed/follows"),
+        json={},
+        status=401,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    try:
+        mod.follow_user(client, _USER_URN)
+        assert False, "Should have raised"
+    except client_mod.LinkedInApiError as e:
+        assert e.code == "AUTH_EXPIRED"

--- a/skills/linkedin/tests/test_linkedin_job.py
+++ b/skills/linkedin/tests/test_linkedin_job.py
@@ -1,0 +1,75 @@
+"""Tests for linkedin/scripts/linkedin_job.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("linkedin", "linkedin_job")
+client_mod = load_script("linkedin", "linkedin_client")
+
+FAKE_COOKIE = 'JSESSIONID="ajax:fakecsrf123"; li_at=fakesession'
+
+_JOB_RESPONSE = {
+    "title": "Senior Software Engineer",
+    "companyDetails": {"company": {"name": "Acme Corp"}},
+    "description": {"text": "We are looking for an experienced engineer to join our team."},
+    "formattedLocation": "San Francisco, CA",
+    "workplaceTypesResolutionResults": {
+        "urn:li:fsd_workplaceType:1": {"localizedName": "On-site"}
+    },
+    "listedAt": 1700000000000,
+    "applies": 150,
+    "views": 2500,
+}
+
+
+@responses.activate
+def test_get_job_returns_details():
+    """get_job returns formatted job posting details."""
+    responses.get(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/jobs/jobPostings/12345678"),
+        json=_JOB_RESPONSE,
+        status=200,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.get_job(client, "12345678")
+
+    assert result["jobId"] == "12345678"
+    assert result["title"] == "Senior Software Engineer"
+    assert result["company"] == "Acme Corp"
+    assert result["location"] == "San Francisco, CA"
+    assert result["workplaceType"] == "On-site"
+    assert result["applies"] == 150
+    assert result["views"] == 2500
+    assert result["url"] == "https://www.linkedin.com/jobs/view/12345678"
+
+
+@responses.activate
+def test_get_job_minimal_data():
+    """get_job handles minimal job data gracefully."""
+    responses.get(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/jobs/jobPostings/99999999"),
+        json={"title": "Intern", "formattedLocation": "Remote"},
+        status=200,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.get_job(client, "99999999")
+
+    assert result["jobId"] == "99999999"
+    assert result["title"] == "Intern"
+    assert result["location"] == "Remote"
+    assert result["company"] == ""
+
+
+def test_get_job_requires_auth():
+    """get_job raises AUTH_REQUIRED when no cookie is provided."""
+    client = client_mod.LinkedInClient("")
+    try:
+        mod.get_job(client, "12345678")
+        assert False, "Should have raised"
+    except client_mod.LinkedInApiError as e:
+        assert e.code == "AUTH_REQUIRED"

--- a/skills/linkedin/tests/test_linkedin_like.py
+++ b/skills/linkedin/tests/test_linkedin_like.py
@@ -1,0 +1,58 @@
+"""Tests for linkedin/scripts/linkedin_like.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("linkedin", "linkedin_like")
+client_mod = load_script("linkedin", "linkedin_client")
+
+FAKE_COOKIE = 'JSESSIONID="ajax:fakecsrf123"; li_at=fakesession'
+
+_POST_URN = "urn:li:activity:7100000000000000001"
+
+
+@responses.activate
+def test_like_post_success():
+    """like_post likes a post and returns success."""
+    responses.post(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/voyagerSocialDashReactions"),
+        json={},
+        status=200,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.like_post(client, _POST_URN)
+
+    assert result["success"] is True
+    assert result["action"] == "liked"
+    assert result["urn"] == _POST_URN
+
+
+@responses.activate
+def test_unlike_post_success():
+    """like_post with undo=True unlikes a post."""
+    responses.post(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/voyagerSocialDashReactions"),
+        json={},
+        status=200,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.like_post(client, _POST_URN, undo=True)
+
+    assert result["success"] is True
+    assert result["action"] == "unliked"
+    assert result["urn"] == _POST_URN
+
+
+def test_like_post_requires_auth():
+    """like_post raises AUTH_REQUIRED when no cookie is provided."""
+    client = client_mod.LinkedInClient("")
+    try:
+        mod.like_post(client, _POST_URN)
+        assert False, "Should have raised"
+    except client_mod.LinkedInApiError as e:
+        assert e.code == "AUTH_REQUIRED"

--- a/skills/linkedin/tests/test_linkedin_me.py
+++ b/skills/linkedin/tests/test_linkedin_me.py
@@ -12,13 +12,20 @@ client_mod = load_script("linkedin", "linkedin_client")
 FAKE_COOKIE = 'JSESSIONID="ajax:fakecsrf123"; li_at=fakesession'
 
 _ME_RESPONSE = {
-    "miniProfile": {
-        "firstName": "Jane",
-        "lastName": "Doe",
-        "headline": "Software Engineer at Acme",
-        "publicIdentifier": "janedoe",
+    "data": {
+        "plainId": 123456,
+        "*miniProfile": "urn:li:fs_miniProfile:ACoAAA123456",
+        "premiumSubscriber": False,
     },
-    "entityUrn": "urn:li:fsd_profile:ACoAAA123456",
+    "included": [
+        {
+            "firstName": "Jane",
+            "lastName": "Doe",
+            "occupation": "Software Engineer at Acme",
+            "publicIdentifier": "janedoe",
+            "dashEntityUrn": "urn:li:fsd_profile:ACoAAA123456",
+        }
+    ],
 }
 
 
@@ -34,6 +41,7 @@ def test_get_me_returns_profile():
     client = client_mod.LinkedInClient(FAKE_COOKIE)
     result = mod.get_me(client)
 
+    assert result["id"] == 123456
     assert result["firstName"] == "Jane"
     assert result["lastName"] == "Doe"
     assert result["headline"] == "Software Engineer at Acme"
@@ -42,25 +50,20 @@ def test_get_me_returns_profile():
 
 
 @responses.activate
-def test_get_me_without_mini_profile():
-    """get_me falls back to top-level fields when miniProfile is absent."""
+def test_get_me_without_included():
+    """get_me returns partial data when included is empty."""
     responses.get(
         url=re.compile(r"https://www\.linkedin\.com/voyager/api/me"),
-        json={
-            "firstName": "John",
-            "lastName": "Smith",
-            "headline": "PM",
-            "publicIdentifier": "johnsmith",
-            "entityUrn": "urn:li:fsd_profile:ACoAAB999999",
-        },
+        json={"data": {"plainId": 999, "premiumSubscriber": True}, "included": []},
         status=200,
     )
 
     client = client_mod.LinkedInClient(FAKE_COOKIE)
     result = mod.get_me(client)
 
-    assert result["firstName"] == "John"
-    assert result["lastName"] == "Smith"
+    assert result["id"] == 999
+    assert result["premium"] is True
+    assert result["firstName"] == ""
 
 
 def test_get_me_requires_auth():

--- a/skills/linkedin/tests/test_linkedin_me.py
+++ b/skills/linkedin/tests/test_linkedin_me.py
@@ -1,0 +1,90 @@
+"""Tests for linkedin/scripts/linkedin_me.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("linkedin", "linkedin_me")
+client_mod = load_script("linkedin", "linkedin_client")
+
+FAKE_COOKIE = 'JSESSIONID="ajax:fakecsrf123"; li_at=fakesession'
+
+_ME_RESPONSE = {
+    "miniProfile": {
+        "firstName": "Jane",
+        "lastName": "Doe",
+        "headline": "Software Engineer at Acme",
+        "publicIdentifier": "janedoe",
+    },
+    "entityUrn": "urn:li:fsd_profile:ACoAAA123456",
+}
+
+
+@responses.activate
+def test_get_me_returns_profile():
+    """get_me returns the current user profile."""
+    responses.get(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/me"),
+        json=_ME_RESPONSE,
+        status=200,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.get_me(client)
+
+    assert result["firstName"] == "Jane"
+    assert result["lastName"] == "Doe"
+    assert result["headline"] == "Software Engineer at Acme"
+    assert result["publicIdentifier"] == "janedoe"
+    assert result["entityUrn"] == "urn:li:fsd_profile:ACoAAA123456"
+
+
+@responses.activate
+def test_get_me_without_mini_profile():
+    """get_me falls back to top-level fields when miniProfile is absent."""
+    responses.get(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/me"),
+        json={
+            "firstName": "John",
+            "lastName": "Smith",
+            "headline": "PM",
+            "publicIdentifier": "johnsmith",
+            "entityUrn": "urn:li:fsd_profile:ACoAAB999999",
+        },
+        status=200,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.get_me(client)
+
+    assert result["firstName"] == "John"
+    assert result["lastName"] == "Smith"
+
+
+def test_get_me_requires_auth():
+    """get_me raises AUTH_REQUIRED when no cookie is provided."""
+    client = client_mod.LinkedInClient("")
+    try:
+        mod.get_me(client)
+        assert False, "Should have raised"
+    except client_mod.LinkedInApiError as e:
+        assert e.code == "AUTH_REQUIRED"
+
+
+@responses.activate
+def test_get_me_expired_session():
+    """get_me raises AUTH_EXPIRED on 401."""
+    responses.get(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/me"),
+        json={},
+        status=401,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    try:
+        mod.get_me(client)
+        assert False, "Should have raised"
+    except client_mod.LinkedInApiError as e:
+        assert e.code == "AUTH_EXPIRED"

--- a/skills/linkedin/tests/test_linkedin_post.py
+++ b/skills/linkedin/tests/test_linkedin_post.py
@@ -1,0 +1,56 @@
+"""Tests for linkedin/scripts/linkedin_post.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("linkedin", "linkedin_post")
+client_mod = load_script("linkedin", "linkedin_client")
+
+FAKE_COOKIE = 'JSESSIONID="ajax:fakecsrf123"; li_at=fakesession'
+
+
+@responses.activate
+def test_create_post_success():
+    """create_post returns success with URN."""
+    responses.post(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/contentcreation/normShares"),
+        json={"urn": "urn:li:activity:7100000000000000099"},
+        status=200,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.create_post(client, "Hello LinkedIn!")
+
+    assert result["success"] is True
+    assert result["urn"] == "urn:li:activity:7100000000000000099"
+    assert "linkedin.com/feed/update/" in result["url"]
+    assert result["message"] == "Post created successfully"
+
+
+@responses.activate
+def test_create_post_with_value_urn():
+    """create_post extracts URN from value.urn fallback."""
+    responses.post(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/contentcreation/normShares"),
+        json={"value": {"urn": "urn:li:activity:7100000000000000100"}},
+        status=200,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.create_post(client, "Another post")
+
+    assert result["success"] is True
+    assert result["urn"] == "urn:li:activity:7100000000000000100"
+
+
+def test_create_post_requires_auth():
+    """create_post raises AUTH_REQUIRED when no cookie is provided."""
+    client = client_mod.LinkedInClient("")
+    try:
+        mod.create_post(client, "test")
+        assert False, "Should have raised"
+    except client_mod.LinkedInApiError as e:
+        assert e.code == "AUTH_REQUIRED"

--- a/skills/linkedin/tests/test_linkedin_profile.py
+++ b/skills/linkedin/tests/test_linkedin_profile.py
@@ -1,0 +1,102 @@
+"""Tests for linkedin/scripts/linkedin_profile.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("linkedin", "linkedin_profile")
+client_mod = load_script("linkedin", "linkedin_client")
+
+FAKE_COOKIE = 'JSESSIONID="ajax:fakecsrf123"; li_at=fakesession'
+
+_PROFILE_RESPONSE = {
+    "elements": [
+        {
+            "miniProfile": {
+                "firstName": "Alice",
+                "lastName": "Wonder",
+                "headline": "Data Scientist",
+                "publicIdentifier": "alicewonder",
+            },
+            "multiLocaleFirstName": {"en_US": "Alice"},
+            "multiLocaleLastName": {"en_US": "Wonder"},
+            "multiLocaleHeadline": {"en_US": "Data Scientist"},
+            "geoLocation": {"geo": {"defaultLocalizedName": "San Francisco"}},
+        }
+    ]
+}
+
+
+@responses.activate
+def test_get_profile_returns_data():
+    """get_profile returns formatted profile data."""
+    responses.get(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/identity/dash/profiles"),
+        json=_PROFILE_RESPONSE,
+        status=200,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.get_profile(client, "alicewonder")
+
+    assert result["firstName"] == "Alice"
+    assert result["lastName"] == "Wonder"
+    assert result["headline"] == "Data Scientist"
+    assert result["location"] == "San Francisco"
+    assert result["profileUrl"] == "https://www.linkedin.com/in/alicewonder"
+
+
+@responses.activate
+def test_get_profile_not_found():
+    """get_profile raises NOT_FOUND when profile data is empty."""
+    responses.get(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/identity/dash/profiles"),
+        json={"elements": []},
+        status=200,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    try:
+        mod.get_profile(client, "nonexistent")
+        assert False, "Should have raised"
+    except client_mod.LinkedInApiError as e:
+        assert e.code == "NOT_FOUND"
+
+
+def test_get_profile_requires_auth():
+    """get_profile raises AUTH_REQUIRED when no cookie is provided."""
+    client = client_mod.LinkedInClient("")
+    try:
+        mod.get_profile(client, "someone")
+        assert False, "Should have raised"
+    except client_mod.LinkedInApiError as e:
+        assert e.code == "AUTH_REQUIRED"
+
+
+@responses.activate
+def test_get_profile_from_included_fallback():
+    """get_profile extracts from included array when elements is empty."""
+    responses.get(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/identity/dash/profiles"),
+        json={
+            "elements": [],
+            "included": [
+                {
+                    "$type": "com.linkedin.voyager.identity.shared.MiniProfile",
+                    "firstName": "Bob",
+                    "lastName": "Builder",
+                    "headline": "Engineer",
+                    "publicIdentifier": "bobbuilder",
+                }
+            ],
+        },
+        status=200,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.get_profile(client, "bobbuilder")
+
+    assert result["firstName"] == "Bob"
+    assert result["lastName"] == "Builder"

--- a/skills/linkedin/tests/test_linkedin_search_jobs.py
+++ b/skills/linkedin/tests/test_linkedin_search_jobs.py
@@ -1,0 +1,91 @@
+"""Tests for linkedin/scripts/linkedin_search_jobs.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("linkedin", "linkedin_search_jobs")
+client_mod = load_script("linkedin", "linkedin_client")
+
+FAKE_COOKIE = 'JSESSIONID="ajax:fakecsrf123"; li_at=fakesession'
+
+_JOBS_RESPONSE = {
+    "elements": [
+        {
+            "jobCardUnion": {
+                "jobPostingCard": {
+                    "jobPostingUrn": "urn:li:fsd_jobPosting:3800000001",
+                    "jobPostingTitle": "Senior Python Developer",
+                    "primaryDescription": {"text": "Acme Corp"},
+                    "secondaryDescription": {"text": "San Francisco, CA"},
+                    "tertiaryDescription": {"text": "$150k - $200k"},
+                    "footerItems": [
+                        {"type": "LISTED_DATE", "timeAt": 1700000000000}
+                    ],
+                }
+            }
+        },
+        {
+            "jobCardUnion": {
+                "jobPostingCard": {
+                    "jobPostingUrn": "urn:li:fsd_jobPosting:3800000002",
+                    "jobPostingTitle": "Backend Engineer",
+                    "primaryDescription": {"text": "Widgets Inc"},
+                    "secondaryDescription": {"text": "Remote"},
+                    "tertiaryDescription": {"text": ""},
+                    "footerItems": [],
+                }
+            }
+        },
+    ]
+}
+
+
+@responses.activate
+def test_search_jobs_returns_results():
+    """search_jobs returns formatted job listings."""
+    responses.get(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/voyagerJobsDashJobCards"),
+        json=_JOBS_RESPONSE,
+        status=200,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.search_jobs(client, "python developer", limit=10)
+
+    assert result["query"] == "python developer"
+    assert result["count"] == 2
+    assert len(result["jobs"]) == 2
+    assert result["jobs"][0]["title"] == "Senior Python Developer"
+    assert result["jobs"][0]["company"] == "Acme Corp"
+    assert result["jobs"][0]["location"] == "San Francisco, CA"
+    assert result["jobs"][0]["jobId"] == "3800000001"
+    assert result["jobs"][0]["rank"] == 1
+
+
+@responses.activate
+def test_search_jobs_empty():
+    """search_jobs returns empty list when no jobs match."""
+    responses.get(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/voyagerJobsDashJobCards"),
+        json={"elements": []},
+        status=200,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.search_jobs(client, "nonexistent job xyz", limit=10)
+
+    assert result["count"] == 0
+    assert result["jobs"] == []
+
+
+def test_search_jobs_requires_auth():
+    """search_jobs raises AUTH_REQUIRED when no cookie is provided."""
+    client = client_mod.LinkedInClient("")
+    try:
+        mod.search_jobs(client, "python")
+        assert False, "Should have raised"
+    except client_mod.LinkedInApiError as e:
+        assert e.code == "AUTH_REQUIRED"

--- a/skills/linkedin/tests/test_linkedin_search_people.py
+++ b/skills/linkedin/tests/test_linkedin_search_people.py
@@ -1,0 +1,95 @@
+"""Tests for linkedin/scripts/linkedin_search_people.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("linkedin", "linkedin_search_people")
+client_mod = load_script("linkedin", "linkedin_client")
+
+FAKE_COOKIE = 'JSESSIONID="ajax:fakecsrf123"; li_at=fakesession'
+
+_PEOPLE_RESPONSE = {
+    "elements": [
+        {
+            "items": [
+                {
+                    "item": {
+                        "entityResult": {
+                            "title": {"text": "Jane Doe"},
+                            "primarySubtitle": {"text": "Software Engineer at Acme"},
+                            "secondarySubtitle": {"text": "San Francisco Bay Area"},
+                            "navigationContext": {
+                                "url": "https://www.linkedin.com/in/janedoe?miniProfileUrn=urn"
+                            },
+                            "entityUrn": "urn:li:fsd_entityResultViewModel:(urn:li:fsd_profile:ACoAAA111111,SEARCH,ALL)",
+                        }
+                    }
+                },
+                {
+                    "item": {
+                        "entityResult": {
+                            "title": {"text": "Bob Smith"},
+                            "primarySubtitle": {"text": "Product Manager"},
+                            "secondarySubtitle": {"text": "New York"},
+                            "navigationContext": {
+                                "url": "https://www.linkedin.com/in/bobsmith?miniProfileUrn=urn"
+                            },
+                            "entityUrn": "urn:li:fsd_entityResultViewModel:(urn:li:fsd_profile:ACoAAB222222,SEARCH,ALL)",
+                        }
+                    }
+                },
+            ]
+        }
+    ]
+}
+
+
+@responses.activate
+def test_search_people_returns_results():
+    """search_people returns formatted people results."""
+    responses.get(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/voyagerSearchDashClusters"),
+        json=_PEOPLE_RESPONSE,
+        status=200,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.search_people(client, "software engineer", limit=10)
+
+    assert result["query"] == "software engineer"
+    assert result["count"] == 2
+    assert len(result["people"]) == 2
+    assert result["people"][0]["name"] == "Jane Doe"
+    assert result["people"][0]["headline"] == "Software Engineer at Acme"
+    assert result["people"][0]["location"] == "San Francisco Bay Area"
+    assert result["people"][0]["publicIdentifier"] == "janedoe"
+    assert result["people"][0]["profileUrl"] == "https://www.linkedin.com/in/janedoe"
+
+
+@responses.activate
+def test_search_people_empty():
+    """search_people returns empty list when no results found."""
+    responses.get(
+        url=re.compile(r"https://www\.linkedin\.com/voyager/api/voyagerSearchDashClusters"),
+        json={"elements": []},
+        status=200,
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.search_people(client, "xyznonexistent", limit=10)
+
+    assert result["count"] == 0
+    assert result["people"] == []
+
+
+def test_search_people_requires_auth():
+    """search_people raises AUTH_REQUIRED when no cookie is provided."""
+    client = client_mod.LinkedInClient("")
+    try:
+        mod.search_people(client, "test")
+        assert False, "Should have raised"
+    except client_mod.LinkedInApiError as e:
+        assert e.code == "AUTH_REQUIRED"

--- a/skills/linkedin/tests/test_linkedin_search_posts.py
+++ b/skills/linkedin/tests/test_linkedin_search_posts.py
@@ -1,0 +1,74 @@
+"""Tests for linkedin/scripts/linkedin_search_posts.py"""
+
+import re
+
+import responses
+
+from test_helpers import load_script
+
+mod = load_script("linkedin", "linkedin_search_posts")
+client_mod = load_script("linkedin", "linkedin_client")
+
+FAKE_COOKIE = 'JSESSIONID="ajax:fakecsrf123"; li_at=fakesession'
+
+_RSC_HTML = (
+    "<html><head><title>LinkedIn</title></head><body>"
+    '<script>window.__INITIAL_STATE__ = {'
+    '\\"actorName\\":\\"John Doe\\"'
+    ',\\"postSlugUrl\\":\\"https:\\/\\/www.linkedin.com\\/posts\\/johndoe_testing-activity\\"'
+    ',\\"children\\":[null,\\"This is a great post about AI\\"]'
+    ",}"
+    '\\"actorName\\":\\"Alice Wang\\"'
+    ',\\"postSlugUrl\\":\\"https:\\/\\/www.linkedin.com\\/posts\\/alicewang_engineering-update\\"'
+    ',\\"children\\":[null,\\"Sharing my thoughts on engineering\\"]'
+    "</script></body></html>"
+)
+
+
+@responses.activate
+def test_search_posts_parses_rsc_html():
+    """search_posts extracts posts from RSC-embedded HTML."""
+    responses.get(
+        url=re.compile(r"https://www\.linkedin\.com/search/results/content/"),
+        body=_RSC_HTML,
+        status=200,
+        content_type="text/html",
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.search_posts(client, "AI", limit=10)
+
+    assert result["query"] == "AI"
+    assert result["count"] == 2
+    assert len(result["posts"]) == 2
+    assert result["posts"][0]["author"] == "John Doe"
+    assert "linkedin.com/posts/" in result["posts"][0]["url"]
+    assert result["posts"][0]["rank"] == 1
+    assert result["posts"][1]["author"] == "Alice Wang"
+
+
+@responses.activate
+def test_search_posts_empty():
+    """search_posts returns empty when no matching content in HTML."""
+    responses.get(
+        url=re.compile(r"https://www\.linkedin\.com/search/results/content/"),
+        body="<html><body>No results</body></html>",
+        status=200,
+        content_type="text/html",
+    )
+
+    client = client_mod.LinkedInClient(FAKE_COOKIE)
+    result = mod.search_posts(client, "xyznonexistent", limit=10)
+
+    assert result["count"] == 0
+    assert result["posts"] == []
+
+
+def test_search_posts_requires_auth():
+    """search_posts raises AUTH_REQUIRED when no cookie is provided."""
+    client = client_mod.LinkedInClient("")
+    try:
+        mod.search_posts(client, "test")
+        assert False, "Should have raised"
+    except client_mod.LinkedInApiError as e:
+        assert e.code == "AUTH_REQUIRED"


### PR DESCRIPTION
## Summary

- Add LinkedIn skill with 12 scripts (7 read + 5 write) + shared client
- **Read**: profile, me, feed, job search, job detail, post search (RSC parsing), people search
- **Write**: post, like/unlike, comment, connect, follow/unfollow
- Uses LinkedIn Voyager API with JSESSIONID CSRF auth
- 39 unit tests, all passing
- SKILL.md with auth guide, safety notes, manual cookie instructions

## Scripts

| Script | Purpose | Auth |
|--------|---------|------|
| `linkedin_me.py` | Current user profile | Required |
| `linkedin_profile.py` | User profile by username | Required |
| `linkedin_feed.py` | Home feed posts | Required |
| `linkedin_search_jobs.py` | Job search with filters | Required |
| `linkedin_search_posts.py` | Post search (RSC HTML) | Required |
| `linkedin_search_people.py` | People search | Required |
| `linkedin_job.py` | Job posting detail | Required |
| `linkedin_post.py` | Create a post | Required |
| `linkedin_like.py` | Like/unlike a post | Required |
| `linkedin_comment.py` | Comment on a post | Required |
| `linkedin_connect.py` | Send connection request | Required |
| `linkedin_follow.py` | Follow/unfollow user | Required |

## Test plan

- [x] `ruff check skills/linkedin/` — zero errors
- [x] `pytest skills/linkedin/tests/ -v` — 39/39 passed
- [x] `prettier --write skills/linkedin/SKILL.md` — formatted
- [ ] Live test with LinkedIn cookies (user to verify)