### PR TITLE
feat(browser): support network proxy for browser launch

### DIFF
--- a/cli/config/config.example.yaml
+++ b/cli/config/config.example.yaml
@@ -50,7 +50,7 @@ providers:
     #   strategy: cookie
     #   config:
     #     ttl: "12h"
-    #   networkProxy: socks5h://127.0.0.1:1080  # route browser through a SOCKS5 proxy
+    #   networkProxy: socks5://127.0.0.1:1080  # route browser through a SOCKS5 proxy
 
     # Cookie auth with path-scoped cookies (e.g. Confluence sets cookies on /wiki)
     # my-wiki:

--- a/cli/config/config.example.yaml
+++ b/cli/config/config.example.yaml
@@ -50,6 +50,7 @@ providers:
     #   strategy: cookie
     #   config:
     #     ttl: "12h"
+    #   networkProxy: socks5h://127.0.0.1:1080  # route browser through a SOCKS5 proxy
 
     # Cookie auth with path-scoped cookies (e.g. Confluence sets cookies on /wiki)
     # my-wiki:

--- a/cli/src/auth-manager.ts
+++ b/cli/src/auth-manager.ts
@@ -54,7 +54,10 @@ export class AuthManager {
      * Get valid credentials for a provider.
      * Tries: stored → refresh → authenticate, in that order.
      */
-    async getCredentials(providerId: string): Promise<Result<Credential, AuthError>> {
+    async getCredentials(
+        providerId: string,
+        options?: { networkProxy?: string },
+    ): Promise<Result<Credential, AuthError>> {
         const provider = this.providers.get(providerId);
         if (!provider) return err(new ProviderNotFoundError(providerId));
 
@@ -91,10 +94,12 @@ export class AuthManager {
 
         // Step 3: Full authentication
         this.logger?.info(`Authenticating with "${providerId}"...`);
+        const resolvedProxy = options?.networkProxy ?? provider.networkProxy;
         const context: AuthContext = {
             browserAdapter: this.browserAdapterFactory(),
             browserConfig: this.browserConfig,
             logger: this.logger,
+            ...(resolvedProxy !== undefined ? { networkProxy: resolvedProxy } : {}),
         };
 
         const authResult = await strategy.authenticate(provider, context);
@@ -149,12 +154,15 @@ export class AuthManager {
     /**
      * Force re-authentication, deleting any stored credentials first.
      */
-    async forceReauth(providerId: string): Promise<Result<Credential, AuthError>> {
+    async forceReauth(
+        providerId: string,
+        options?: { networkProxy?: string },
+    ): Promise<Result<Credential, AuthError>> {
         const provider = this.providers.get(providerId);
         if (provider) {
             await this.storage.delete(this.storageKey(provider));
         }
-        return this.getCredentials(providerId);
+        return this.getCredentials(providerId, options);
     }
 
     /**

--- a/cli/src/browser/flows/hybrid-flow.ts
+++ b/cli/src/browser/flows/hybrid-flow.ts
@@ -52,6 +52,8 @@ export interface HybridFlowOptions {
     localStorage?: LocalStorageConfig[];
     /** Logger for flow progress messages */
     logger: ILogger;
+    /** Network proxy for the browser, e.g. "socks5h://127.0.0.1:1080" */
+    networkProxy?: string;
 }
 
 /**
@@ -120,10 +122,18 @@ async function attemptAuth<T>(
     const logger = options.logger;
 
     try {
+        const args: string[] = [];
+        if (options.networkProxy) {
+            args.push(`--proxy-server=${options.networkProxy}`);
+        }
+        if (options.browserArgs) {
+            args.push(...options.browserArgs);
+        }
+
         const launchOptions: BrowserLaunchOptions = {
             headless: options.headless,
             timeout: options.timeout,
-            args: options.browserArgs,
+            args: args.length > 0 ? args : undefined,
         };
 
         session = await adapter.launch(launchOptions);

--- a/cli/src/browser/flows/hybrid-flow.ts
+++ b/cli/src/browser/flows/hybrid-flow.ts
@@ -52,7 +52,7 @@ export interface HybridFlowOptions {
     localStorage?: LocalStorageConfig[];
     /** Logger for flow progress messages */
     logger: ILogger;
-    /** Network proxy for the browser, e.g. "socks5h://127.0.0.1:1080" */
+    /** Network proxy for the browser, e.g. "socks5://127.0.0.1:1080" */
     networkProxy?: string;
 }
 

--- a/cli/src/cli/commands/login.ts
+++ b/cli/src/cli/commands/login.ts
@@ -38,6 +38,7 @@ function toProviderEntry(pc: ProviderConfig): ProviderEntry {
         ...(pc.localStorage ? { localStorage: pc.localStorage } : {}),
         ...(pc.forceVisible !== undefined ? { forceVisible: pc.forceVisible } : {}),
         ...(pc.proxy ? { proxy: pc.proxy } : {}),
+        ...(pc.networkProxy ? { networkProxy: pc.networkProxy } : {}),
     };
 }
 
@@ -89,6 +90,14 @@ export async function runLogin(
 
     const hasOverrides = flags.strategy !== undefined || typeof flags.as === 'string';
     const provider = hasOverrides ? { ...baseProvider } : baseProvider;
+
+    const networkProxy =
+        typeof flags['network-proxy'] === 'string' ? flags['network-proxy'] : undefined;
+
+    // Apply networkProxy to auto-provisioned providers so it persists in config
+    if (networkProxy !== undefined && provider.autoProvisioned) {
+        provider.networkProxy = networkProxy;
+    }
 
     // --as <id>: override the provider ID (useful for auto-provisioned providers)
     if (typeof flags.as === 'string') {
@@ -326,7 +335,10 @@ export async function runLogin(
 
     process.stderr.write(`  [3/3] Opening browser...\n`);
     process.stderr.write(`Authenticating with "${provider.name}" via browser...\n`);
-    const result = await deps.authManager.forceReauth(provider.id);
+    const result = await deps.authManager.forceReauth(
+        provider.id,
+        networkProxy !== undefined ? { networkProxy } : undefined,
+    );
     if (!isOk(result)) {
         await logAuditEvent({
             action: AuditAction.LOGIN,

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -85,7 +85,7 @@ Authentication:
     --username <u> --password <p>  Basic auth (no browser)
     --strategy <name>            Force strategy (cookie|oauth2|api-token|basic)
     --force                      Skip stored/refresh check, go straight to browser
-    --network-proxy <url>        Browser network proxy (e.g. socks5h://127.0.0.1:1080)
+    --network-proxy <url>        Browser network proxy (e.g. socks5://127.0.0.1:1080)
   logout [provider]            Clear credentials (all if none specified)
 
 Credentials (most → least secure):

--- a/cli/src/cli/main.ts
+++ b/cli/src/cli/main.ts
@@ -85,6 +85,7 @@ Authentication:
     --username <u> --password <p>  Basic auth (no browser)
     --strategy <name>            Force strategy (cookie|oauth2|api-token|basic)
     --force                      Skip stored/refresh check, go straight to browser
+    --network-proxy <url>        Browser network proxy (e.g. socks5h://127.0.0.1:1080)
   logout [provider]            Clear credentials (all if none specified)
 
 Credentials (most → least secure):

--- a/cli/src/config/schema.ts
+++ b/cli/src/config/schema.ts
@@ -95,4 +95,5 @@ export interface ProviderEntry {
     localStorage?: LocalStorageConfig[];
     forceVisible?: boolean;
     proxy?: ProxyConfig;
+    networkProxy?: string; // e.g. "socks5h://127.0.0.1:1080"
 }

--- a/cli/src/config/schema.ts
+++ b/cli/src/config/schema.ts
@@ -95,5 +95,5 @@ export interface ProviderEntry {
     localStorage?: LocalStorageConfig[];
     forceVisible?: boolean;
     proxy?: ProxyConfig;
-    networkProxy?: string; // e.g. "socks5h://127.0.0.1:1080"
+    networkProxy?: string; // e.g. "socks5://127.0.0.1:1080"
 }

--- a/cli/src/config/validator.ts
+++ b/cli/src/config/validator.ts
@@ -459,5 +459,6 @@ function parseProviderEntry(raw: Record<string, unknown>): ProviderEntry {
                   },
               }
             : {}),
+        ...(typeof raw.networkProxy === 'string' ? { networkProxy: raw.networkProxy } : {}),
     };
 }

--- a/cli/src/core/interfaces/auth-strategy.ts
+++ b/cli/src/core/interfaces/auth-strategy.ts
@@ -14,6 +14,7 @@ export interface AuthContext {
     browserAdapter: IBrowserAdapter;
     browserConfig: BrowserConfig;
     logger?: ILogger;
+    networkProxy?: string; // e.g. "socks5h://127.0.0.1:1080"
 }
 
 /**

--- a/cli/src/core/interfaces/auth-strategy.ts
+++ b/cli/src/core/interfaces/auth-strategy.ts
@@ -14,7 +14,7 @@ export interface AuthContext {
     browserAdapter: IBrowserAdapter;
     browserConfig: BrowserConfig;
     logger?: ILogger;
-    networkProxy?: string; // e.g. "socks5h://127.0.0.1:1080"
+    networkProxy?: string; // e.g. "socks5://127.0.0.1:1080"
 }
 
 /**

--- a/cli/src/core/types.ts
+++ b/cli/src/core/types.ts
@@ -150,6 +150,7 @@ export interface ProviderConfig {
     autoProvisioned?: boolean; // True if created by auto-provision (not from config file)
     forceVisible?: boolean; // Skip headless, go straight to visible browser mode
     proxy?: ProxyConfig; // MITM proxy injection rules
+    networkProxy?: string; // Browser network proxy, e.g. "socks5h://127.0.0.1:1080"
 }
 
 // ============================================================================

--- a/cli/src/core/types.ts
+++ b/cli/src/core/types.ts
@@ -150,7 +150,7 @@ export interface ProviderConfig {
     autoProvisioned?: boolean; // True if created by auto-provision (not from config file)
     forceVisible?: boolean; // Skip headless, go straight to visible browser mode
     proxy?: ProxyConfig; // MITM proxy injection rules
-    networkProxy?: string; // Browser network proxy, e.g. "socks5h://127.0.0.1:1080"
+    networkProxy?: string; // Browser network proxy, e.g. "socks5://127.0.0.1:1080"
 }
 
 // ============================================================================

--- a/cli/src/deps.ts
+++ b/cli/src/deps.ts
@@ -79,6 +79,7 @@ export async function createAuthDeps(
             localStorage: entry.localStorage,
             ...(entry.forceVisible !== undefined ? { forceVisible: entry.forceVisible } : {}),
             ...(entry.proxy !== undefined ? { proxy: entry.proxy } : {}),
+            ...(entry.networkProxy !== undefined ? { networkProxy: entry.networkProxy } : {}),
         }),
     );
 

--- a/cli/src/strategies/cookie.strategy.ts
+++ b/cli/src/strategies/cookie.strategy.ts
@@ -96,6 +96,7 @@ class CookieStrategy implements IAuthStrategy {
             providerDomains: provider.domains,
             localStorage: provider.localStorage,
             logger: context.logger ?? stderrLogger,
+            ...(context.networkProxy !== undefined ? { networkProxy: context.networkProxy } : {}),
 
             isAuthenticated: async (page) => {
                 // If requiredCookies is set, auth is complete only when those cookies exist

--- a/cli/src/strategies/oauth2.strategy.ts
+++ b/cli/src/strategies/oauth2.strategy.ts
@@ -74,6 +74,7 @@ class OAuth2Strategy implements IAuthStrategy {
             providerDomains: provider.domains,
             localStorage: provider.localStorage,
             logger: context.logger ?? stderrLogger,
+            ...(context.networkProxy !== undefined ? { networkProxy: context.networkProxy } : {}),
 
             isAuthenticated: async (page) => {
                 const onLogin = await isLoginPage(page);

--- a/cli/tests/unit/cli/login-network-proxy.test.ts
+++ b/cli/tests/unit/cli/login-network-proxy.test.ts
@@ -102,7 +102,7 @@ describe('runLogin --network-proxy', () => {
             // Use --cookie to avoid browser launch, --network-proxy to set proxy
             await runLogin(
                 ['https://blocked-site.example.com/'],
-                { 'network-proxy': 'socks5h://127.0.0.1:1080', cookie: 'session=abc123' },
+                { 'network-proxy': 'socks5://127.0.0.1:1080', cookie: 'session=abc123' },
                 deps,
             );
 
@@ -112,7 +112,7 @@ describe('runLogin --network-proxy', () => {
             expect(addProviderToConfig).toHaveBeenCalledTimes(1);
             const [id, entry] = addProviderToConfig.mock.calls[0];
             expect(id).toBe('blocked-site');
-            expect(entry.networkProxy).toBe('socks5h://127.0.0.1:1080');
+            expect(entry.networkProxy).toBe('socks5://127.0.0.1:1080');
         });
 
         it('includes networkProxy alongside other provider fields', async () => {
@@ -147,7 +147,7 @@ describe('runLogin --network-proxy', () => {
 
             await runLogin(
                 ['jira'],
-                { 'network-proxy': 'socks5h://127.0.0.1:1080', token: 'my-token' },
+                { 'network-proxy': 'socks5://127.0.0.1:1080', token: 'my-token' },
                 deps,
             );
 
@@ -169,7 +169,7 @@ describe('runLogin --network-proxy', () => {
 
             await runLogin(
                 ['github'],
-                { 'network-proxy': 'socks5h://127.0.0.1:7890', token: 'ghp_abc' },
+                { 'network-proxy': 'socks5://127.0.0.1:7890', token: 'ghp_abc' },
                 deps,
             );
 

--- a/cli/tests/unit/cli/login-network-proxy.test.ts
+++ b/cli/tests/unit/cli/login-network-proxy.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AuthManager } from '../../../src/auth-manager.js';
+import { MemoryStorage } from '../../../src/storage/memory-storage.js';
+import { ProviderRegistry } from '../../../src/providers/provider-registry.js';
+import { StrategyRegistry } from '../../../src/strategies/registry.js';
+import { CookieStrategyFactory } from '../../../src/strategies/cookie.strategy.js';
+import { ApiTokenStrategyFactory } from '../../../src/strategies/api-token.strategy.js';
+import { runLogin } from '../../../src/cli/commands/login.js';
+import type { AuthDeps } from '../../../src/deps.js';
+import type { ProviderConfig } from '../../../src/core/types.js';
+import type { IBrowserAdapter } from '../../../src/core/interfaces/browser-adapter.js';
+import type { BrowserConfig, SigConfig } from '../../../src/config/schema.js';
+
+const addProviderToConfig = vi.fn(async () => {});
+
+vi.mock('../../../src/config/loader.js', () => ({
+    addProviderToConfig: (...args: unknown[]) => addProviderToConfig(...args),
+    removeProviderFromConfig: vi.fn(async () => {}),
+    loadConfig: vi.fn(),
+    getConfigPath: vi.fn(() => '/tmp/test-config.yaml'),
+    saveConfig: vi.fn(),
+}));
+
+const browserConfig: BrowserConfig = {
+    browserDataDir: '/tmp/test-browser-data',
+    channel: 'chrome',
+    headlessTimeout: 30_000,
+    visibleTimeout: 120_000,
+    waitUntil: 'load',
+};
+
+function createDeps(providers?: ProviderConfig[]): {
+    deps: AuthDeps;
+    storage: MemoryStorage;
+    providerRegistry: ProviderRegistry;
+} {
+    const storage = new MemoryStorage();
+    const strategyRegistry = new StrategyRegistry();
+    strategyRegistry.register(new CookieStrategyFactory());
+    strategyRegistry.register(new ApiTokenStrategyFactory());
+
+    const providerRegistry = new ProviderRegistry(providers ?? []);
+
+    const authManager = new AuthManager({
+        storage,
+        strategyRegistry,
+        providerRegistry,
+        browserAdapterFactory: () => ({}) as IBrowserAdapter,
+        browserConfig,
+    });
+
+    const config: SigConfig = {
+        browser: browserConfig,
+        storage: { credentialsDir: '/tmp/test-credentials' },
+        providers: {},
+    };
+
+    const deps: AuthDeps = {
+        authManager,
+        storage,
+        providerRegistry,
+        strategyRegistry,
+        config,
+        browserAvailable: true,
+    };
+
+    return { deps, storage, providerRegistry };
+}
+
+describe('runLogin --network-proxy', () => {
+    let stderrChunks: string[];
+    let stdoutChunks: string[];
+    let originalExitCode: number | undefined;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        stderrChunks = [];
+        stdoutChunks = [];
+        originalExitCode = process.exitCode;
+        process.exitCode = undefined;
+
+        vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+            stderrChunks.push(String(chunk));
+            return true;
+        });
+
+        vi.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+            stdoutChunks.push(String(chunk));
+            return true;
+        });
+    });
+
+    afterEach(() => {
+        process.exitCode = originalExitCode;
+        vi.restoreAllMocks();
+    });
+
+    describe('auto-provisioned provider', () => {
+        it('persists networkProxy in config when provider is auto-provisioned', async () => {
+            const { deps } = createDeps();
+
+            // Use --cookie to avoid browser launch, --network-proxy to set proxy
+            await runLogin(
+                ['https://blocked-site.example.com/'],
+                { 'network-proxy': 'socks5h://127.0.0.1:1080', cookie: 'session=abc123' },
+                deps,
+            );
+
+            expect(process.exitCode).not.toBe(1);
+
+            // addProviderToConfig should have been called with networkProxy in the entry
+            expect(addProviderToConfig).toHaveBeenCalledTimes(1);
+            const [id, entry] = addProviderToConfig.mock.calls[0];
+            expect(id).toBe('blocked-site');
+            expect(entry.networkProxy).toBe('socks5h://127.0.0.1:1080');
+        });
+
+        it('includes networkProxy alongside other provider fields', async () => {
+            const { deps } = createDeps();
+
+            await runLogin(
+                ['https://jira.corp.example.com/browse/PROJ-1'],
+                { 'network-proxy': 'http://proxy.corp.com:8080', cookie: 'sid=xyz' },
+                deps,
+            );
+
+            expect(process.exitCode).not.toBe(1);
+            expect(addProviderToConfig).toHaveBeenCalledTimes(1);
+            const [, entry] = addProviderToConfig.mock.calls[0];
+            expect(entry.networkProxy).toBe('http://proxy.corp.com:8080');
+            expect(entry.strategy).toBe('cookie');
+            expect(entry.domains).toContain('jira.corp.example.com');
+        });
+    });
+
+    describe('existing provider', () => {
+        it('does NOT persist networkProxy when provider already exists', async () => {
+            const existingProvider: ProviderConfig = {
+                id: 'jira',
+                name: 'Jira',
+                domains: ['jira.example.com'],
+                entryUrl: 'https://jira.example.com/',
+                strategy: 'api-token',
+                strategyConfig: { strategy: 'api-token' },
+            };
+            const { deps } = createDeps([existingProvider]);
+
+            await runLogin(
+                ['jira'],
+                { 'network-proxy': 'socks5h://127.0.0.1:1080', token: 'my-token' },
+                deps,
+            );
+
+            expect(process.exitCode).not.toBe(1);
+            // Should NOT call addProviderToConfig (provider already exists, not auto-provisioned)
+            expect(addProviderToConfig).not.toHaveBeenCalled();
+        });
+
+        it('applies proxy for this login session (existing provider uses token path)', async () => {
+            const existingProvider: ProviderConfig = {
+                id: 'github',
+                name: 'GitHub',
+                domains: ['github.com', 'api.github.com'],
+                entryUrl: 'https://github.com/',
+                strategy: 'api-token',
+                strategyConfig: { strategy: 'api-token' },
+            };
+            const { deps, storage } = createDeps([existingProvider]);
+
+            await runLogin(
+                ['github'],
+                { 'network-proxy': 'socks5h://127.0.0.1:7890', token: 'ghp_abc' },
+                deps,
+            );
+
+            expect(process.exitCode).not.toBe(1);
+
+            // Token still stored successfully
+            const stored = await storage.get('github');
+            expect(stored).not.toBeNull();
+            expect(stored!.credential.type).toBe('api-key');
+
+            // Proxy NOT persisted
+            expect(addProviderToConfig).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('without --network-proxy flag', () => {
+        it('does not include networkProxy when flag is not provided', async () => {
+            const { deps } = createDeps();
+
+            await runLogin(['https://new-service.example.com/'], { cookie: 'token=abc' }, deps);
+
+            expect(process.exitCode).not.toBe(1);
+            expect(addProviderToConfig).toHaveBeenCalledTimes(1);
+            const [, entry] = addProviderToConfig.mock.calls[0];
+            expect(entry.networkProxy).toBeUndefined();
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Closes #77

- Adds per-provider `networkProxy` config field (e.g. `socks5h://127.0.0.1:1080`) to route browser traffic through SOCKS5/HTTP proxies during `sig login`
- Adds `--network-proxy <url>` CLI flag for one-off proxy usage
- For auto-provisioned providers, the proxy is persisted to config automatically
- For existing providers, the proxy applies once without modifying config

## Usage

```bash
# One-off with auto-provisioned provider (persists proxy to config)
sig login https://linkedin.com --network-proxy socks5h://127.0.0.1:1080

# One-off with existing provider (applies once, no persistence)
sig login jira --network-proxy socks5h://127.0.0.1:1080

# Pre-configured in ~/.sig/config.yaml
providers:
  linkedin:
    domains: [linkedin.com]
    strategy: cookie
    networkProxy: socks5h://127.0.0.1:1080
```

## Implementation

Proxy is threaded through: `login.ts` → `AuthManager.forceReauth(id, {networkProxy})` → `AuthContext` → strategy → `runHybridFlow({networkProxy})` → `--proxy-server=<url>` Chromium arg → Playwright adapter.

## Test plan

- [x] Build passes (`pnpm --filter @sigcli/cli build`)
- [x] All 689 tests pass (`pnpm --filter @sigcli/cli test`)
- [x] New test file: `tests/unit/cli/login-network-proxy.test.ts` (5 tests)
  - Auto-provisioned provider persists `networkProxy` in config
  - Existing provider does NOT persist proxy
  - Token/cookie paths work correctly with the flag
  - Without flag, no proxy field in config