### PR TITLE
feat(skills): add @sigcli/skills package for npx installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
                 options:
                     - '@sigcli/cli'
                     - '@sigcli/sdk'
+                    - '@sigcli/skills'
             release_type:
                 description: Release type
                 required: true
@@ -53,15 +54,24 @@ jobs:
                     echo "dir=cli" >> "$GITHUB_OUTPUT"
                   elif [ "${{ inputs.package }}" = "@sigcli/sdk" ]; then
                     echo "dir=sdk/typescript" >> "$GITHUB_OUTPUT"
+                  elif [ "${{ inputs.package }}" = "@sigcli/skills" ]; then
+                    echo "dir=packages/skills" >> "$GITHUB_OUTPUT"
                   fi
 
             - name: Type check
+              if: inputs.package != '@sigcli/skills'
               run: pnpm --filter '${{ inputs.package }}' exec tsc --noEmit
 
             - name: Build
+              if: inputs.package != '@sigcli/skills'
               run: pnpm --filter '${{ inputs.package }}' build
 
+            - name: Bundle skills
+              if: inputs.package == '@sigcli/skills'
+              run: node packages/skills/scripts/bundle-skills.js
+
             - name: Run tests
+              if: inputs.package != '@sigcli/skills'
               run: pnpm --filter '${{ inputs.package }}' test
 
             - name: Publish beta

--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ in your browser         -->   credentials locally          -->  on your behalf
 
 Pre-built Python scripts that let AI agents operate 14+ web services — email, chat, forums, video platforms, social networks, and more. Each skill includes scripts + documentation that agents read and execute autonomously.
 
+Install skills to your coding agent (Claude Code, Cursor, Windsurf, Cline):
+
 ```bash
-git clone https://github.com/sigcli/sigcli.git
-cd sigcli/skills && ./install.sh
+npx @sigcli/skills            # npx one-liner (recommended)
+sig skills install --all      # or via sig CLI if already installed
 ```
 
 See the [full skills catalog](skills/README.md) for details.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ Pre-built Python scripts that let AI agents operate 14+ web services — email, 
 Install skills to your coding agent (Claude Code, Cursor, Windsurf, Cline):
 
 ```bash
-npx @sigcli/skills            # npx one-liner (recommended)
-sig skills install --all      # or via sig CLI if already installed
+npx @sigcli/skills            # install skills to your coding agent
 ```
 
 See the [full skills catalog](skills/README.md) for details.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -104,9 +104,9 @@ export default tseslint.config(
         },
     },
 
