### PR TITLE
fix(cookie): prevent premature auth detection during OAuth/SSO redirects

### DIFF
--- a/cli/src/strategies/cookie.strategy.ts
+++ b/cli/src/strategies/cookie.strategy.ts
@@ -141,6 +141,16 @@ class CookieStrategy implements IAuthStrategy {
                     return this.requiredCookies.every((name) => cookieNames.has(name));
                 }
 
+                // If the page is not on the provider's domains, we're still in an OAuth/SSO redirect
+                // Don't consider authentication complete until the browser returns to the provider
+                const currentUrl = page.url().toLowerCase();
+                const onProviderDomain = provider.domains.some((d) =>
+                    currentUrl.includes(d.toLowerCase()),
+                );
+                if (!onProviderDomain) {
+                    return false;
+                }
+
                 // Default: auth is complete when we're no longer on a login page
                 const onLoginPage = await isLoginPage(page);
                 return !onLoginPage;


### PR DESCRIPTION
## Problem

When authenticating to sites that use OAuth/SSO (e.g. Grafana with OAuth), the cookie strategy incorrectly declares authentication complete while the browser is still on the OAuth provider's domain mid-redirect.

**What happens:**
1. Browser navigates to provider (e.g. `grafana.example.com/login`)
2. Provider redirects to OAuth IdP (e.g. `accounts.google.com` or corporate SSO)
3. OAuth IdP sets intermediate cookies (`oauth_state`, `redirectTo`, `stickounet`) on the provider domain
4. `isLoginPage()` checks the current page — it's on the IdP domain, has no password field, URL doesn't match login patterns → returns `false`
5. `isAuthenticated()` returns `true` (thinks auth is done)
6. sig extracts cookies immediately — only gets intermediate OAuth cookies, **not** the final `grafana_session`
7. OAuth callback (which would set `grafana_session`) never completes because the browser is already closed

**Result:** `sig get` returns useless cookies like `oauth_state` and `redirectTo`. API calls fail with 401.

## Fix

Added a domain check before the `isLoginPage()` fallback in the `isAuthenticated` callback:

```typescript
const currentUrl = page.url().toLowerCase();
const onProviderDomain = provider.domains.some((d) =>
    currentUrl.includes(d.toLowerCase()),
);
if (!onProviderDomain) {
    return false;
}
```

If the browser is not on the provider's configured domains, we know we're still in an OAuth/SSO redirect flow and should keep waiting. Authentication is only considered complete when:
1. The browser has returned to the provider's domain, AND
2. The page is no longer a login page

This does not affect providers that configure `requiredCookies` (which already has its own explicit check).

## Testing

Verified with a Grafana instance using OAuth — `sig login` now correctly waits for the OAuth flow to complete and captures `grafana_session`.