### PR TITLE
fix(cli): clear credentials on init --force and fix Windows browser hang

### DIFF
--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -150,6 +150,20 @@ export async function runInit(
     // Write config
     await fsp.writeFile(configPath, yaml, 'utf-8');
 
+    // Clear stored credentials when reinitializing
+    if (force) {
+        try {
+            const files = fs.readdirSync(credentialsDir);
+            for (const file of files) {
+                if (file.endsWith('.json')) {
+                    fs.unlinkSync(path.join(credentialsDir, file));
+                }
+            }
+        } catch {
+            /* credentials dir may not exist yet */
+        }
+    }
+
     // Ensure encryption key exists
     await loadEncryptionKey();
 

--- a/cli/src/commands/proxy.ts
+++ b/cli/src/commands/proxy.ts
@@ -8,6 +8,7 @@ import { ProxySubcommand } from '../types/index.js';
 import { clearState, isRunning, readState } from '../proxy/proxy-state.js';
 import { ExitCode } from '../utils/exit-codes.js';
 import { expandHome } from '../utils/path.js';
+import { killPid } from '../utils/process-kill.js';
 import { AuditAction, AuditStatus, logAuditEvent } from '../audit/audit-log.js';
 import type { AuthManager } from '../auth-manager.js';
 
@@ -146,7 +147,7 @@ async function handleStop(): Promise<void> {
     }
 
     try {
-        process.kill(state.pid, 'SIGTERM');
+        killPid(state.pid);
         await logAuditEvent({
             action: AuditAction.PROXY_STOP,
             status: AuditStatus.SUCCESS,

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -4,6 +4,7 @@ import { unlinkSync, writeFileSync } from 'node:fs';
 import { isOk } from '../types/index.js';
 import { credentialToEnvVars } from '../utils/credential-env.js';
 import { ExitCode } from '../utils/exit-codes.js';
+import { killProcess } from '../utils/process-kill.js';
 import { extractSensitiveValues, redactOutput } from '../utils/redact.js';
 import { AuditAction, AuditStatus, logAuditEvent } from '../audit/audit-log.js';
 import type { AuthManager } from '../auth-manager.js';
@@ -124,7 +125,11 @@ export async function runRun(
 
     const forwardSignal = (signal: NodeJS.Signals) => {
         cleanup();
-        child.kill(signal);
+        if (process.platform === 'win32') {
+            killProcess(child);
+        } else {
+            child.kill(signal);
+        }
     };
 
     process.on('SIGINT', () => forwardSignal('SIGINT'));

--- a/cli/src/strategies/browser/browser-strategy.ts
+++ b/cli/src/strategies/browser/browser-strategy.ts
@@ -21,6 +21,7 @@ import type {
 } from '../../types/interfaces/headless-extractor.js';
 import type { ExtractionResult } from '../../types/interfaces/strategy.js';
 import { expandHome } from '../../utils/path.js';
+import { killProcess } from '../../utils/process-kill.js';
 import { findFreePort, removeSingletonLock, waitForBrowserReady } from './browser-lifecycle.js';
 import { attachToPageTarget, connectCdpWs, type CdpWsClient } from './cdp-ws.js';
 import { CdpCookieExtractor } from './extractors/cdp-cookie.js';
@@ -187,16 +188,7 @@ export class BrowserStrategy implements IStrategy {
         let browser: ChildProcess | undefined;
         const cleanup = () => {
             if (browser && !browser.killed) {
-                browser.kill('SIGTERM');
-                setTimeout(() => {
-                    if (browser && !browser.killed) {
-                        try {
-                            browser.kill('SIGKILL');
-                        } catch {
-                            /* ignore */
-                        }
-                    }
-                }, 3000).unref();
+                killProcess(browser);
             }
         };
 

--- a/cli/src/utils/process-kill.ts
+++ b/cli/src/utils/process-kill.ts
@@ -1,0 +1,45 @@
+import { execSync, type ChildProcess } from 'node:child_process';
+
+/**
+ * Kill a child process reliably across platforms.
+ * On Windows, uses taskkill /F /T to force-kill the process tree.
+ * On Unix, sends SIGTERM with a SIGKILL fallback after timeout.
+ */
+export function killProcess(child: ChildProcess, timeoutMs = 3000): void {
+    if (!child || child.killed || child.pid == null) return;
+
+    if (process.platform === 'win32') {
+        try {
+            execSync(`taskkill /F /T /PID ${child.pid}`, { stdio: 'ignore' });
+        } catch {
+            /* process may already be gone */
+        }
+    } else {
+        child.kill('SIGTERM');
+        setTimeout(() => {
+            if (!child.killed) {
+                try {
+                    child.kill('SIGKILL');
+                } catch {
+                    /* ignore */
+                }
+            }
+        }, timeoutMs).unref();
+    }
+}
+
+/**
+ * Kill a process by PID reliably across platforms.
+ * On Windows, uses taskkill. On Unix, sends signal.
+ */
+export function killPid(pid: number, signal: NodeJS.Signals = 'SIGTERM'): void {
+    if (process.platform === 'win32') {
+        try {
+            execSync(`taskkill /F /T /PID ${pid}`, { stdio: 'ignore' });
+        } catch {
+            /* process may already be gone */
+        }
+    } else {
+        process.kill(pid, signal);
+    }
+}

--- a/cli/tests/unit/cli/init.test.ts
+++ b/cli/tests/unit/cli/init.test.ts
@@ -15,8 +15,12 @@ import { validateConfig } from '../../../src/config/validator.js';
 vi.mock('node:fs', () => ({
     default: {
         existsSync: vi.fn(),
+        readdirSync: vi.fn().mockReturnValue([]),
+        unlinkSync: vi.fn(),
     },
     existsSync: vi.fn(),
+    readdirSync: vi.fn().mockReturnValue([]),
+    unlinkSync: vi.fn(),
 }));
 
 vi.mock('node:fs/promises', () => ({


### PR DESCRIPTION
## Summary
- `sig init --force` now clears stored credentials in `~/.sig/credentials/`, fixing the issue where `sig status` showed empty providers while `sig get`/`sig login` still worked from stale cached creds
- Add cross-platform `killProcess`/`killPid` utility — uses `taskkill /F /T /PID` on Windows, SIGTERM→SIGKILL cascade on Unix
- Apply the utility to browser strategy CDP cleanup, `sig proxy stop`, and `sig run` signal forwarding

## Test plan
- [x] Build passes
- [x] All 335 tests pass
- [ ] Windows: `sig login <url>` should exit cleanly after auth completes
- [ ] `sig init --force` followed by `sig status` shows empty (credentials cleared)