### PR TITLE
fix(windows): use single quotes for execPath in generated config

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sigcli/cli",
-    "version": "1.3.0-beta.2",
+    "version": "2.0.0-beta.1",
     "description": "General-purpose authentication CLI with pluggable strategies and browser adapters",
     "main": "dist/index.js",
     "type": "module",

--- a/cli/src/config/generator.ts
+++ b/cli/src/config/generator.ts
@@ -24,7 +24,7 @@ export function generateConfigYaml(options: InitOptions): string {
             : 'mode: browser                              # Use "browserless" on remote/headless machines';
 
     const execPathLine = options.execPath
-        ? `\n  execPath: "${options.execPath}"              # Detected browser binary`
+        ? `\n  execPath: '${options.execPath}'              # Detected browser binary`
         : '';
 
     return `# SigCLI configuration


### PR DESCRIPTION
## Summary
- Fix YAML parse error on Windows where `execPath` contains backslashes
- Double-quoted YAML strings interpret `\M`, `\E`, `\A` as invalid escape sequences
- Single-quoted strings preserve backslashes literally

## Test plan
- [ ] `sig init` on Windows generates valid YAML with execPath like `'C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe'`
- [ ] `sig login` parses the config without error