### PR TITLE
fix(browser): use config timeouts instead of hardcoded values

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sigcli/cli",
-    "version": "1.3.0-beta.2",
+    "version": "2.0.0-beta.1",
     "description": "General-purpose authentication CLI with pluggable strategies and browser adapters",
     "main": "dist/index.js",
     "type": "module",

--- a/cli/src/auth-manager.ts
+++ b/cli/src/auth-manager.ts
@@ -98,6 +98,7 @@ export class AuthManager {
                     channel: config.browser.channel,
                     execPath: config.browser.execPath ?? '',
                     waitUntil: config.browser.waitUntil,
+                    headlessTimeout: config.browser.headlessTimeout,
                 }),
             );
         }

--- a/cli/src/strategies/browser/browser-strategy.ts
+++ b/cli/src/strategies/browser/browser-strategy.ts
@@ -35,6 +35,7 @@ export interface BrowserStrategyOptions {
     execPath: string;
     channel: string;
     waitUntil: WaitUntilValue;
+    headlessTimeout: number;
 }
 
 export class BrowserStrategy implements IStrategy {
@@ -91,7 +92,10 @@ export class BrowserStrategy implements IStrategy {
                 const waitUntil = ctx.waitUntil ?? this.options.waitUntil;
 
                 if (ctx.entryUrl) {
-                    await page.goto(ctx.entryUrl, { waitUntil, timeout: ctx.timeout ?? 15000 });
+                    await page.goto(ctx.entryUrl, {
+                        waitUntil,
+                        timeout: this.options.headlessTimeout,
+                    });
                 }
 
                 const currentUrl = (page.url() as string).toLowerCase();
@@ -219,7 +223,7 @@ export class BrowserStrategy implements IStrategy {
         try {
             browser = spawn(execPath, browserArgs, { detached: false, stdio: 'ignore' });
 
-            const wsUrl = await waitForBrowserReady(cdpPort, 15000);
+            const wsUrl = await waitForBrowserReady(cdpPort, ctx.timeout);
             cdpClient = await connectCdpWs(wsUrl);
 
             const result = await this.pollUntilComplete(cdpClient, rules, ctx);


### PR DESCRIPTION
## Summary
- CDP browser startup (`waitForBrowserReady`) now uses `visibleTimeout` (120s default) instead of hardcoded 15s
- Headless `page.goto` now uses `headlessTimeout` (30s default) from config instead of hardcoded 15s
- Fixes timeout on Windows where Edge startup can exceed 15s

## Test plan
- [ ] `sig login` on Windows no longer times out waiting for CDP endpoint
- [ ] Headless check still fails fast when browser not authenticated