### PR TITLE
fix(skills): add linkedin to install.sh and pyproject.toml

### DIFF
--- a/skills/install.sh
+++ b/skills/install.sh
@@ -12,7 +12,7 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ALL_SKILLS="sigcli-auth outlook msteams slack v2ex zhihu reddit bilibili youtube"
+ALL_SKILLS="sigcli-auth outlook msteams slack v2ex zhihu reddit bilibili youtube linkedin"
 
 # --- Agent detection ---
 

--- a/skills/pyproject.toml
+++ b/skills/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = ["requests>=2.28.0", "beautifulsoup4>=4.12.0"]
 dev = ["pytest>=8.0", "responses>=0.25.0", "ruff>=0.4.0"]
 
 [tool.pytest.ini_options]
-testpaths = ["outlook/tests", "msteams/tests", "slack/tests", "v2ex/tests", "zhihu/tests", "reddit/tests", "bilibili/tests", "youtube/tests"]
+testpaths = ["outlook/tests", "msteams/tests", "slack/tests", "v2ex/tests", "zhihu/tests", "reddit/tests", "bilibili/tests", "youtube/tests", "linkedin/tests"]
 pythonpath = ["."]
 addopts = "-v --tb=short"
 


### PR DESCRIPTION
## Summary
- Add `linkedin` to `ALL_SKILLS` in `install.sh`
- Add `linkedin/tests` to `testpaths` in `pyproject.toml`

Missed in the LinkedIn skill PR (#60).