### PR TITLE
fix(ci): bump beta version past both npm registry and local package.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
                   ")
 
                   BETA_VERSION="${BASE_VERSION%-*}-beta.${NEXT_BETA}"
-                  npm version "${BETA_VERSION}" --no-git-tag-version
+                  npm version "${BETA_VERSION}" --no-git-tag-version --allow-same-version
                   npm publish --tag beta
                   echo "## Published \`${PKG_NAME}@${BETA_VERSION}\` (beta)" >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
## Problem

Beta release workflow fails with `npm error Version not changed` when the calculated next beta number matches the version already in `package.json`.

Example: npm has `1.3.0-beta.0`, `package.json` has `1.3.0-beta.1`. Workflow calculates next = max(0) + 1 = 1, tries `npm version "1.3.0-beta.1"` which is already the current version → error.

## Fix

Include the local `package.json` beta number in the max calculation:

```
NEXT_BETA = max(published betas on npm, local package.json beta) + 1
```

This ensures the version always bumps forward regardless of whether the collision comes from npm or from the local file.