### PR TITLE
chore(skills): bump version to 1.0.1

### DIFF
--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sigcli/skills",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "AI agent skills for authenticated web access via sigcli",
     "type": "module",
     "bin": {


### PR DESCRIPTION
## Summary

- Bumps @sigcli/skills from 1.0.0 to 1.0.1
- 1.0.0 accidentally included xiaohongshu (reverted in #72) — this release ships without it

## Test plan

- [x] `node packages/skills/scripts/bundle-skills.js` bundles without xiaohongshu
- [x] Trigger stable release after merge