### PR TITLE
chore(cli): bump version to 2.0.0-beta.1

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sigcli/cli",
-    "version": "1.3.0-beta.2",
+    "version": "2.0.0-beta.1",
     "description": "General-purpose authentication CLI with pluggable strategies and browser adapters",
     "main": "dist/index.js",
     "type": "module",


### PR DESCRIPTION
## Summary
- Bump @sigcli/cli version from 1.3.0-beta.2 to 2.0.0-beta.1
- Major version bump for the v2 extract/apply architecture redesign

## Test plan
- [ ] CI passes
- [ ] Release workflow publishes beta to npm