### PR TITLE
fix(test): allow pre-release suffix in version assertion

### DIFF
--- a/cli/tests/unit/core/constants.test.ts
+++ b/cli/tests/unit/core/constants.test.ts
@@ -226,7 +226,7 @@ describe('constants', () => {
         });
 
         it('APP_VERSION is a semver string', () => {
-            expect(APP_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+            expect(APP_VERSION).toMatch(/^\d+\.\d+\.\d+(-[\w.]+)?$/);
         });
     });
 


### PR DESCRIPTION
The version regex was too strict — rejected beta/rc suffixes.