### PR TITLE
feat(cli): add `sig skills` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ in your browser         -->   credentials locally          -->  on your behalf
 Pre-built Python scripts that let AI agents operate 14+ web services — email, chat, forums, video platforms, social networks, and more. Each skill includes scripts + documentation that agents read and execute autonomously.
 
 ```bash
-git clone https://github.com/sigcli/sigcli.git
-cd sigcli/skills && ./install.sh
+sig skills install --all      # install all skills to your coding agent
+sig skills list               # see available skills
 ```
 
 See the [full skills catalog](skills/README.md) for details.

--- a/cli/eslint.config.js
+++ b/cli/eslint.config.js
@@ -94,9 +94,9 @@ export default tseslint.config(
         },
     },
 
-    // Node.js globals for bin/ scripts
+    // Node.js globals for bin/ and scripts/
     {
-        files: ['bin/**/*.js'],
+        files: ['bin/**/*.js', 'scripts/**/*.js'],
         languageOptions: {
             globals: {
                 console: 'readonly',
@@ -108,7 +108,13 @@ export default tseslint.config(
 
     // Plain JS and config files — disable type-checked rules
     {
-        files: ['bin/**/*.js', '**/*.config.ts', '**/*.config.js', 'eslint.config.js'],
+        files: [
+            'bin/**/*.js',
+            'scripts/**/*.js',
+            '**/*.config.ts',
+            '**/*.config.js',
+            'eslint.config.js',
+        ],
         ...tseslint.configs.disableTypeChecked,
     },
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -13,7 +13,8 @@
     ],
     "scripts": {
         "build": "tsc",
-        "prepack": "pnpm run build",
+        "copy-skills": "node scripts/copy-skills.js",
+        "prepack": "pnpm run build && pnpm run copy-skills",
         "start": "node bin/sig.js",
         "dev": "tsc && node bin/sig.js",
         "test": "vitest run",

--- a/cli/scripts/copy-skills.js
+++ b/cli/scripts/copy-skills.js
@@ -1,0 +1,33 @@
+import { readdirSync, statSync, mkdirSync, cpSync, existsSync, rmSync } from 'node:fs';
+import { join, dirname, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SKILLS_SRC = join(__dirname, '../../skills');
+const SKILLS_DEST = join(__dirname, '../dist/skills');
+
+const EXCLUDE_DIRS = new Set(['tests', '__pycache__', 'node_modules']);
+
+// Discover skills: directories containing SKILL.md
+const skills = readdirSync(SKILLS_SRC).filter((name) => {
+    const p = join(SKILLS_SRC, name);
+    return statSync(p).isDirectory() && existsSync(join(p, 'SKILL.md'));
+});
+
+// Clean and recreate dest
+if (existsSync(SKILLS_DEST)) rmSync(SKILLS_DEST, { recursive: true });
+mkdirSync(SKILLS_DEST, { recursive: true });
+
+for (const skill of skills) {
+    cpSync(join(SKILLS_SRC, skill), join(SKILLS_DEST, skill), {
+        recursive: true,
+        filter: (src) => {
+            const b = basename(src);
+            return !EXCLUDE_DIRS.has(b) && !b.endsWith('.pyc');
+        },
+    });
+    process.stderr.write(`  + ${skill}\n`);
+}
+
+process.stderr.write(`\nBundled ${skills.length} skills to ${SKILLS_DEST}\n`);

--- a/cli/src/cli/commands/completion.ts
+++ b/cli/src/cli/commands/completion.ts
@@ -1,7 +1,7 @@
 import { ExitCode } from '../exit-codes.js';
 
 const SUBCOMMANDS =
-    'init doctor get login request status logout providers remote sync watch rename remove completion';
+    'init doctor get login request status logout providers remote sync watch rename remove completion skills';
 
 function bashScript(): string {
     return [
@@ -31,6 +31,9 @@ function bashScript(): string {
         '            ;;',
         '        completion)',
         '            COMPREPLY=($(compgen -W "bash zsh fish" -- "$cur"))',
+        '            ;;',
+        '        skills)',
+        '            COMPREPLY=($(compgen -W "install uninstall list" -- "$cur"))',
         '            ;;',
         '        --format)',
         '            COMPREPLY=($(compgen -W "json table yaml env plain" -- "$cur"))',
@@ -70,6 +73,7 @@ function zshScript(): string {
         "        'rename:Rename a provider'",
         "        'remove:Remove provider and credentials'",
         "        'completion:Generate shell completion script'",
+        "        'skills:Install AI agent skills'",
         '    )',
         '',
         '    _arguments -C \\',
@@ -105,6 +109,10 @@ function zshScript(): string {
         '                    local -a shells=(bash zsh fish)',
         "                    _describe 'shells' shells",
         '                    ;;',
+        '                skills)',
+        '                    local -a sub=(install uninstall list)',
+        "                    _describe 'skills subcommands' sub",
+        '                    ;;',
         '            esac',
         '            ;;',
         '    esac',
@@ -134,6 +142,7 @@ function fishScript(): string {
         'complete -c sig -n "__fish_use_subcommand" -a rename -d "Rename a provider"',
         'complete -c sig -n "__fish_use_subcommand" -a remove -d "Remove provider and credentials"',
         'complete -c sig -n "__fish_use_subcommand" -a completion -d "Generate shell completion script"',
+        'complete -c sig -n "__fish_use_subcommand" -a skills -d "Install AI agent skills"',
         '',
         'function __sig_providers',
         "    sig providers --format json 2>/dev/null | node -e \"process.stdin.resume();let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{JSON.parse(d).forEach(p=>console.log(p.id))}catch{}}\" 2>/dev/null",
@@ -144,6 +153,7 @@ function fishScript(): string {
         'complete -c sig -n "__fish_seen_subcommand_from sync" -a "push pull"',
         'complete -c sig -n "__fish_seen_subcommand_from watch" -a "add remove list start set-interval"',
         'complete -c sig -n "__fish_seen_subcommand_from completion" -a "bash zsh fish"',
+        'complete -c sig -n "__fish_seen_subcommand_from skills" -a "install uninstall list"',
         'complete -c sig -l verbose -d "Debug output to stderr"',
         'complete -c sig -l help -d "Show help"',
         'complete -c sig -l format -d "Output format" -a "json table yaml env plain"',

--- a/cli/src/cli/commands/skills.ts
+++ b/cli/src/cli/commands/skills.ts
@@ -1,0 +1,239 @@
+import { existsSync } from 'node:fs';
+import { readdir, rm, mkdir, cp } from 'node:fs/promises';
+import { join, dirname, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { homedir } from 'node:os';
+import { createInterface } from 'node:readline';
+import { SkillsSubcommand } from '../../core/constants.js';
+import { ExitCode } from '../exit-codes.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function getSkillsDir(): string {
+    // Published package: dist/cli/commands/skills.js -> dist/skills/
+    const published = join(__dirname, '../../skills');
+    if (existsSync(published)) return published;
+    // Dev mode: dist/cli/commands/ -> monorepo skills/
+    const dev = join(__dirname, '../../../../skills');
+    if (existsSync(dev)) return dev;
+    return published;
+}
+
+const AGENT_MAP: Record<string, string> = {
+    claude: join(homedir(), '.claude', 'skills'),
+    cursor: join(homedir(), '.cursor', 'skills'),
+    windsurf: join(homedir(), '.windsurf', 'skills'),
+    cline: join(homedir(), '.cline', 'skills'),
+};
+
+function detectDestination(flags: Record<string, string | boolean | string[]>): string {
+    if (typeof flags.dest === 'string') return flags.dest;
+
+    if (typeof flags.agent === 'string') {
+        const dest = AGENT_MAP[flags.agent];
+        if (!dest) {
+            process.stderr.write(
+                `Unknown agent: ${flags.agent}. Use: claude, cursor, windsurf, cline\n`,
+            );
+            process.exitCode = ExitCode.GENERAL_ERROR;
+            return '';
+        }
+        return dest;
+    }
+
+    // Auto-detect
+    for (const [agent, dest] of Object.entries(AGENT_MAP)) {
+        if (existsSync(join(homedir(), `.${agent}`))) {
+            process.stderr.write(`Auto-detected: ${agent}\n`);
+            return dest;
+        }
+    }
+
+    return AGENT_MAP.claude;
+}
+
+async function getAvailableSkills(): Promise<string[]> {
+    const dir = getSkillsDir();
+    if (!existsSync(dir)) return [];
+    const entries = await readdir(dir, { withFileTypes: true });
+    return entries
+        .filter((e) => e.isDirectory() && existsSync(join(dir, e.name, 'SKILL.md')))
+        .map((e) => e.name)
+        .sort();
+}
+
+async function promptSelect(skills: string[], action: string): Promise<string[]> {
+    if (!process.stdin.isTTY) return skills;
+
+    process.stderr.write(`\nAvailable skills (${action}):\n`);
+    skills.forEach((s, i) => process.stderr.write(`  ${i + 1}) ${s}\n`));
+
+    const rl = createInterface({ input: process.stdin, output: process.stderr });
+    const answer = await new Promise<string>((resolve) =>
+        rl.question(`\nEnter numbers (e.g. 1,3,5) or 'a' for all: `, resolve),
+    );
+    rl.close();
+
+    if (answer.trim().toLowerCase() === 'a' || answer.trim() === '') return skills;
+
+    const selected: string[] = [];
+    for (const num of answer.split(/[,\s]+/)) {
+        const idx = parseInt(num, 10) - 1;
+        if (idx >= 0 && idx < skills.length) selected.push(skills[idx]);
+    }
+    return selected;
+}
+
+const USAGE = `Usage: sig skills <subcommand>
+
+Subcommands:
+  list                         List available skills and install status
+  install [skill...]           Install AI agent skills
+    --all                        Install all skills
+    --agent <name>               Target: claude|cursor|windsurf|cline
+    --dest <path>                Custom install path
+  uninstall [skill...]         Remove installed skills
+    --all                        Remove all skills
+`;
+
+export async function runSkills(
+    positionals: string[],
+    flags: Record<string, string | boolean | string[]>,
+): Promise<void> {
+    const subcommand = positionals[0];
+
+    switch (subcommand) {
+        case SkillsSubcommand.INSTALL:
+            await handleInstall(positionals.slice(1), flags);
+            break;
+        case SkillsSubcommand.UNINSTALL:
+            await handleUninstall(positionals.slice(1), flags);
+            break;
+        case SkillsSubcommand.LIST:
+            await handleList(flags);
+            break;
+        default:
+            process.stderr.write(USAGE);
+            if (subcommand) process.exitCode = ExitCode.GENERAL_ERROR;
+    }
+}
+
+async function handleInstall(
+    positionals: string[],
+    flags: Record<string, string | boolean | string[]>,
+): Promise<void> {
+    const dest = detectDestination(flags);
+    if (!dest) return;
+
+    const available = await getAvailableSkills();
+    if (available.length === 0) {
+        process.stderr.write('No bundled skills found.\n');
+        process.exitCode = ExitCode.GENERAL_ERROR;
+        return;
+    }
+
+    let selected: string[];
+    if (positionals.length > 0) {
+        selected = positionals.filter((s) => {
+            if (!available.includes(s)) {
+                process.stderr.write(`  ! unknown skill: ${s}\n`);
+                return false;
+            }
+            return true;
+        });
+    } else if (flags.all === true) {
+        selected = available;
+    } else {
+        selected = await promptSelect(available, 'install');
+    }
+
+    if (selected.length === 0) {
+        process.stderr.write('No skills selected.\n');
+        return;
+    }
+
+    await mkdir(dest, { recursive: true });
+    const skillsDir = getSkillsDir();
+
+    for (const skill of selected) {
+        const src = join(skillsDir, skill);
+        const target = join(dest, skill);
+        await rm(target, { recursive: true, force: true });
+        await cp(src, target, {
+            recursive: true,
+            filter: (source: string) => {
+                const b = basename(source);
+                return b !== 'tests' && b !== '__pycache__' && !b.endsWith('.pyc');
+            },
+        });
+        process.stderr.write(`  + ${skill}\n`);
+    }
+
+    process.stderr.write(`\nInstalled ${selected.length} skill(s) to ${dest}\n`);
+}
+
+async function handleUninstall(
+    positionals: string[],
+    flags: Record<string, string | boolean | string[]>,
+): Promise<void> {
+    const dest = detectDestination(flags);
+    if (!dest) return;
+
+    if (!existsSync(dest)) {
+        process.stderr.write(`No skills installed at ${dest}\n`);
+        return;
+    }
+
+    const available = await getAvailableSkills();
+    const entries = await readdir(dest, { withFileTypes: true });
+    const installed = entries
+        .filter((e) => e.isDirectory() && available.includes(e.name))
+        .map((e) => e.name)
+        .sort();
+
+    if (installed.length === 0) {
+        process.stderr.write('No skills installed.\n');
+        return;
+    }
+
+    let selected: string[];
+    if (positionals.length > 0) {
+        selected = positionals.filter((s) => installed.includes(s));
+    } else if (flags.all === true) {
+        selected = installed;
+    } else {
+        selected = await promptSelect(installed, 'uninstall');
+    }
+
+    if (selected.length === 0) {
+        process.stderr.write('No skills selected.\n');
+        return;
+    }
+
+    for (const skill of selected) {
+        await rm(join(dest, skill), { recursive: true, force: true });
+        process.stderr.write(`  - ${skill}\n`);
+    }
+
+    process.stderr.write(`\nRemoved ${selected.length} skill(s) from ${dest}\n`);
+}
+
+async function handleList(flags: Record<string, string | boolean | string[]>): Promise<void> {
+    const dest = detectDestination(flags);
+    if (!dest) return;
+
+    const available = await getAvailableSkills();
+    if (available.length === 0) {
+        process.stderr.write('No bundled skills found.\n');
+        return;
+    }
+
+    process.stdout.write('Available skills:\n');
+    for (const skill of available) {
+        const installed = existsSync(join(dest, skill));
+        const marker = installed ? '  [installed]' : '';
+        process.stdout.write(`  ${skill}${marker}\n`);
+    }
+    process.stdout.write(`\nInstall path: ${dest}\n`);
+}

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -21,6 +21,7 @@ import { runRemove } from './commands/remove.js';
 import { runCompletion } from './commands/completion.js';
 import { runRun } from './commands/run.js';
 import { runProxy } from './commands/proxy.js';
+import { runSkills } from './commands/skills.js';
 import { ExitCode } from './exit-codes.js';
 
 interface ParsedArgs {
@@ -134,6 +135,15 @@ Watch:
   watch remove <provider>      Remove provider from watch list
   watch set-interval <dur>     Set default check interval
 
+Skills:
+  skills list                    List available skills and install status
+  skills install [skill...]      Install AI agent skills
+    --all                          Install all skills
+    --agent <name>                 Target: claude|cursor|windsurf|cline
+    --dest <path>                  Custom install path
+  skills uninstall [skill...]    Remove installed skills
+    --all                          Remove all skills
+
 Setup:
   init                         Create ~/.sig/config.yaml
     --remote                     Headless machine setup (mode: browserless)
@@ -184,6 +194,10 @@ export async function run(args: string[]): Promise<void> {
     }
     if (command === Command.COMPLETION) {
         await runCompletion(positionals, flags);
+        return;
+    }
+    if (command === Command.SKILLS) {
+        await runSkills(positionals, flags);
         return;
     }
 

--- a/cli/src/core/constants.ts
+++ b/cli/src/core/constants.ts
@@ -27,6 +27,7 @@ export const Command = {
     COMPLETION: 'completion',
     RUN: 'run',
     PROXY: 'proxy',
+    SKILLS: 'skills',
     HELP: 'help',
 } as const;
 
@@ -64,6 +65,15 @@ export const ProxySubcommand = {
     STOP: 'stop',
     STATUS: 'status',
     TRUST: 'trust',
+} as const;
+
+/**
+ * Subcommands for the 'skills' command.
+ */
+export const SkillsSubcommand = {
+    INSTALL: 'install',
+    UNINSTALL: 'uninstall',
+    LIST: 'list',
 } as const;
 
 /**

--- a/cli/tests/unit/core/constants.test.ts
+++ b/cli/tests/unit/core/constants.test.ts
@@ -38,11 +38,12 @@ describe('constants', () => {
             expect(Command.COMPLETION).toBe('completion');
             expect(Command.RUN).toBe('run');
             expect(Command.PROXY).toBe('proxy');
+            expect(Command.SKILLS).toBe('skills');
             expect(Command.HELP).toBe('help');
         });
 
         it('has exactly the expected number of commands', () => {
-            expect(Object.keys(Command)).toHaveLength(17);
+            expect(Object.keys(Command)).toHaveLength(18);
         });
 
         it('values are all lowercase strings', () => {

--- a/skills/README.md
+++ b/skills/README.md
@@ -2,7 +2,22 @@
 
 AI agent skills for authenticated access to web services via sigcli.
 
-## Install
+## Install Skills
+
+### sig CLI
+
+If you have `@sigcli/cli` installed (`npm install -g @sigcli/cli`):
+
+```bash
+sig skills install                     # Interactive install
+sig skills install --all               # Install all skills
+sig skills install outlook slack x     # Install specific skills
+sig skills install --agent cursor      # Target Cursor
+sig skills list                        # List available skills
+sig skills uninstall --all             # Uninstall all
+```
+
+### Shell script
 
 ```bash
 # Auto-detect your agent (Claude Code, Cursor, Windsurf, Cline)


### PR DESCRIPTION
## Summary
- Bundle AI agent skills with the CLI npm package at build time (`dist/skills/`)
- Add `sig skills install/uninstall/list` subcommands
- Auto-detect coding agent (Claude, Cursor, Windsurf, Cline) or specify via `--agent`/`--dest`
- Interactive skill selection on TTY, `--all` for non-interactive

## Usage
```bash
sig skills list                          # List available skills
sig skills install                       # Interactive install
sig skills install --all                 # Install all skills
sig skills install outlook slack x       # Install specific skills
sig skills install --agent cursor        # Target Cursor
sig skills uninstall --all               # Uninstall all
```

## Changes
- **New**: `cli/scripts/copy-skills.js` — build-time bundler
- **New**: `cli/src/cli/commands/skills.ts` — command implementation
- **Modified**: `cli/package.json` — added `copy-skills` script, updated `prepack`
- **Modified**: `cli/src/core/constants.ts` — `Command.SKILLS`, `SkillsSubcommand`
- **Modified**: `cli/src/cli/main.ts` — routing + help text
- **Modified**: `cli/src/cli/commands/completion.ts` — shell completions
- **Modified**: `cli/eslint.config.js` — node globals for `scripts/`

## Test plan
- [x] `pnpm --filter @sigcli/cli build` compiles
- [x] `node cli/scripts/copy-skills.js` bundles 13 skills
- [x] `sig skills list --dest /tmp/test` shows all skills
- [x] `sig skills install outlook slack --dest /tmp/test` installs correctly
- [x] `sig skills uninstall outlook --dest /tmp/test` removes correctly
- [x] `sig --help` shows Skills section