### PR TITLE
chore(cli): bump version to 2.1.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sigcli/cli",
-    "version": "2.0.0-beta.2",
+    "version": "2.1.0",
     "description": "General-purpose authentication CLI with pluggable strategies and browser adapters",
     "main": "dist/index.js",
     "type": "module",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sigcli/cli",
-    "version": "2.0.0-beta",
+    "version": "2.0.0-beta.2",
     "description": "General-purpose authentication CLI with pluggable strategies and browser adapters",
     "main": "dist/index.js",
     "type": "module",


### PR DESCRIPTION
Bump base version to 2.1.0 for beta release (2.0.0-beta.* blocked by npm 24h unpublish policy)