-    // Node.js globals for bin/ scripts
+    // Node.js globals for bin/ and scripts/
     {
-        files: ['cli/bin/**/*.js'],
+        files: ['cli/bin/**/*.js', 'cli/scripts/**/*.js', 'packages/skills/**/*.js'],
         languageOptions: {
             globals: {
                 console: 'readonly',
@@ -118,7 +118,14 @@ export default tseslint.config(
 
     // Plain JS and config files — disable type-checked rules
     {
-        files: ['cli/bin/**/*.js', '**/*.config.ts', '**/*.config.js', 'eslint.config.js'],
+        files: [
+            'cli/bin/**/*.js',
+            'cli/scripts/**/*.js',
+            'packages/skills/**/*.js',
+            '**/*.config.ts',
+            '**/*.config.js',
+            'eslint.config.js',
+        ],
         ...tseslint.configs.disableTypeChecked,
     },
 

--- a/packages/skills/.gitignore
+++ b/packages/skills/.gitignore
@@ -1,0 +1,2 @@
+data/
+node_modules/

--- a/packages/skills/bin/install.js
+++ b/packages/skills/bin/install.js
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+import { existsSync } from 'node:fs';
+import { readdir, rm, mkdir, cp } from 'node:fs/promises';
+import { join, dirname, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { homedir } from 'node:os';
+import { createInterface } from 'node:readline';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const DATA_DIR = join(__dirname, '../data');
+
+const HELP = `@sigcli/skills — Install AI agent skills for authenticated web access
+
+Usage: npx @sigcli/skills [options] [skill...]
+
+Options:
+  --agent <name>     Target: claude, cursor, windsurf, cline (auto-detected)
+  --dest <path>      Custom install path
+  --all              Install/uninstall all skills
+  --list             List available skills and install status
+  --uninstall        Remove installed skills
+  --help, -h         Show this help
+
+Examples:
+  npx @sigcli/skills                     # Interactive install
+  npx @sigcli/skills --all               # Install all skills
+  npx @sigcli/skills outlook slack x     # Install specific skills
+  npx @sigcli/skills --agent cursor      # Target Cursor
+  npx @sigcli/skills --list              # List skills
+  npx @sigcli/skills --uninstall         # Uninstall
+`;
+
+function parseArgs(args) {
+    const flags = {};
+    const positionals = [];
+    let i = 0;
+    while (i < args.length) {
+        const arg = args[i];
+        if (arg === '--help' || arg === '-h') {
+            flags.help = true;
+            i++;
+        } else if (arg === '--all') {
+            flags.all = true;
+            i++;
+        } else if (arg === '--list') {
+            flags.list = true;
+            i++;
+        } else if (arg === '--uninstall') {
+            flags.uninstall = true;
+            i++;
+        } else if (arg === '--agent' && args[i + 1]) {
+            flags.agent = args[i + 1];
+            i += 2;
+        } else if (arg === '--dest' && args[i + 1]) {
+            flags.dest = args[i + 1];
+            i += 2;
+        } else if (arg.startsWith('--')) {
+            i++;
+        } else {
+            positionals.push(arg);
+            i++;
+        }
+    }
+    return { flags, positionals };
+}
+
+function detectDestination(flags) {
+    if (flags.dest) return flags.dest;
+
+    const agentMap = {
+        claude: join(homedir(), '.claude', 'skills'),
+        cursor: join(homedir(), '.cursor', 'skills'),
+        windsurf: join(homedir(), '.windsurf', 'skills'),
+        cline: join(homedir(), '.cline', 'skills'),
+    };
+
+    if (flags.agent) {
+        const dest = agentMap[flags.agent];
+        if (!dest) {
+            process.stderr.write(
+                `Unknown agent: ${flags.agent}. Use: claude, cursor, windsurf, cline\n`,
+            );
+            process.exit(1);
+        }
+        return dest;
+    }
+
+    // Auto-detect
+    for (const [agent, dest] of Object.entries(agentMap)) {
+        if (existsSync(join(homedir(), `.${agent}`))) {
+            process.stderr.write(`Auto-detected: ${agent}\n`);
+            return dest;
+        }
+    }
+
+    return agentMap.claude;
+}
+
+async function getAvailableSkills() {
+    if (!existsSync(DATA_DIR)) return [];
+    const entries = await readdir(DATA_DIR, { withFileTypes: true });
+    return entries
+        .filter((e) => e.isDirectory() && existsSync(join(DATA_DIR, e.name, 'SKILL.md')))
+        .map((e) => e.name)
+        .sort();
+}
+
+async function promptSelect(skills, action) {
+    if (!process.stdin.isTTY) return skills;
+
+    process.stderr.write(`\nAvailable skills (${action}):\n`);
+    skills.forEach((s, i) => process.stderr.write(`  ${i + 1}) ${s}\n`));
+
+    const rl = createInterface({ input: process.stdin, output: process.stderr });
+    const answer = await new Promise((resolve) =>
+        rl.question(`\nEnter numbers (e.g. 1,3,5) or 'a' for all: `, resolve),
+    );
+    rl.close();
+
+    if (answer.trim().toLowerCase() === 'a' || answer.trim() === '') return skills;
+
+    const selected = [];
+    for (const num of answer.split(/[,\s]+/)) {
+        const idx = parseInt(num, 10) - 1;
+        if (idx >= 0 && idx < skills.length) selected.push(skills[idx]);
+    }
+    return selected;
+}
+
+async function handleInstall(positionals, flags) {
+    const dest = detectDestination(flags);
+    const available = await getAvailableSkills();
+
+    if (available.length === 0) {
+        process.stderr.write('No bundled skills found.\n');
+        process.exit(1);
+    }
+
+    let selected;
+    if (positionals.length > 0) {
+        selected = positionals.filter((s) => {
+            if (!available.includes(s)) {
+                process.stderr.write(`  ! unknown skill: ${s}\n`);
+                return false;
+            }
+            return true;
+        });
+    } else if (flags.all) {
+        selected = available;
+    } else {
+        selected = await promptSelect(available, 'install');
+    }
+
+    if (selected.length === 0) {
+        process.stderr.write('No skills selected.\n');
+        return;
+    }
+
+    await mkdir(dest, { recursive: true });
+
+    for (const skill of selected) {
+        const src = join(DATA_DIR, skill);
+        const target = join(dest, skill);
+        await rm(target, { recursive: true, force: true });
+        await cp(src, target, {
+            recursive: true,
+            filter: (source) => {
+                const b = basename(source);
+                return b !== 'tests' && b !== '__pycache__' && !b.endsWith('.pyc');
+            },
+        });
+        process.stderr.write(`  + ${skill}\n`);
+    }
+
+    process.stderr.write(`\nInstalled ${selected.length} skill(s) to ${dest}\n`);
+}
+
+async function handleUninstall(positionals, flags) {
+    const dest = detectDestination(flags);
+
+    if (!existsSync(dest)) {
+        process.stderr.write(`No skills installed at ${dest}\n`);
+        return;
+    }
+
+    const available = await getAvailableSkills();
+    const entries = await readdir(dest, { withFileTypes: true });
+    const installed = entries
+        .filter((e) => e.isDirectory() && available.includes(e.name))
+        .map((e) => e.name)
+        .sort();
+
+    if (installed.length === 0) {
+        process.stderr.write('No skills installed.\n');
+        return;
+    }
+
+    let selected;
+    if (positionals.length > 0) {
+        selected = positionals.filter((s) => installed.includes(s));
+    } else if (flags.all) {
+        selected = installed;
+    } else {
+        selected = await promptSelect(installed, 'uninstall');
+    }
+
+    if (selected.length === 0) {
+        process.stderr.write('No skills selected.\n');
+        return;
+    }
+
+    for (const skill of selected) {
+        await rm(join(dest, skill), { recursive: true, force: true });
+        process.stderr.write(`  - ${skill}\n`);
+    }
+
+    process.stderr.write(`\nRemoved ${selected.length} skill(s) from ${dest}\n`);
+}
+
+async function handleList(flags) {
+    const dest = detectDestination(flags);
+    const available = await getAvailableSkills();
+
+    if (available.length === 0) {
+        process.stderr.write('No bundled skills found.\n');
+        return;
+    }
+
+    process.stdout.write('Available skills:\n');
+    for (const skill of available) {
+        const installed = existsSync(join(dest, skill));
+        const marker = installed ? '  [installed]' : '';
+        process.stdout.write(`  ${skill}${marker}\n`);
+    }
+    process.stdout.write(`\nInstall path: ${dest}\n`);
+}
+
+// Main
+const { flags, positionals } = parseArgs(process.argv.slice(2));
+
+if (flags.help) {
+    process.stdout.write(HELP);
+} else if (flags.list) {
+    await handleList(flags);
+} else if (flags.uninstall) {
+    await handleUninstall(positionals, flags);
+} else {
+    await handleInstall(positionals, flags);
+}

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,0 +1,38 @@
+{
+    "name": "@sigcli/skills",
+    "version": "1.0.0",
+    "description": "AI agent skills for authenticated web access via sigcli",
+    "type": "module",
+    "bin": {
+        "sigcli-skills": "./bin/install.js"
+    },
+    "files": [
+        "bin/",
+        "data/"
+    ],
+    "scripts": {
+        "prepack": "node scripts/bundle-skills.js"
+    },
+    "keywords": [
+        "sigcli",
+        "skills",
+        "ai",
+        "agent",
+        "claude",
+        "cursor"
+    ],
+    "author": "pylon <pylon.peng@gmail.com>",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/sigcli/sigcli.git",
+        "directory": "packages/skills"
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "publishConfig": {
+        "registry": "https://registry.npmjs.org/",
+        "access": "public"
+    }
+}

--- a/packages/skills/scripts/bundle-skills.js
+++ b/packages/skills/scripts/bundle-skills.js
@@ -1,0 +1,33 @@
+import { readdirSync, statSync, mkdirSync, cpSync, existsSync, rmSync } from 'node:fs';
+import { join, dirname, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SKILLS_SRC = join(__dirname, '../../../skills');
+const SKILLS_DEST = join(__dirname, '../data');
+
+const EXCLUDE_DIRS = new Set(['tests', '__pycache__', 'node_modules']);
+
+// Discover skills: directories containing SKILL.md
+const skills = readdirSync(SKILLS_SRC).filter((name) => {
+    const p = join(SKILLS_SRC, name);
+    return statSync(p).isDirectory() && existsSync(join(p, 'SKILL.md'));
+});
+
+// Clean and recreate dest
+if (existsSync(SKILLS_DEST)) rmSync(SKILLS_DEST, { recursive: true });
+mkdirSync(SKILLS_DEST, { recursive: true });
+
+for (const skill of skills) {
+    cpSync(join(SKILLS_SRC, skill), join(SKILLS_DEST, skill), {
+        recursive: true,
+        filter: (src) => {
+            const b = basename(src);
+            return !EXCLUDE_DIRS.has(b) && !b.endsWith('.pyc');
+        },
+    });
+    process.stderr.write(`  + ${skill}\n`);
+}
+
+process.stderr.write(`\nBundled ${skills.length} skills to ${SKILLS_DEST}\n`);

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
     - cli
     - sdk/typescript
+    - packages/skills
     - website

--- a/skills/README.md
+++ b/skills/README.md
@@ -4,6 +4,31 @@ AI agent skills for authenticated access to web services via sigcli.
 
 ## Install
 
+### npx (recommended)
+
+```bash
+npx @sigcli/skills                     # Interactive install
+npx @sigcli/skills --all               # Install all skills
+npx @sigcli/skills outlook slack x     # Install specific skills
+npx @sigcli/skills --agent cursor      # Target Cursor
+npx @sigcli/skills --list              # List available skills
+npx @sigcli/skills --uninstall         # Uninstall
+```
+
+### sig CLI
+
+If you have `@sigcli/cli` installed:
+
+```bash
+sig skills install                     # Interactive install
+sig skills install --all               # Install all skills
+sig skills install outlook slack x     # Install specific skills
+sig skills list                        # List available skills
+sig skills uninstall --all             # Uninstall
+```
+
+### Shell script
+
 ```bash
 # Auto-detect your agent (Claude Code, Cursor, Windsurf, Cline)
 ./install.sh

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,7 +6,7 @@ AI agent skills for authenticated access to web services via sigcli.
 
 Install skills to your coding agent (Claude Code, Cursor, Windsurf, Cline):
 
-### npx (recommended)
+### npx
 
 ```bash
 npx @sigcli/skills                     # Interactive install
@@ -15,18 +15,6 @@ npx @sigcli/skills outlook slack x     # Install specific skills
 npx @sigcli/skills --agent cursor      # Target Cursor
 npx @sigcli/skills --list              # List available skills
 npx @sigcli/skills --uninstall         # Uninstall
-```
-
-### sig CLI
-
-If you have `@sigcli/cli` installed:
-
-```bash
-sig skills install                     # Interactive install
-sig skills install --all               # Install all skills
-sig skills install outlook slack x     # Install specific skills
-sig skills list                        # List available skills
-sig skills uninstall --all             # Uninstall
 ```
 
 ### Shell script

--- a/skills/README.md
+++ b/skills/README.md
@@ -2,7 +2,9 @@
 
 AI agent skills for authenticated access to web services via sigcli.
 
-## Install
+## Install Skills
+
+Install skills to your coding agent (Claude Code, Cursor, Windsurf, Cline):
 
 ### npx (recommended)
 


### PR DESCRIPTION
## Summary
- Create standalone `@sigcli/skills` npm package at `packages/skills/`
- Enables `npx @sigcli/skills` one-liner installation for AI agent skills
- Same agent auto-detection, interactive selection, install/uninstall as the CLI command
- Add to release workflow for automated publishing

## Usage
```bash
npx @sigcli/skills                     # Interactive install
npx @sigcli/skills --all               # Install all skills
npx @sigcli/skills outlook slack x     # Install specific skills
npx @sigcli/skills --agent cursor      # Target Cursor
npx @sigcli/skills --list              # List skills
npx @sigcli/skills --uninstall         # Uninstall
```

## Changes
- **New**: `packages/skills/package.json` — package config
- **New**: `packages/skills/bin/install.js` — CLI entry point
- **New**: `packages/skills/scripts/bundle-skills.js` — build-time skill bundler
- **New**: `packages/skills/.gitignore` — ignore `data/`
- **Modified**: `pnpm-workspace.yaml` — add workspace member
- **Modified**: `.github/workflows/release.yml` — add `@sigcli/skills` option
- **Modified**: `eslint.config.js` — node globals for `packages/skills/`

## Test plan
- [x] `node packages/skills/scripts/bundle-skills.js` bundles 13 skills
- [x] `node packages/skills/bin/install.js --help` shows usage
- [x] `node packages/skills/bin/install.js --list --dest /tmp/test` lists skills
- [x] `node packages/skills/bin/install.js --dest /tmp/test outlook x` installs correctly