### PR TITLE
chore(cli): bump version to 1.3.0-beta.2

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sigcli/cli",
-    "version": "1.3.0-beta.1",
+    "version": "1.3.0-beta.2",
     "description": "General-purpose authentication CLI with pluggable strategies and browser adapters",
     "main": "dist/index.js",
     "type": "module",


### PR DESCRIPTION
Beta release with OAuth/SSO domain check fix (#89).