### PR TITLE
chore(cli): set base version to 2.0.0 for release workflow

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sigcli/cli",
-    "version": "2.0.0-beta.1",
+    "version": "2.0.0",
     "description": "General-purpose authentication CLI with pluggable strategies and browser adapters",
     "main": "dist/index.js",
     "type": "module",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sigcli/cli",
-    "version": "1.3.0-beta.2",
+    "version": "2.0.0-beta.1",
     "description": "General-purpose authentication CLI with pluggable strategies and browser adapters",
     "main": "dist/index.js",
     "type": "module",


### PR DESCRIPTION
## Summary
- Remove prerelease suffix from package.json version
- The release workflow computes `beta.N` automatically from npm registry
- Having `2.0.0-beta.1` in package.json caused `npm version` to fail when the computed version matched

## Test plan
- [ ] Release workflow succeeds after merge