### PR TITLE
chore(cli): bump version to 1.2.3

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sigcli/cli",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "description": "General-purpose authentication CLI with pluggable strategies and browser adapters",
     "main": "dist/index.js",
     "type": "module",


### PR DESCRIPTION
## Summary

- Bumps @sigcli/cli version from 1.2.2 to 1.2.3 for release

## Test plan

- [ ] `pnpm --filter @sigcli/cli build` passes
- [ ] `pnpm --filter @sigcli/cli test` passes