### PR TITLE
chore(cli): set base version to 1.3.0 for beta release

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sigcli/cli",
-    "version": "2.0.0-beta.2",
+    "version": "1.3.0",
     "description": "General-purpose authentication CLI with pluggable strategies and browser adapters",
     "main": "dist/index.js",
     "type": "module",


### PR DESCRIPTION
Set base version to 1.3.0 — workflow will publish as 1.3.0-beta.0