### PR TITLE
fix(cookie): only check expiry of requiredCookies when configured

### DIFF
--- a/cli/src/auth-manager.ts
+++ b/cli/src/auth-manager.ts
@@ -212,7 +212,7 @@ export class AuthManager {
         const validation = strategy.validate(stored.credential, provider.strategyConfig);
         const valid = isOk(validation) && validation.value;
 
-        const expiresAt = this.getExpiresAt(stored.credential);
+        const expiresAt = this.getExpiresAt(stored.credential, provider);
         const expiresInMinutes = expiresAt
             ? Math.max(0, Math.round((expiresAt.getTime() - Date.now()) / 60000))
             : undefined;
@@ -336,15 +336,20 @@ export class AuthManager {
         await this.storage.set(providerId, stored);
     }
 
-    private getExpiresAt(credential: Credential): Date | null {
+    private getExpiresAt(credential: Credential, provider?: ProviderConfig): Date | null {
         switch (credential.type) {
             case CredentialTypeName.BEARER:
                 return credential.expiresAt ? new Date(credential.expiresAt) : null;
             case CredentialTypeName.COOKIE: {
-                // Earliest cookie expiry, or null if all session cookies
-                const expiries = credential.cookies
-                    .filter((c) => c.expires > 0)
-                    .map((c) => c.expires * 1000);
+                // Only consider requiredCookies if configured, otherwise all cookies
+                const requiredCookies = (
+                    provider?.strategyConfig as unknown as Record<string, unknown>
+                )?.requiredCookies as string[] | undefined;
+                const cookies =
+                    requiredCookies && requiredCookies.length > 0
+                        ? credential.cookies.filter((c) => requiredCookies.includes(c.name))
+                        : credential.cookies;
+                const expiries = cookies.filter((c) => c.expires > 0).map((c) => c.expires * 1000);
                 return expiries.length > 0 ? new Date(Math.min(...expiries)) : null;
             }
             default:

--- a/cli/src/strategies/cookie.strategy.ts
+++ b/cli/src/strategies/cookie.strategy.ts
@@ -61,9 +61,13 @@ class CookieStrategy implements IAuthStrategy {
             return ok(false);
         }
 
-        // Check individual cookie expiry
+        // Check cookie expiry — only consider requiredCookies if configured
         const now = Date.now() / 1000;
-        const hasExpired = credential.cookies.some((c) => c.expires > 0 && c.expires < now);
+        const cookiesToCheck =
+            this.requiredCookies.length > 0
+                ? credential.cookies.filter((c) => this.requiredCookies.includes(c.name))
+                : credential.cookies;
+        const hasExpired = cookiesToCheck.some((c) => c.expires > 0 && c.expires < now);
         if (hasExpired) return ok(false);
 
         // Ensure we have at least one cookie


### PR DESCRIPTION
## Summary

Fixes a bug where short-lived tracking cookies (e.g. `_gat` from Google Analytics, 1-min TTL) would immediately invalidate credentials even though the actual auth cookies were still valid for weeks/months.

**Root cause:** `validate()` checked expiry of ALL stored cookies, and `getExpiresAt()` reported the minimum expiry across ALL cookies — including irrelevant ones like analytics trackers.

**Fix:** When `requiredCookies` is configured on a provider, only those cookies are checked for expiry. Falls back to checking all cookies when no `requiredCookies` are specified.

## Before/After

```
# Before: V2EX shows expired (because _gat expires in 1 min)
sig status v2ex → valid: false, expiresAt: "2026-04-29T01:08:34.000Z"

# After: V2EX shows valid (only checks A2 cookie, expires July 23)
sig status v2ex → valid: true, expiresAt: "2026-07-23T02:17:26.679Z"
```

## Test plan

- [x] Build passes
- [x] All 689 tests pass
- [x] Verified locally: `sig status v2ex` and `sig status reddit` now show `valid: true`