### PR TITLE
fix(cookie): use entryUrl for path-scoped cookie detection

### DIFF
--- a/cli/src/strategies/cookie.strategy.ts
+++ b/cli/src/strategies/cookie.strategy.ts
@@ -87,7 +87,9 @@ class CookieStrategy implements IAuthStrategy {
             isAuthenticated: async (page) => {
                 // If requiredCookies is set, auth is complete only when those cookies exist
                 if (this.requiredCookies.length > 0) {
-                    const urls = provider.domains.map((d) => `https://${d}/`);
+                    const urls = [provider.entryUrl!];
+                    const currentUrl = page.url();
+                    if (currentUrl && currentUrl !== provider.entryUrl) urls.push(currentUrl);
                     const cookies = await page.cookies(urls);
                     const cookieNames = new Set(cookies.map((c) => c.name));
                     return this.requiredCookies.every((name) => cookieNames.has(name));
@@ -99,11 +101,9 @@ class CookieStrategy implements IAuthStrategy {
             },
 
             extractCredentials: async (page, xHeaders, localStorage, meta) => {
-                // Only extract cookies matching this provider's domains (not all cookies from the shared profile)
-                // Include both domain roots AND current page URL (to capture path-scoped cookies like /wiki)
-                const urls = provider.domains.map((d) => `https://${d}/`);
+                const urls = [provider.entryUrl!];
                 const currentUrl = page.url();
-                if (currentUrl && !urls.includes(currentUrl)) urls.push(currentUrl);
+                if (currentUrl && currentUrl !== provider.entryUrl) urls.push(currentUrl);
                 const cookies = await page.cookies(urls);
                 if (cookies.length === 0) {
                     return err(


### PR DESCRIPTION
## Summary

Fixes #64 — `CookieStrategy.isAuthenticated` missed path-scoped cookies (e.g. `path=/wiki`).

- `isAuthenticated` queried cookies using domain roots (`https://domain/`), which never matched cookies scoped to sub-paths
- `extractCredentials` had a partial workaround using `page.url()` but `isAuthenticated` lacked it entirely
- Both now use `entryUrl` (which already contains the correct domain + path) instead of deriving URLs from `domains`

`entryUrl` is the right source of truth — it has both the domain and path. `page.url()` is kept as a fallback for post-SSO redirects. `domains` is for provider URL resolution, not cookie extraction.

## Test plan

- [x] Build passes
- [x] All 666 unit tests pass
- [ ] Manual: `sig login` with a provider using path-scoped cookies (e.g. Confluence with `seraph.confluence` at `path=/wiki`)