### PR TITLE
docs: adopt extract/apply config format

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ sig request https://jira.example.com/rest/api/2/search --method POST --body '{"j
 
 - **Browser SSO** — signs in through a real browser. Works with any website, any login flow.
 - **Encrypted at rest** — AES-256-GCM encryption. Every access is audit-logged.
+- **Declarative config** — define what to extract (cookies, localStorage, tokens) and how to apply them to requests.
 - **Multi-provider** — inject credentials from multiple systems in a single command.
 - **MITM proxy** — agents set `HTTP_PROXY` and credentials are injected transparently. Zero-trust.
 - **AI-native** — stable CLI with predictable exit codes and JSON output. Built for agents.
@@ -36,9 +37,25 @@ sig request https://jira.example.com/rest/api/2/search --method POST --body '{"j
 ## How It Works
 
 ```
-You log in once               sig stores & encrypts             AI agent operates
+You log in once               sig extracts & encrypts           AI agent operates
 in your browser         -->   credentials locally          -->  on your behalf
-(browser SSO)                 (~/.sig/credentials/)             (sig request / sig proxy)
+(any SSO/login flow)          (~/.sig/credentials/)             (sig request / sig proxy)
+```
+
+**sig login** opens a real browser to the provider's entry URL. You log in normally — SSO, MFA, SAML, anything. Once authenticated, sig extracts credentials (cookies, localStorage tokens) based on your config's `extract[]` rules, encrypts them with AES-256-GCM, and stores them locally. When your agent needs to make a request, `apply[]` rules control how credentials are injected into HTTP headers, body, or query params.
+
+### Config Example
+
+```yaml
+providers:
+    my-jira:
+        domains: [jira.example.com]
+        entryUrl: https://jira.example.com/
+        strategy: browser
+        extract:
+            - { from: cookies, name: session, key: '*' }
+        apply:
+            - { in: header, name: Cookie, value: '${session}' }
 ```
 
 ## AI Agent Skills
@@ -55,7 +72,7 @@ See the [full skills catalog](skills/README.md) for details.
 
 ## Documentation
 
-Full docs, configuration, strategies, SDK, and AI agent integration guide at **[sigcli.ai](https://sigcli.ai)**.
+Full docs, configuration, SDK, and AI agent integration guide at **[sigcli.ai](https://sigcli.ai)**.
 
 ## License
 

--- a/skills/bilibili/SKILL.md
+++ b/skills/bilibili/SKILL.md
@@ -29,12 +29,19 @@ sig login https://www.bilibili.com/
 
 ```yaml
 bilibili:
-    domains: ['www.bilibili.com', 'bilibili.com', 'api.bilibili.com']
+    domains: [www.bilibili.com, bilibili.com, api.bilibili.com]
     entryUrl: https://www.bilibili.com/
-    strategy: cookie
-    config:
-        ttl: '7d'
-        requiredCookies: ['SESSDATA', 'bili_jct']
+    strategy: browser
+    ttl: '7d'
+    required: [session.SESSDATA, session.bili_jct]
+    extract:
+        - from: cookies
+          name: session
+          key: '*'
+    apply:
+        - in: header
+          name: Cookie
+          value: '${session}'
 ```
 
 ## Scripts Reference

--- a/skills/hackernews/SKILL.md
+++ b/skills/hackernews/SKILL.md
@@ -36,11 +36,18 @@ sig login https://news.ycombinator.com/login
 
 ```yaml
 hackernews:
-    domains: ['news.ycombinator.com']
+    domains: [news.ycombinator.com]
     entryUrl: https://news.ycombinator.com/login
-    strategy: cookie
-    config:
-        requiredCookies: ['user']
+    strategy: browser
+    required: [session.user]
+    extract:
+        - from: cookies
+          name: session
+          key: '*'
+    apply:
+        - in: header
+          name: Cookie
+          value: '${session}'
 ```
 
 ## Scripts Reference

--- a/skills/linkedin/SKILL.md
+++ b/skills/linkedin/SKILL.md
@@ -39,12 +39,19 @@ sig login https://www.linkedin.com/login
 
 ```yaml
 linkedin:
-    domains: ['www.linkedin.com', 'linkedin.com']
+    domains: [www.linkedin.com, linkedin.com]
     entryUrl: https://www.linkedin.com/login
-    strategy: cookie
-    config:
-        ttl: '30d'
-        requiredCookies: ['JSESSIONID', 'li_at']
+    strategy: browser
+    ttl: '30d'
+    required: [session.JSESSIONID, session.li_at]
+    extract:
+        - from: cookies
+          name: session
+          key: '*'
+    apply:
+        - in: header
+          name: Cookie
+          value: '${session}'
 ```
 
 ## Scripts Reference

--- a/skills/outlook/SKILL.md
+++ b/skills/outlook/SKILL.md
@@ -39,14 +39,22 @@ Then retry the `sig run` command.
 
 ```yaml
 ms-graph:
-    domains: ['graph.microsoft.com']
+    name: Microsoft Graph
+    domains: [graph.microsoft.com]
     entryUrl: https://teams.cloud.microsoft/v2/
-    strategy: oauth2
-    config:
-        audiences: ['https://graph.microsoft.com']
+    strategy: browser
+    required: [access_token]
+    extract:
+        - from: localStorage
+          name: access_token
+          key: '*|accesstoken|*graph.microsoft.com*'
+    apply:
+        - in: header
+          name: Authorization
+          value: 'Bearer ${access_token}'
 ```
 
-No separate Outlook-specific provider is needed — the Graph API audience covers all mail endpoints. The token is obtained via the Teams portal entry URL, which grants `Mail.Read` and `Mail.ReadWrite` scopes.
+No separate Outlook-specific provider is needed — the Graph API token covers all mail endpoints. The token is extracted from Teams portal localStorage after you log in at the entry URL.
 
 ## Scripts Reference
 

--- a/skills/reddit/SKILL.md
+++ b/skills/reddit/SKILL.md
@@ -36,12 +36,19 @@ sig login https://www.reddit.com/
 
 ```yaml
 reddit:
-    domains: ['www.reddit.com', 'reddit.com']
+    domains: [www.reddit.com, reddit.com]
     entryUrl: https://www.reddit.com/login
-    strategy: cookie
-    config:
-        ttl: '7d'
-        requiredCookies: ['token_v2']
+    strategy: browser
+    ttl: '7d'
+    required: [session.token_v2]
+    extract:
+        - from: cookies
+          name: session
+          key: '*'
+    apply:
+        - in: header
+          name: Cookie
+          value: '${session}'
 ```
 
 ## Scripts Reference

--- a/skills/sigcli-auth/SKILL.md
+++ b/skills/sigcli-auth/SKILL.md
@@ -4,12 +4,23 @@ Operate sigcli to authenticate with any web service from the CLI. This guide is 
 
 ## Overview
 
-sigcli (`sig`) is a CLI tool that stores and manages authentication credentials for web services. It supports browser-based SSO, OAuth2, API tokens, cookies, and HTTP Basic auth. Credentials are encrypted at rest (AES-256-GCM) and stored locally (`~/.sig/`), then applied automatically to HTTP requests.
+sigcli (`sig`) is a CLI tool that stores and manages authentication credentials for web services. It opens a real browser for SSO login, extracts credentials (cookies, localStorage tokens) based on declarative rules, encrypts them at rest (AES-256-GCM), and injects them into HTTP requests automatically.
 
 **Binary:** `sig`  
 **Config:** `~/.sig/config.yaml`  
 **Credentials:** `~/.sig/credentials/<provider-id>.json` (encrypted, AES-256-GCM)  
 **Encryption key:** `~/.sig/encryption.key`
+
+---
+
+## How sig login Works
+
+1. Opens a browser to the provider's `entryUrl`
+2. You log in normally (SSO, MFA, SAML — any login flow)
+3. Once logged in, sigcli extracts credentials based on the `extract[]` rules in your config (cookies, localStorage values, etc.)
+4. The `required[]` field (if set) determines when extraction is "complete" — sigcli polls until all required values are present
+5. Extracted credentials are encrypted and stored locally
+6. Later, `apply[]` rules control how those credentials are injected into HTTP requests
 
 ---
 
@@ -42,23 +53,18 @@ sigcli (`sig`) is a CLI tool that stores and manages authentication credentials 
 
 ---
 
-## Strategy Selection Guide
-
-Use this decision tree to choose the right `sig login` approach:
+## Login Decision Tree
 
 ```
 Do you have credentials already?
 |
-+- YES: Has API key or Personal Access Token (GitHub, GitLab, etc.)
++- YES: Has API key or Personal Access Token
 |       +- sig login <url> --token <value>         # < 1s, no browser
 |
-+- YES: Has cookies copied from browser DevTools (Network tab -> Copy as curl)
++- YES: Has cookies copied from browser DevTools
 |       +- sig login <url> --cookie "k=v; k2=v2"  # < 1s, no browser
 |
-+- YES: Has username + password (HTTP Basic auth)
-|       +- sig login <url> --username <u> --password <p>  # < 1s, no browser
-|
-+- NO: Must complete SSO/OAuth in a browser
++- NO: Must complete login in a browser
         |
         +- Machine HAS a display (developer laptop)
         |   +- sig login <url>                     # 30-120s, opens browser
@@ -66,17 +72,6 @@ Do you have credentials already?
         +- Machine is HEADLESS / CI / remote
             +- sig sync pull                       # Pull creds from a machine that has them
                (requires: sig remote add first, credentials exist on source machine)
-```
-
-### Strategy flag override
-
-If auto-detection picks the wrong strategy, force one:
-
-```bash
-sig login <url> --strategy cookie      # Browser SSO -> CookieCredential
-sig login <url> --strategy oauth2      # Browser OAuth2 -> BearerCredential
-sig login <url> --strategy api-token   # Static API key -> ApiKeyCredential
-sig login <url> --strategy basic       # Username/password -> BasicCredential
 ```
 
 ---
@@ -266,9 +261,8 @@ sig proxy stop
 | Error Code                 | Cause                                                    | Fix                                                                    |
 | -------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------- |
 | `CREDENTIAL_EXPIRED`       | Token/cookie expired, refresh failed                     | `sig logout <provider> && sig login <url>`                             |
-| `CREDENTIAL_TYPE_MISMATCH` | Wrong credential type for provider                       | Re-login with correct strategy: `--strategy <name>`                    |
 | `REFRESH_FAILED`           | OAuth2 refresh token rejected                            | Re-login: `sig logout <provider> && sig login <url>`                   |
-| `BROWSER_LAUNCH_ERROR`     | playwright-core not installed or no browser channel      | `sig doctor` to diagnose; install playwright-core or chrome            |
+| `BROWSER_LAUNCH_ERROR`     | No browser found or playwright-core not installed        | `sig doctor` to diagnose; install playwright-core or chrome            |
 | `BROWSER_TIMEOUT`          | Browser auth took too long (30s headless / 120s visible) | Try again; if CAPTCHA/MFA: ensure visible browser mode                 |
 | `BROWSER_UNAVAILABLE`      | Machine is in browserless mode                           | Use `--token`/`--cookie` or `sig sync pull`                            |
 | `BROWSER_NAVIGATION_ERROR` | Failed to load URL in browser                            | Check URL is reachable; check network                                  |
@@ -339,28 +333,60 @@ sig login <url>             # 30-120s; uses playwright-core
 
 Each skill needs a provider in `~/.sig/config.yaml`. See [`references/config-template.yaml`](references/config-template.yaml) for a ready-to-use template with all skills pre-configured (Jira, Outlook, MS Teams, Slack). Replace placeholder values (`<...>`) with your organization's URLs and IDs.
 
-### Cookie Strategy Config Options
+### Provider Config Format
 
-When using `strategy: cookie`, the following config fields are available:
-
-| Field             | Type       | Description                                                                                |
-| ----------------- | ---------- | ------------------------------------------------------------------------------------------ |
-| `ttl`             | `string`   | Credential lifetime (e.g. `"12h"`, `"7d"`). Default: `"24h"`                               |
-| `waitUntil`       | `string`   | Page load condition: `load`, `networkidle`, `domcontentloaded`, `commit`                   |
-| `requiredCookies` | `string[]` | Cookie names that must exist before auth is considered complete                            |
-| `cookiePaths`     | `string[]` | Additional URL paths to query when checking cookies (for path-scoped cookies like `/wiki`) |
-
-**When to use `cookiePaths`:** Some sites set auth cookies on a sub-path (e.g. Confluence uses `path=/wiki`). Without `cookiePaths`, sigcli only queries domain roots (`/`) and cannot detect those cookies. Add the relevant path to `cookiePaths` to fix detection:
+Every provider declares **what to extract** and **how to apply** credentials:
 
 ```yaml
-my-wiki:
-    domains: ['wiki.example.com']
-    entryUrl: https://wiki.example.com/wiki/display/Home
-    strategy: cookie
-    config:
-        requiredCookies: ['seraph.confluence']
-        cookiePaths: ['/wiki']
+my-provider:
+    domains: [service.example.com]
+    entryUrl: https://service.example.com/
+    strategy: browser
+    ttl: '12h' # optional: credential lifetime
+    required: [session.my_cookie] # optional: wait for specific values
+    extract:
+        - from: cookies # cookies | localStorage | eval
+          name: session # stored under this name
+          key: '*' # which cookies (* = all)
+    apply:
+        - in: header # header | body | query
+          name: Cookie # HTTP header/field name
+          value: '${session}' # template with extracted values
 ```
+
+### Provider-level fields
+
+| Field          | Type       | Description                                                      |
+| -------------- | ---------- | ---------------------------------------------------------------- |
+| `domains`      | `string[]` | Domains this provider matches (for `sig request` URL matching)   |
+| `entryUrl`     | `string`   | URL opened in browser during `sig login`                         |
+| `strategy`     | `string`   | `browser` (opens browser) or `prompt` (asks user for value)      |
+| `ttl`          | `string`   | Credential lifetime (e.g. `"12h"`, `"7d"`). Default: `"24h"`     |
+| `required`     | `string[]` | Completion check: `name.field` format (e.g. `session.my_cookie`) |
+| `cookiePaths`  | `string[]` | Extra URL paths for path-scoped cookies (e.g. `["/wiki"]`)       |
+| `networkProxy` | `string`   | SOCKS proxy for browser (e.g. `socks5://127.0.0.1:3333`)         |
+| `extract`      | `array`    | What to extract (see below)                                      |
+| `apply`        | `array`    | How to inject into requests (see below)                          |
+
+### extract[] fields
+
+Each entry has exactly 3 fields:
+
+| Field  | Description                         | Values                                       |
+| ------ | ----------------------------------- | -------------------------------------------- |
+| `from` | Where to extract                    | `cookies` \| `localStorage` \| `eval`        |
+| `name` | Store as this name (credential key) | Any string (referenced in `apply` templates) |
+| `key`  | What to extract                     | `*` (all) \| specific name \| glob pattern   |
+
+### apply[] fields
+
+Each entry has exactly 3 fields:
+
+| Field   | Description       | Values                                      |
+| ------- | ----------------- | ------------------------------------------- |
+| `in`    | Where to inject   | `header` \| `body` \| `query`               |
+| `name`  | Field/header name | `Cookie`, `Authorization`, etc.             |
+| `value` | Value template    | `"${name}"` \| `"Bearer ${name}"` \| static |
 
 ### Quick Start
 

--- a/skills/sigcli-auth/references/config-template.yaml
+++ b/skills/sigcli-auth/references/config-template.yaml
@@ -1,4 +1,4 @@
-# Sigcli configuration template for skills
+# SigCLI configuration template for skills
 # Copy to ~/.sig/config.yaml and replace <...> placeholders with your values.
 #
 # Docs: https://sigcli.ai
@@ -7,7 +7,7 @@ mode: browser
 
 browser:
     browserDataDir: ~/.sig/browser-data
-    channel: chrome
+    channel: msedge # or chrome, chromium
     headlessTimeout: 30000
     visibleTimeout: 120000
     waitUntil: load
@@ -17,23 +17,38 @@ storage:
 
 providers:
     # ── Microsoft Teams Chat API ────────────────────────────────────────────
-    # OAuth2 bearer token. Audience: Teams Chat Service.
+    # Bearer token extracted from MSAL localStorage cache.
     ms-teams:
         name: Microsoft Teams
-        domains: ['teams.cloud.microsoft']
+        domains: [teams.cloud.microsoft]
         entryUrl: https://teams.cloud.microsoft/v2/
-        strategy: oauth2
-        config:
-            audiences: ['https://ic3.teams.office.com']
+        strategy: browser
+        required: [access_token]
+        extract:
+            - from: localStorage
+              name: access_token
+              key: '*|accesstoken|*ic3.teams.office.com*'
+        apply:
+            - in: header
+              name: Authorization
+              value: 'Bearer ${access_token}'
 
-    # ── Microsoft Graph API (Outlook + Teams people search) ─────────────────
-    # OAuth2 bearer token. Same login URL as ms-teams.
+    # ── Microsoft Graph API (Outlook, People, Calendar) ────────────────────
+    # Same login URL as ms-teams, different audience.
     ms-graph:
-        domains: ['graph.microsoft.com']
+        name: Microsoft Graph
+        domains: [graph.microsoft.com]
         entryUrl: https://teams.cloud.microsoft/v2/
-        strategy: oauth2
-        config:
-            audiences: ['https://graph.microsoft.com']
+        strategy: browser
+        required: [access_token]
+        extract:
+            - from: localStorage
+              name: access_token
+              key: '*|accesstoken|*graph.microsoft.com*'
+        apply:
+            - in: header
+              name: Authorization
+              value: 'Bearer ${access_token}'
 
     # ── Slack ───────────────────────────────────────────────────────────────
     # Cookie (xoxd) + localStorage (xoxc token).
@@ -47,37 +62,67 @@ providers:
     # Enterprise Grid orgs start with "E", regular workspaces start with "T".
     app-slack:
         name: Slack
-        domains: ['<your-workspace>.slack.com'] # e.g. mycompany.slack.com
+        domains: [<your-workspace>.slack.com] # e.g. mycompany.slack.com
         entryUrl: https://app.slack.com/client/<your-team-id>
-        strategy: cookie
-        config:
-            ttl: '7d'
-            requiredCookies: ['d']
-        localStorage:
-            - name: xoxc-token
-              key: localConfig_v2
-              jsonPath: teams.<your-team-id>.token
-        # Inject rules — control how credentials are applied via sig proxy / sig request.
-        # Slack needs both the cookie header AND the xoxc token in the POST body.
-        proxy:
-            inject:
-                # Set the Cookie header from the stored d=xoxd-... cookie
-                - in: header
-                  action: set
-                  name: Cookie
-                  from: credential.cookies
-                # Inject the xoxc token into the request body as the "token" form field
-                - in: body
-                  action: set
-                  name: token
-                  from: credential.localStorage.xoxc-token
+        strategy: browser
+        ttl: '7d'
+        required: [session.d, xoxc-token]
+        extract:
+            - from: cookies
+              name: session
+              key: '*'
+            - from: localStorage
+              name: xoxc-token
+              key: 'localConfig_v2.teams.<your-team-id>.token'
+        apply:
+            - in: header
+              name: Cookie
+              value: '${session}'
+            - in: header
+              name: Authorization
+              value: 'Bearer ${xoxc-token}'
+
+    # ── Jira ────────────────────────────────────────────────────────────────
+    # Simple cookie extraction.
+    jira-tools:
+        name: jira.tools.sap
+        domains: [jira.tools.sap]
+        entryUrl: https://jira.tools.sap/
+        strategy: browser
+        ttl: '10d'
+        extract:
+            - from: cookies
+              name: session
+              key: '*'
+        apply:
+            - in: header
+              name: Cookie
+              value: '${session}'
+
+    # ── Wiki ────────────────────────────────────────────────────────────────
+    # Cookie with path scoping (Confluence uses /wiki path).
+    wiki-one:
+        name: wiki.one.int.sap
+        domains: [wiki.one.int.sap]
+        entryUrl: https://wiki.one.int.sap/
+        strategy: browser
+        ttl: '12h'
+        cookiePaths: ['/wiki']
+        extract:
+            - from: cookies
+              name: session
+              key: '*'
+        apply:
+            - in: header
+              name: Cookie
+              value: '${session}'
 
 # ── Optional: auto-refresh credentials before they expire ─────────────────
 # Managed by: sig watch add/remove/set-interval
 # watch:
 #   interval: "5m"
 #   providers:
-#     jira:
+#     jira-tools:
 #     ms-teams:
 #     ms-graph:
 

--- a/skills/v2ex/SKILL.md
+++ b/skills/v2ex/SKILL.md
@@ -33,9 +33,17 @@ Then retry the `sig run` command.
 
 ```yaml
 v2ex:
-    domains: ['www.v2ex.com', 'v2ex.com']
+    domains: [www.v2ex.com, v2ex.com]
     entryUrl: https://www.v2ex.com/signin
-    strategy: cookie
+    strategy: browser
+    extract:
+        - from: cookies
+          name: session
+          key: '*'
+    apply:
+        - in: header
+          name: Cookie
+          value: '${session}'
 ```
 
 ## Scripts Reference

--- a/skills/x/SKILL.md
+++ b/skills/x/SKILL.md
@@ -36,12 +36,19 @@ sig login https://x.com/
 
 ```yaml
 x:
-    domains: ['x.com', 'twitter.com']
+    domains: [x.com, twitter.com]
     entryUrl: https://x.com/i/flow/login
-    strategy: cookie
-    config:
-        ttl: '7d'
-        requiredCookies: ['ct0', 'auth_token']
+    strategy: browser
+    ttl: '7d'
+    required: [session.ct0, session.auth_token]
+    extract:
+        - from: cookies
+          name: session
+          key: '*'
+    apply:
+        - in: header
+          name: Cookie
+          value: '${session}'
 ```
 
 ## Scripts Reference

--- a/skills/youtube/SKILL.md
+++ b/skills/youtube/SKILL.md
@@ -39,12 +39,19 @@ sig login https://www.youtube.com/
 
 ```yaml
 youtube:
-    domains: ['www.youtube.com', 'youtube.com']
+    domains: [www.youtube.com, youtube.com]
     entryUrl: https://www.youtube.com/
-    strategy: cookie
-    config:
-        ttl: '30d'
-        requiredCookies: ['__Secure-3PAPISID', 'LOGIN_INFO']
+    strategy: browser
+    ttl: '30d'
+    required: [session.__Secure-3PAPISID, session.LOGIN_INFO]
+    extract:
+        - from: cookies
+          name: session
+          key: '*'
+    apply:
+        - in: header
+          name: Cookie
+          value: '${session}'
 ```
 
 ## Scripts Reference

--- a/skills/zhihu/SKILL.md
+++ b/skills/zhihu/SKILL.md
@@ -31,12 +31,19 @@ Then retry the `sig run` command.
 
 ```yaml
 zhihu:
-    domains: ['www.zhihu.com', 'zhihu.com']
+    domains: [www.zhihu.com, zhihu.com]
     entryUrl: https://www.zhihu.com/signin
-    strategy: cookie
-    config:
-        ttl: '7d'
-        requiredCookies: ['z_c0']
+    strategy: browser
+    ttl: '7d'
+    required: [session.z_c0]
+    extract:
+        - from: cookies
+          name: session
+          key: '*'
+    apply:
+        - in: header
+          name: Cookie
+          value: '${session}'
 ```
 
 ## Scripts Reference

--- a/website/src/content/docs-zh.tsx
+++ b/website/src/content/docs-zh.tsx
@@ -1080,10 +1080,10 @@ curl https://jira.example.com/api/me   # 凭证自动注入`}</CodeBlock>
                         处理长期守护进程、会派生进程树的工具， 或只读取代理环境变量的工具。
                     </P>
                     <P>
-                        <strong>凭证注入：</strong>代理使用提供者的{' '}
-                        <Code>apply[]</Code> 规则将凭证注入请求。这些规则同样被{' '}
-                        <Code>sig request</Code>、<Code>sig get</Code> 和{' '}
-                        <Code>sig run</Code> 使用——一份配置适用所有访问方式。
+                        <strong>凭证注入：</strong>代理使用提供者的 <Code>apply[]</Code>{' '}
+                        规则将凭证注入请求。这些规则同样被 <Code>sig request</Code>、
+                        <Code>sig get</Code> 和 <Code>sig run</Code>{' '}
+                        使用——一份配置适用所有访问方式。
                     </P>
                     <CodeBlock lang="yaml">{`# 示例：同时注入 cookie 和 bearer 令牌
 providers:
@@ -1096,8 +1096,8 @@ providers:
       - { in: header, name: Cookie, value: "\${session}" }
       - { in: header, name: Authorization, value: "Bearer \${xoxc-token}" }`}</CodeBlock>
                     <P>
-                        <Code>apply[]</Code> 规则支持注入到 header、body 和 query 参数。
-                        模板变量（<Code>{'${name}'}</Code>）引用已提取的凭证名称。
+                        <Code>apply[]</Code> 规则支持注入到 header、body 和 query 参数。 模板变量（
+                        <Code>{'${name}'}</Code>）引用已提取的凭证名称。
                     </P>
                     <P>
                         <strong>自动刷新：</strong>代理守护进程会自动运行监视/刷新循环。 在{' '}
@@ -1250,8 +1250,8 @@ providers:
                         提供者配置
                     </SectionHeading>
                     <P>
-                        每个提供者声明<strong>提取什么</strong>（cookie、localStorage 值等）
-                        以及<strong>如何应用</strong>到 HTTP 请求中。所有访问方式——
+                        每个提供者声明<strong>提取什么</strong>（cookie、localStorage 值等） 以及
+                        <strong>如何应用</strong>到 HTTP 请求中。所有访问方式——
                         <Code>sig get</Code>、<Code>sig request</Code>、<Code>sig run</Code>、
                         <Code>sig proxy</Code>——使用相同的配置。
                     </P>
@@ -1294,8 +1294,8 @@ providers:
                         apply[] 规则
                     </SectionHeading>
                     <P>
-                        每条规则告诉 sigcli 如何将提取的值注入 HTTP 请求。模板变量
-                        （<Code>{'${name}'}</Code>）引用 extract 规则中的 <Code>name</Code> 字段。
+                        每条规则告诉 sigcli 如何将提取的值注入 HTTP 请求。模板变量 （
+                        <Code>{'${name}'}</Code>）引用 extract 规则中的 <Code>name</Code> 字段。
                     </P>
                     <CodeBlock lang="yaml">{`apply:
   # 注入所有 cookie 为 Cookie 头
@@ -1363,9 +1363,7 @@ app-slack:
                     <SectionHeading id="browser-adapters" level={1}>
                         浏览器适配器
                     </SectionHeading>
-                    <P>
-                        Sigcli 使用真实浏览器进行 SSO 登录。内置两个适配器：
-                    </P>
+                    <P>Sigcli 使用真实浏览器进行 SSO 登录。内置两个适配器：</P>
 
                     <List>
                         <Li>

--- a/website/src/content/docs-zh.tsx
+++ b/website/src/content/docs-zh.tsx
@@ -30,7 +30,7 @@ export const pageContent = {
     meta: {
         title: 'Sigcli 文档 — 完整参考',
         description:
-            'Sigcli 完整文档：快速上手、命令参考、环境变量、配置、认证策略、浏览器适配器、SDK、AI 代理集成与远程同步。',
+            'Sigcli 完整文档：快速上手、命令参考、环境变量、配置、浏览器适配器、SDK、AI 代理集成与远程同步。',
     },
 
     toc: [
@@ -121,11 +121,16 @@ export const pageContent = {
             parent: '#configuration',
             prefix: '└ ',
         }),
-        tocItem('#strategies', '认证策略'),
-        tocItem('#strat-cookie', 'cookie', { level: 1, parent: '#strategies', prefix: '├ ' }),
-        tocItem('#strat-oauth2', 'oauth2', { level: 1, parent: '#strategies', prefix: '├ ' }),
-        tocItem('#strat-api-token', 'api-token', { level: 1, parent: '#strategies', prefix: '├ ' }),
-        tocItem('#strat-basic', 'basic', { level: 1, parent: '#strategies', prefix: '└ ' }),
+        tocItem('#config-extract', 'extract[] 规则', {
+            level: 1,
+            parent: '#configuration',
+            prefix: '├ ',
+        }),
+        tocItem('#config-apply', 'apply[] 规则', {
+            level: 1,
+            parent: '#configuration',
+            prefix: '└ ',
+        }),
         tocItem('#browser-adapters', '浏览器适配器'),
         tocItem('#sdk', 'SDK'),
         tocItem('#sdk-ts', 'TypeScript SDK', { level: 1, parent: '#sdk', prefix: '├ ' }),
@@ -939,12 +944,6 @@ sig login https://jira.example.com --cookie "SESSION=abc123; csrf_token=xyz"
 # HTTP 基本认证
 sig login https://jira.example.com --username alice --password hunter2
 
-# 强制指定策略
-sig login https://jira.example.com --strategy cookie
-sig login https://jira.example.com --strategy oauth2
-sig login https://jira.example.com --strategy api-token
-sig login https://jira.example.com --strategy basic
-
 # 跳过存储的凭证检查，直接进入浏览器
 sig login https://jira.example.com --force`}</CodeBlock>
 
@@ -1081,27 +1080,24 @@ curl https://jira.example.com/api/me   # 凭证自动注入`}</CodeBlock>
                         处理长期守护进程、会派生进程树的工具， 或只读取代理环境变量的工具。
                     </P>
                     <P>
-                        <strong>注入规则：</strong>
-                        对于需要在非标准位置（请求体字段、查询参数、自定义标头） 注入凭证的
-                        API，可在 Provider 配置中添加 <Code>proxy.inject</Code> 规则。 代理和{' '}
-                        <Code>sig request</Code> 会在标准凭证标头之后应用这些规则。
+                        <strong>凭证注入：</strong>代理使用提供者的{' '}
+                        <Code>apply[]</Code> 规则将凭证注入请求。这些规则同样被{' '}
+                        <Code>sig request</Code>、<Code>sig get</Code> 和{' '}
+                        <Code>sig run</Code> 使用——一份配置适用所有访问方式。
                     </P>
-                    <CodeBlock lang="yaml">{`# Example: inject xoxc token from localStorage as form body parameter
+                    <CodeBlock lang="yaml">{`# 示例：同时注入 cookie 和 bearer 令牌
 providers:
   app-slack:
-    # ... domains, strategy, etc.
-    proxy:
-      inject:
-        - in: body           # header | body | query
-          action: set         # set | append | remove
-          name: token
-          from: credential.localStorage.xoxc-token`}</CodeBlock>
+    strategy: browser
+    extract:
+      - { from: cookies, name: session, key: "*" }
+      - { from: localStorage, name: xoxc-token, key: "localConfig_v2.teams.*.token" }
+    apply:
+      - { in: header, name: Cookie, value: "\${session}" }
+      - { in: header, name: Authorization, value: "Bearer \${xoxc-token}" }`}</CodeBlock>
                     <P>
-                        <Code>from</Code> 字段对已存储凭证中的路径进行解析：{' '}
-                        <Code>credential.cookies</Code>、<Code>credential.accessToken</Code>、{' '}
-                        <Code>credential.localStorage.&lt;key&gt;</Code>。 请求体注入支持{' '}
-                        <Code>application/json</Code> 和{' '}
-                        <Code>application/x-www-form-urlencoded</Code> 内容类型。
+                        <Code>apply[]</Code> 规则支持注入到 header、body 和 query 参数。
+                        模板变量（<Code>{'${name}'}</Code>）引用已提取的凭证名称。
                     </P>
                     <P>
                         <strong>自动刷新：</strong>代理守护进程会自动运行监视/刷新循环。 在{' '}
@@ -1222,100 +1218,140 @@ elif auth_type == "bearer":
                     </SectionHeading>
                     <P>
                         Sigcli 读取 <Code>~/.sig/config.yaml</Code>。运行 <Code>sig init</Code>{' '}
-                        生成初始文件。顶级键为 <Code>mode</Code> 和 <Code>providers</Code>。
+                        生成初始文件。提供者由 <Code>sig login &lt;url&gt;</Code> 自动创建，
+                        也可手动添加以精确控制提取和注入规则。
                     </P>
-                    <CodeBlock lang="bash">{`# ~/.sig/config.yaml
+                    <CodeBlock lang="yaml">{`# ~/.sig/config.yaml
 
-mode: browser          # browser | browserless
-browserChannel: chrome # chrome | msedge | chromium（默认：chromium）
+mode: browser                    # browser | browserless
+
+browser:
+  channel: msedge                # msedge | chrome | chromium
+  browserDataDir: ~/.sig/browser-data
+  headlessTimeout: 30000
+  visibleTimeout: 120000
+  waitUntil: load
+
+storage:
+  credentialsDir: ~/.sig/credentials
 
 providers:
   my-jira:
-    url: https://jira.example.com
-    strategy: cookie
-    requiredCookies:
-      - SESSION`}</CodeBlock>
+    domains: [jira.example.com]
+    entryUrl: https://jira.example.com/
+    strategy: browser
+    ttl: "10d"
+    extract:
+      - { from: cookies, name: session, key: "*" }
+    apply:
+      - { in: header, name: Cookie, value: "\${session}" }`}</CodeBlock>
 
                     <SectionHeading id="config-providers" level={2}>
-                        提供者配置选项
+                        提供者配置
                     </SectionHeading>
-                    <CodeBlock lang="bash">{`providers:
+                    <P>
+                        每个提供者声明<strong>提取什么</strong>（cookie、localStorage 值等）
+                        以及<strong>如何应用</strong>到 HTTP 请求中。所有访问方式——
+                        <Code>sig get</Code>、<Code>sig request</Code>、<Code>sig run</Code>、
+                        <Code>sig proxy</Code>——使用相同的配置。
+                    </P>
+                    <CodeBlock lang="yaml">{`providers:
   <provider-id>:
-    url: <base-url>              # 必填：要匹配的 URL
-    strategy: cookie|oauth2|api-token|basic
-    requiredCookies:             # 等待这些 cookie 出现
-      - SESSION
-    cookiePaths:                 # 子路径 cookie 的额外查询路径
-      - /wiki
-    forceVisible: true           # 始终打开可视浏览器（默认：false）
-    waitUntil: networkidle       # 加载事件：load|domcontentloaded|networkidle
-    ttl: 8h                      # 凭证 TTL（例如 1h、8h、7d）`}</CodeBlock>
+    domains: [example.com]       # 此提供者匹配的域名
+    entryUrl: https://...        # sig login 时打开的 URL
+    strategy: browser            # browser | prompt
+    ttl: "12h"                   # 凭证有效期（如 12h、7d）
+    required: [session.MY_COOKIE]  # 完成性检查（可选）
+    cookiePaths: ["/wiki"]       # 子路径 cookie 的额外路径（可选）
+    extract:
+      - from: cookies            # cookies | localStorage | eval
+        name: session            # 存储为此名称
+        key: "*"                 # 提取哪些值（* = 全部，或 glob 模式）
+    apply:
+      - in: header               # header | body | query
+        name: Cookie             # HTTP 头/字段名
+        value: "\${session}"      # 引用已提取名称的模板`}</CodeBlock>
+
+                    <SectionHeading id="config-extract" level={2}>
+                        extract[] 规则
+                    </SectionHeading>
+                    <P>
+                        每条规则告诉 sigcli 登录后从浏览器中提取什么。三个字段：
+                        <Code>from</Code>（从哪里）、<Code>name</Code>（存储为）、
+                        <Code>key</Code>（提取什么）。
+                    </P>
+                    <CodeBlock lang="yaml">{`extract:
+  # 域名下的所有 cookie
+  - { from: cookies, name: session, key: "*" }
+
+  # 特定的 localStorage 值（点路径访问 JSON）
+  - { from: localStorage, name: xoxc-token, key: "localConfig_v2.teams.E7RBBBXHB.token" }
+
+  # MSAL OAuth2 令牌（glob 模式）
+  - { from: localStorage, name: access_token, key: "*|accesstoken|*graph.microsoft.com*" }`}</CodeBlock>
+
+                    <SectionHeading id="config-apply" level={2}>
+                        apply[] 规则
+                    </SectionHeading>
+                    <P>
+                        每条规则告诉 sigcli 如何将提取的值注入 HTTP 请求。模板变量
+                        （<Code>{'${name}'}</Code>）引用 extract 规则中的 <Code>name</Code> 字段。
+                    </P>
+                    <CodeBlock lang="yaml">{`apply:
+  # 注入所有 cookie 为 Cookie 头
+  - { in: header, name: Cookie, value: "\${session}" }
+
+  # 注入 Bearer 令牌
+  - { in: header, name: Authorization, value: "Bearer \${access_token}" }
+
+  # 注入到查询字符串
+  - { in: query, name: api_key, value: "\${api_key}" }`}</CodeBlock>
+
+                    <P>
+                        <strong>实际示例：</strong>
+                    </P>
+                    <CodeBlock lang="yaml">{`# 简单 cookie 站点（Jira、Wiki 等）
+my-jira:
+  domains: [jira.example.com]
+  entryUrl: https://jira.example.com/
+  strategy: browser
+  ttl: "10d"
+  extract:
+    - { from: cookies, name: session, key: "*" }
+  apply:
+    - { in: header, name: Cookie, value: "\${session}" }
+
+# OAuth2 通过 localStorage（MS Teams、Graph API）
+ms-teams:
+  domains: [teams.cloud.microsoft]
+  entryUrl: https://teams.cloud.microsoft/v2/
+  strategy: browser
+  required: [access_token]
+  extract:
+    - { from: localStorage, name: access_token, key: "*|accesstoken|*ic3.teams.office.com*" }
+  apply:
+    - { in: header, name: Authorization, value: "Bearer \${access_token}" }
+
+# 多重提取（Slack：cookie + localStorage 令牌）
+app-slack:
+  domains: [mycompany.slack.com]
+  entryUrl: https://app.slack.com/client/E7RBBBXHB
+  strategy: browser
+  ttl: "7d"
+  required: [session.d, xoxc-token]
+  extract:
+    - { from: cookies, name: session, key: "*" }
+    - { from: localStorage, name: xoxc-token, key: "localConfig_v2.teams.E7RBBBXHB.token" }
+  apply:
+    - { in: header, name: Cookie, value: "\${session}" }
+    - { in: header, name: Authorization, value: "Bearer \${xoxc-token}" }`}</CodeBlock>
                 </>
             ),
             aside: (
                 <P>
-                    提供者 ID（例如 <Code>my-jira</Code>）是在所有命令中引用提供者的方式。 当你向{' '}
+                    提供者 ID（例如 <Code>my-jira</Code>）是在所有命令中引用提供者的方式。当你向{' '}
                     <Code>sig login</Code> 传入 URL 时，它会自动创建提供者条目；使用{' '}
                     <Code>--as</Code> 设置自定义 ID。
-                </P>
-            ),
-        },
-
-        /* ── 认证策略 ── */
-        {
-            content: (
-                <>
-                    <SectionHeading id="strategies" level={1}>
-                        认证策略
-                    </SectionHeading>
-                    <P>
-                        策略实现 <Code>IAuthStrategy</Code> 接口：<Code>validate</Code>、
-                        <Code>authenticate</Code>、<Code>refresh</Code> 和{' '}
-                        <Code>applyToRequest</Code>。Sigcli 内置四种策略，自动检测会选择正确的策略；
-                        使用 <Code>--strategy</Code> 覆盖。
-                    </P>
-
-                    <SectionHeading id="strat-cookie" level={3}>
-                        cookie
-                    </SectionHeading>
-                    <P>
-                        从真实浏览器会话中捕获 cookie。适合任何 等 SSO
-                        网站或多步骤登录（二维码、SAML、MFA）。 支持 <Code>forceVisible</Code>、
-                        <Code>waitUntil</Code>、<Code>requiredCookies</Code> 和{' '}
-                        <Code>cookiePaths</Code>（用于在子路径如 <Code>/wiki</Code> 上设置认证
-                        cookie 的站点）。
-                    </P>
-                    <CodeBlock lang="bash">{`sig login https://jira.example.com --strategy cookie`}</CodeBlock>
-
-                    <SectionHeading id="strat-oauth2" level={3}>
-                        oauth2
-                    </SectionHeading>
-                    <P>
-                        监视出站请求中的 <Code>Authorization: Bearer ...</Code>，或从 OAuth
-                        重定向中解码 JWT。存在刷新令牌时自动刷新。
-                    </P>
-                    <CodeBlock lang="bash">{`sig login https://jira.example.com --strategy oauth2`}</CodeBlock>
-
-                    <SectionHeading id="strat-api-token" level={3}>
-                        api-token
-                    </SectionHeading>
-                    <P>适用于你已有的静态 API 密钥或个人访问令牌。无需浏览器——非常适合 CI/CD。</P>
-                    <CodeBlock lang="bash">{`sig login https://jira.example.com --token <your-pat>`}</CodeBlock>
-
-                    <SectionHeading id="strat-basic" level={3}>
-                        basic
-                    </SectionHeading>
-                    <P>
-                        用户名和密码，在请求时编码为 Basic 认证头。明文密码仅存储在{' '}
-                        <Code>~/.sig/credentials/</Code> 下的密封凭证文件中。
-                    </P>
-                    <CodeBlock lang="bash">{`sig login https://jira.example.com --username alice --password hunter2`}</CodeBlock>
-                </>
-            ),
-            aside: (
-                <P>
-                    策略返回 <Code>{'Result<T, AuthError>'}</Code>——对于预期失败从不抛出异常。
-                    通过实现 <Code>IAuthStrategyFactory</Code> 构建自定义策略。
                 </P>
             ),
         },
@@ -1328,37 +1364,36 @@ providers:
                         浏览器适配器
                     </SectionHeading>
                     <P>
-                        Sigcli 通过 <Code>IBrowserAdapter</Code> 抽象浏览器——三个小类：
-                        <strong>Adapter → Session → Page</strong>。内置两个适配器。
+                        Sigcli 使用真实浏览器进行 SSO 登录。内置两个适配器：
                     </P>
 
                     <List>
                         <Li>
                             <strong>playwright</strong>——默认。使用 <Code>playwright-core</Code>{' '}
-                            配合 Chromium、Chrome 或 Edge。支持无头和可视模式。浏览器 SSO 必需。
+                            配合 Chromium、Chrome 或 Edge。支持无头和可视模式。
                         </Li>
                         <Li>
-                            <strong>chrome-cdp</strong>——通过 Chrome DevTools Protocol 连接到现有
-                            Chrome 实例。适用于附加到已打开的浏览器而无需启动新实例的场景。
+                            <strong>chrome-cdp</strong>——通过 CDP 连接到现有 Chrome/Edge 实例。
+                            适用于复用已打开的浏览器会话。
                         </Li>
                     </List>
 
                     <P>
                         <Code>sig init --remote</Code> 将 Sigcli 置于 <Code>browserless</Code>{' '}
-                        模式，使用 <Code>NullBrowserAdapter</Code>——令牌/cookie/basic 登录仍然有效，
-                        但 SSO 流程被禁用。
+                        模式——令牌/cookie 登录仍然有效，但浏览器 SSO 流程被禁用。使用{' '}
+                        <Code>sig sync pull</Code> 从有浏览器的机器获取凭证。
                     </P>
-                    <CodeBlock lang="bash">{`# 选择哪个适配器？
-# → 带显示器的开发笔记本：playwright（默认）
+                    <CodeBlock lang="bash">{`# 选择哪种模式？
+# → 带显示器的开发笔记本：browser（默认）
 # → 附加到已打开的 Chrome：chrome-cdp
 # → 无头 CI / 远程服务器：browserless 模式 + sig sync pull`}</CodeBlock>
                 </>
             ),
             aside: (
                 <P>
-                    通过实现 <Code>IBrowserAdapter</Code>、<Code>IBrowserSession</Code> 和{' '}
-                    <Code>IBrowserPage</Code> 编写自定义适配器。延迟导入浏览器库，并在导入失败时抛出{' '}
-                    <Code>BrowserLaunchError</Code>，以便 <Code>sig doctor</Code> 诊断缺失的依赖。
+                    在配置中设置 <Code>browser.channel</Code> 为 <Code>msedge</Code>、
+                    <Code>chrome</Code> 或 <Code>chromium</Code>。运行 <Code>sig doctor</Code>{' '}
+                    验证浏览器是否被正确检测。
                 </P>
             ),
         },
@@ -1494,7 +1529,7 @@ sig status my-jira --format json
                     </SectionHeading>
                     <List>
                         <Li>
-                            <Code>sigcli-auth</Code> — 认证指南：策略选择、命令参考、错误恢复。
+                            <Code>sigcli-auth</Code> — 认证指南：配置参考、命令参考、错误恢复。
                         </Li>
                         <Li>
                             <Code>outlook</Code> — 通过 Microsoft Graph
@@ -1507,7 +1542,7 @@ sig status my-jira --format json
                         </Li>
                         <Li>
                             <Code>slack</Code> — 频道、消息、搜索、表情。使用 <Code>app-slack</Code>{' '}
-                            提供者（cookie + localStorage）。
+                            提供者。
                         </Li>
                     </List>
 
@@ -1684,9 +1719,6 @@ sig watch start --interval 1h`}</CodeBlock>
                     </P>
                     <CodeBlock lang="bash">{`CREDENTIAL_EXPIRED        # 令牌/cookie 已过期，刷新失败
                           # 修复：sig logout <p> && sig login <url>
-
-CREDENTIAL_TYPE_MISMATCH  # 提供者的凭证类型错误
-                          # 修复：使用 --strategy <name> 重新登录
 
 REFRESH_FAILED            # OAuth2 刷新令牌被拒绝
                           # 修复：sig logout <p> && sig login <url>

--- a/website/src/content/docs.tsx
+++ b/website/src/content/docs.tsx
@@ -29,7 +29,7 @@ export const pageContent = {
     meta: {
         title: 'Sigcli Docs — Complete Reference',
         description:
-            'Complete documentation for Sigcli: getting started, commands reference, environment variables, configuration, strategies, browser adapters, SDK, AI agents, and remote sync.',
+            'Complete documentation for Sigcli: getting started, commands reference, environment variables, configuration, browser adapters, SDK, AI agents, and remote sync.',
     },
 
     toc: [
@@ -112,11 +112,16 @@ export const pageContent = {
             parent: '#configuration',
             prefix: '└ ',
         }),
-        tocItem('#strategies', 'Auth Strategies'),
-        tocItem('#strat-cookie', 'cookie', { level: 1, parent: '#strategies', prefix: '├ ' }),
-        tocItem('#strat-oauth2', 'oauth2', { level: 1, parent: '#strategies', prefix: '├ ' }),
-        tocItem('#strat-api-token', 'api-token', { level: 1, parent: '#strategies', prefix: '├ ' }),
-        tocItem('#strat-basic', 'basic', { level: 1, parent: '#strategies', prefix: '└ ' }),
+        tocItem('#config-extract', 'extract[] rules', {
+            level: 1,
+            parent: '#configuration',
+            prefix: '├ ',
+        }),
+        tocItem('#config-apply', 'apply[] rules', {
+            level: 1,
+            parent: '#configuration',
+            prefix: '└ ',
+        }),
         tocItem('#browser-adapters', 'Browser Adapters'),
         tocItem('#sdk', 'SDK'),
         tocItem('#sdk-ts', 'TypeScript SDK', { level: 1, parent: '#sdk', prefix: '├ ' }),
@@ -720,12 +725,6 @@ sig login https://jira.example.com --cookie "SESSION=abc123; csrf_token=xyz"
 # HTTP Basic auth
 sig login https://jira.example.com --username alice --password hunter2
 
-# Force a specific strategy
-sig login https://jira.example.com --strategy cookie
-sig login https://jira.example.com --strategy oauth2
-sig login https://jira.example.com --strategy api-token
-sig login https://jira.example.com --strategy basic
-
 # Skip stored credential check, go straight to browser
 sig login https://jira.example.com --force`}</CodeBlock>
 
@@ -870,28 +869,25 @@ curl https://jira.example.com/api/me   # credentials injected automatically`}</C
                         vars.
                     </P>
                     <P>
-                        <strong>Inject rules:</strong> For APIs that need credentials in
-                        non-standard locations (body fields, query parameters, custom headers), add{' '}
-                        <Code>proxy.inject</Code> rules to the provider config. The proxy and{' '}
-                        <Code>sig request</Code> apply these rules after standard credential
-                        headers.
+                        <strong>Credential injection:</strong> The proxy uses the provider's{' '}
+                        <Code>apply[]</Code> rules to inject credentials into requests. These
+                        same rules are used by <Code>sig request</Code>, <Code>sig get</Code>,
+                        and <Code>sig run</Code> — one config for all access methods.
                     </P>
-                    <CodeBlock lang="yaml">{`# Example: inject xoxc token from localStorage as form body parameter
+                    <CodeBlock lang="yaml">{`# Example: inject both cookie and bearer token
 providers:
   app-slack:
-    # ... domains, strategy, etc.
-    proxy:
-      inject:
-        - in: body           # header | body | query
-          action: set         # set | append | remove
-          name: token
-          from: credential.localStorage.xoxc-token`}</CodeBlock>
+    strategy: browser
+    extract:
+      - { from: cookies, name: session, key: "*" }
+      - { from: localStorage, name: xoxc-token, key: "localConfig_v2.teams.*.token" }
+    apply:
+      - { in: header, name: Cookie, value: "\${session}" }
+      - { in: header, name: Authorization, value: "Bearer \${xoxc-token}" }`}</CodeBlock>
                     <P>
-                        The <Code>from</Code> field resolves paths against the stored credential:{' '}
-                        <Code>credential.cookies</Code>, <Code>credential.accessToken</Code>,{' '}
-                        <Code>credential.localStorage.&lt;key&gt;</Code>. Body injection supports{' '}
-                        <Code>application/json</Code> and{' '}
-                        <Code>application/x-www-form-urlencoded</Code> content types.
+                        The <Code>apply[]</Code> rules support injection into headers, body
+                        fields, and query parameters. Template variables (<Code>{'${name}'}</Code>)
+                        reference extracted credential names.
                     </P>
                     <P>
                         <strong>Auto-refresh:</strong> The proxy daemon runs the watch/refresh loop
@@ -1015,35 +1011,136 @@ elif auth_type == "bearer":
                     </SectionHeading>
                     <P>
                         Sigcli reads <Code>~/.sig/config.yaml</Code>. Run <Code>sig init</Code> to
-                        generate a starter file. The top-level keys are <Code>mode</Code> and{' '}
-                        <Code>providers</Code>.
+                        generate a starter file. Providers are auto-created by{' '}
+                        <Code>sig login &lt;url&gt;</Code>, or you can add them manually for
+                        fine-grained control over extraction and injection rules.
                     </P>
-                    <CodeBlock lang="bash">{`# ~/.sig/config.yaml
+                    <CodeBlock lang="yaml">{`# ~/.sig/config.yaml
 
-mode: browser          # browser | browserless
-browserChannel: chrome # chrome | msedge | chromium (default: chromium)
+mode: browser                    # browser | browserless
+
+browser:
+  channel: msedge                # msedge | chrome | chromium
+  browserDataDir: ~/.sig/browser-data
+  headlessTimeout: 30000
+  visibleTimeout: 120000
+  waitUntil: load
+
+storage:
+  credentialsDir: ~/.sig/credentials
 
 providers:
   my-jira:
-    url: https://jira.example.com
-    strategy: cookie
-    requiredCookies:
-      - SESSION`}</CodeBlock>
+    domains: [jira.example.com]
+    entryUrl: https://jira.example.com/
+    strategy: browser
+    ttl: "10d"
+    extract:
+      - { from: cookies, name: session, key: "*" }
+    apply:
+      - { in: header, name: Cookie, value: "\${session}" }`}</CodeBlock>
 
                     <SectionHeading id="config-providers" level={2}>
-                        Provider config options
+                        Provider config
                     </SectionHeading>
-                    <CodeBlock lang="bash">{`providers:
+                    <P>
+                        Every provider declares <strong>what to extract</strong> (cookies,
+                        localStorage values, etc.) and <strong>how to apply</strong> them to HTTP
+                        requests. This is the same config used by all access methods — {' '}
+                        <Code>sig get</Code>, <Code>sig request</Code>, <Code>sig run</Code>, and{' '}
+                        <Code>sig proxy</Code>.
+                    </P>
+                    <CodeBlock lang="yaml">{`providers:
   <provider-id>:
-    url: <base-url>              # required: URL to match
-    strategy: cookie|oauth2|api-token|basic
-    requiredCookies:             # wait until these cookies appear
-      - SESSION
-    cookiePaths:                 # extra paths for path-scoped cookies
-      - /wiki
-    forceVisible: true           # always open visible browser (default: false)
-    waitUntil: networkidle       # load event: load|domcontentloaded|networkidle
-    ttl: 8h                      # credential TTL (e.g. 1h, 8h, 7d)`}</CodeBlock>
+    domains: [example.com]       # domains this provider matches
+    entryUrl: https://...        # URL opened during sig login
+    strategy: browser            # browser | prompt
+    ttl: "12h"                   # credential lifetime (e.g. 12h, 7d)
+    required: [session.MY_COOKIE]  # completion check (optional)
+    cookiePaths: ["/wiki"]       # extra paths for path-scoped cookies (optional)
+    extract:
+      - from: cookies            # cookies | localStorage | eval
+        name: session            # stored under this name
+        key: "*"                 # which values (* = all, or glob pattern)
+    apply:
+      - in: header               # header | body | query
+        name: Cookie             # HTTP header/field name
+        value: "\${session}"      # template referencing extracted names`}</CodeBlock>
+
+                    <SectionHeading id="config-extract" level={2}>
+                        extract[] rules
+                    </SectionHeading>
+                    <P>
+                        Each entry tells sigcli what to pull from the browser after login.
+                        Three fields: <Code>from</Code> (where), <Code>name</Code> (store as),
+                        and <Code>key</Code> (what to grab).
+                    </P>
+                    <CodeBlock lang="yaml">{`extract:
+  # All cookies from the domain
+  - { from: cookies, name: session, key: "*" }
+
+  # A specific localStorage value (dot-path into JSON)
+  - { from: localStorage, name: xoxc-token, key: "localConfig_v2.teams.E7RBBBXHB.token" }
+
+  # MSAL OAuth2 token from localStorage (glob pattern)
+  - { from: localStorage, name: access_token, key: "*|accesstoken|*graph.microsoft.com*" }`}</CodeBlock>
+
+                    <SectionHeading id="config-apply" level={2}>
+                        apply[] rules
+                    </SectionHeading>
+                    <P>
+                        Each entry tells sigcli how to inject extracted values into HTTP requests.
+                        Template variables (<Code>{'${name}'}</Code>) reference the <Code>name</Code>{' '}
+                        field from your extract rules.
+                    </P>
+                    <CodeBlock lang="yaml">{`apply:
+  # Inject all cookies as a Cookie header
+  - { in: header, name: Cookie, value: "\${session}" }
+
+  # Inject a bearer token
+  - { in: header, name: Authorization, value: "Bearer \${access_token}" }
+
+  # Inject into query string
+  - { in: query, name: api_key, value: "\${api_key}" }`}</CodeBlock>
+
+                    <P>
+                        <strong>Real-world examples:</strong>
+                    </P>
+                    <CodeBlock lang="yaml">{`# Simple cookie site (Jira, Wiki, etc.)
+my-jira:
+  domains: [jira.example.com]
+  entryUrl: https://jira.example.com/
+  strategy: browser
+  ttl: "10d"
+  extract:
+    - { from: cookies, name: session, key: "*" }
+  apply:
+    - { in: header, name: Cookie, value: "\${session}" }
+
+# OAuth2 via localStorage (MS Teams, Graph API)
+ms-teams:
+  domains: [teams.cloud.microsoft]
+  entryUrl: https://teams.cloud.microsoft/v2/
+  strategy: browser
+  required: [access_token]
+  extract:
+    - { from: localStorage, name: access_token, key: "*|accesstoken|*ic3.teams.office.com*" }
+  apply:
+    - { in: header, name: Authorization, value: "Bearer \${access_token}" }
+
+# Multi-extraction (Slack: cookies + localStorage token)
+app-slack:
+  domains: [mycompany.slack.com]
+  entryUrl: https://app.slack.com/client/E7RBBBXHB
+  strategy: browser
+  ttl: "7d"
+  required: [session.d, xoxc-token]
+  extract:
+    - { from: cookies, name: session, key: "*" }
+    - { from: localStorage, name: xoxc-token, key: "localConfig_v2.teams.E7RBBBXHB.token" }
+  apply:
+    - { in: header, name: Cookie, value: "\${session}" }
+    - { in: header, name: Authorization, value: "Bearer \${xoxc-token}" }`}</CodeBlock>
                 </>
             ),
             aside: (
@@ -1051,71 +1148,6 @@ providers:
                     Provider IDs (e.g. <Code>my-jira</Code>) are how you reference a provider in all
                     commands. <Code>sig login</Code> auto-creates a provider entry when you pass a
                     URL; use <Code>--as</Code> to set a custom ID.
-                </P>
-            ),
-        },
-
-        /* ── Auth Strategies ── */
-        {
-            content: (
-                <>
-                    <SectionHeading id="strategies" level={1}>
-                        Auth Strategies
-                    </SectionHeading>
-                    <P>
-                        A strategy implements <Code>IAuthStrategy</Code>: <Code>validate</Code>,{' '}
-                        <Code>authenticate</Code>, <Code>refresh</Code>, and{' '}
-                        <Code>applyToRequest</Code>. Sigcli ships four built-in strategies.
-                        Auto-detection picks the right one; use <Code>--strategy</Code> to override.
-                    </P>
-
-                    <SectionHeading id="strat-cookie" level={3}>
-                        cookie
-                    </SectionHeading>
-                    <P>
-                        Captures the cookie jar from a real browser session. Best for SSO sites like
-                        Any site with multi-step login (QR codes, SAML, MFA). Supports{' '}
-                        <Code>forceVisible</Code>, <Code>waitUntil</Code>,{' '}
-                        <Code>requiredCookies</Code>, and <Code>cookiePaths</Code> (for sites that
-                        set auth cookies on a sub-path like <Code>/wiki</Code>).
-                    </P>
-                    <CodeBlock lang="bash">{`sig login https://jira.example.com --strategy cookie`}</CodeBlock>
-
-                    <SectionHeading id="strat-oauth2" level={3}>
-                        oauth2
-                    </SectionHeading>
-                    <P>
-                        Watches for <Code>Authorization: Bearer ...</Code> on outgoing requests, or
-                        decodes a JWT from an OAuth redirect. Auto-refreshes when a refresh token is
-                        present.
-                    </P>
-                    <CodeBlock lang="bash">{`sig login https://jira.example.com --strategy oauth2`}</CodeBlock>
-
-                    <SectionHeading id="strat-api-token" level={3}>
-                        api-token
-                    </SectionHeading>
-                    <P>
-                        For static API keys or Personal Access Tokens you already have. No browser
-                        needed — ideal for CI/CD.
-                    </P>
-                    <CodeBlock lang="bash">{`sig login https://jira.example.com --token <your-pat>`}</CodeBlock>
-
-                    <SectionHeading id="strat-basic" level={3}>
-                        basic
-                    </SectionHeading>
-                    <P>
-                        Username and password, encoded to a Basic auth header at request time. The
-                        plaintext password is stored only in the sealed credential file under{' '}
-                        <Code>~/.sig/credentials/</Code>.
-                    </P>
-                    <CodeBlock lang="bash">{`sig login https://jira.example.com --username alice --password hunter2`}</CodeBlock>
-                </>
-            ),
-            aside: (
-                <P>
-                    Strategies return <Code>{'Result<T, AuthError>'}</Code> — never throw for
-                    expected failures. Callers check <Code>isOk()</Code> / <Code>isErr()</Code>.
-                    Build custom strategies by implementing <Code>IAuthStrategyFactory</Code>.
                 </P>
             ),
         },
@@ -1128,41 +1160,37 @@ providers:
                         Browser Adapters
                     </SectionHeading>
                     <P>
-                        Sigcli abstracts the browser behind <Code>IBrowserAdapter</Code> — three
-                        small classes: <strong>Adapter → Session → Page</strong>. Two adapters ship
-                        in the box.
+                        Sigcli uses a real browser for SSO login. Two adapters are available:
                     </P>
 
                     <List>
                         <Li>
                             <strong>playwright</strong> — Default. Uses <Code>playwright-core</Code>{' '}
                             with Chromium, Chrome, or Edge. Supports headless and visible modes.
-                            Required for browser SSO.
                         </Li>
                         <Li>
-                            <strong>chrome-cdp</strong> — Connects to an existing Chrome instance
-                            via the Chrome DevTools Protocol. Useful when you want to attach to your
-                            already-open browser without launching a new one.
+                            <strong>chrome-cdp</strong> — Connects to an existing Chrome/Edge instance
+                            via CDP. Useful when you want to reuse your already-open browser session.
                         </Li>
                     </List>
 
                     <P>
                         <Code>sig init --remote</Code> puts Sigcli into <Code>browserless</Code>{' '}
-                        mode, where the <Code>NullBrowserAdapter</Code> is used — token/cookie/basic
-                        login still works, but SSO flows are disabled.
+                        mode — token/cookie login still works, but browser-based SSO flows are
+                        disabled. Use <Code>sig sync pull</Code> to get credentials from a machine
+                        that has a browser.
                     </P>
-                    <CodeBlock lang="bash">{`# Which adapter to use?
-# → Developer laptop with display: playwright (default)
+                    <CodeBlock lang="bash">{`# Which mode to use?
+# → Developer laptop with display: browser (default)
 # → Attach to open Chrome: chrome-cdp
 # → Headless CI / remote server: browserless mode + sig sync pull`}</CodeBlock>
                 </>
             ),
             aside: (
                 <P>
-                    Write a custom adapter by implementing <Code>IBrowserAdapter</Code>,{' '}
-                    <Code>IBrowserSession</Code>, and <Code>IBrowserPage</Code>. Lazy-import the
-                    browser library and throw <Code>BrowserLaunchError</Code> on import failure so{' '}
-                    <Code>sig doctor</Code> can diagnose what's missing.
+                    Set <Code>browser.channel</Code> in config to <Code>msedge</Code>,{' '}
+                    <Code>chrome</Code>, or <Code>chromium</Code>. Run <Code>sig doctor</Code>{' '}
+                    to verify your browser is detected correctly.
                 </P>
             ),
         },
@@ -1305,12 +1333,12 @@ sig status my-jira --format json
                     </SectionHeading>
                     <List>
                         <Li>
-                            <Code>sigcli-auth</Code> — Authentication guide. Strategy selection,
+                            <Code>sigcli-auth</Code> — Authentication guide. Config reference,
                             command reference, error recovery. Bundled with every install.
                         </Li>
                         <Li>
                             <Code>outlook</Code> — Read, send, search, reply, forward emails via
-                            Microsoft Graph. Uses <Code>ms-graph</Code> provider (OAuth2).
+                            Microsoft Graph. Uses <Code>ms-graph</Code> provider.
                         </Li>
                         <Li>
                             <Code>msteams</Code> — Messages, conversations, people search, calendar
@@ -1319,7 +1347,7 @@ sig status my-jira --format json
                         </Li>
                         <Li>
                             <Code>slack</Code> — Channels, messages, search, reactions via Slack Web
-                            API. Uses <Code>app-slack</Code> provider (cookie + localStorage).
+                            API. Uses <Code>app-slack</Code> provider.
                         </Li>
                     </List>
                     <P>
@@ -1554,9 +1582,6 @@ sig watch start --interval 1h`}</CodeBlock>
                     </P>
                     <CodeBlock lang="bash">{`CREDENTIAL_EXPIRED        # token/cookie expired, refresh failed
                           # fix: sig logout <p> && sig login <url>
-
-CREDENTIAL_TYPE_MISMATCH  # wrong credential type for provider
-                          # fix: re-login with --strategy <name>
 
 REFRESH_FAILED            # OAuth2 refresh token rejected
                           # fix: sig logout <p> && sig login <url>

--- a/website/src/content/docs.tsx
+++ b/website/src/content/docs.tsx
@@ -870,9 +870,9 @@ curl https://jira.example.com/api/me   # credentials injected automatically`}</C
                     </P>
                     <P>
                         <strong>Credential injection:</strong> The proxy uses the provider's{' '}
-                        <Code>apply[]</Code> rules to inject credentials into requests. These
-                        same rules are used by <Code>sig request</Code>, <Code>sig get</Code>,
-                        and <Code>sig run</Code> — one config for all access methods.
+                        <Code>apply[]</Code> rules to inject credentials into requests. These same
+                        rules are used by <Code>sig request</Code>, <Code>sig get</Code>, and{' '}
+                        <Code>sig run</Code> — one config for all access methods.
                     </P>
                     <CodeBlock lang="yaml">{`# Example: inject both cookie and bearer token
 providers:
@@ -885,8 +885,8 @@ providers:
       - { in: header, name: Cookie, value: "\${session}" }
       - { in: header, name: Authorization, value: "Bearer \${xoxc-token}" }`}</CodeBlock>
                     <P>
-                        The <Code>apply[]</Code> rules support injection into headers, body
-                        fields, and query parameters. Template variables (<Code>{'${name}'}</Code>)
+                        The <Code>apply[]</Code> rules support injection into headers, body fields,
+                        and query parameters. Template variables (<Code>{'${name}'}</Code>)
                         reference extracted credential names.
                     </P>
                     <P>
@@ -1046,7 +1046,7 @@ providers:
                     <P>
                         Every provider declares <strong>what to extract</strong> (cookies,
                         localStorage values, etc.) and <strong>how to apply</strong> them to HTTP
-                        requests. This is the same config used by all access methods — {' '}
+                        requests. This is the same config used by all access methods —{' '}
                         <Code>sig get</Code>, <Code>sig request</Code>, <Code>sig run</Code>, and{' '}
                         <Code>sig proxy</Code>.
                     </P>
@@ -1071,9 +1071,9 @@ providers:
                         extract[] rules
                     </SectionHeading>
                     <P>
-                        Each entry tells sigcli what to pull from the browser after login.
-                        Three fields: <Code>from</Code> (where), <Code>name</Code> (store as),
-                        and <Code>key</Code> (what to grab).
+                        Each entry tells sigcli what to pull from the browser after login. Three
+                        fields: <Code>from</Code> (where), <Code>name</Code> (store as), and{' '}
+                        <Code>key</Code> (what to grab).
                     </P>
                     <CodeBlock lang="yaml">{`extract:
   # All cookies from the domain
@@ -1090,8 +1090,8 @@ providers:
                     </SectionHeading>
                     <P>
                         Each entry tells sigcli how to inject extracted values into HTTP requests.
-                        Template variables (<Code>{'${name}'}</Code>) reference the <Code>name</Code>{' '}
-                        field from your extract rules.
+                        Template variables (<Code>{'${name}'}</Code>) reference the{' '}
+                        <Code>name</Code> field from your extract rules.
                     </P>
                     <CodeBlock lang="yaml">{`apply:
   # Inject all cookies as a Cookie header
@@ -1159,9 +1159,7 @@ app-slack:
                     <SectionHeading id="browser-adapters" level={1}>
                         Browser Adapters
                     </SectionHeading>
-                    <P>
-                        Sigcli uses a real browser for SSO login. Two adapters are available:
-                    </P>
+                    <P>Sigcli uses a real browser for SSO login. Two adapters are available:</P>
 
                     <List>
                         <Li>
@@ -1169,8 +1167,9 @@ app-slack:
                             with Chromium, Chrome, or Edge. Supports headless and visible modes.
                         </Li>
                         <Li>
-                            <strong>chrome-cdp</strong> — Connects to an existing Chrome/Edge instance
-                            via CDP. Useful when you want to reuse your already-open browser session.
+                            <strong>chrome-cdp</strong> — Connects to an existing Chrome/Edge
+                            instance via CDP. Useful when you want to reuse your already-open
+                            browser session.
                         </Li>
                     </List>
 
@@ -1189,8 +1188,8 @@ app-slack:
             aside: (
                 <P>
                     Set <Code>browser.channel</Code> in config to <Code>msedge</Code>,{' '}
-                    <Code>chrome</Code>, or <Code>chromium</Code>. Run <Code>sig doctor</Code>{' '}
-                    to verify your browser is detected correctly.
+                    <Code>chrome</Code>, or <Code>chromium</Code>. Run <Code>sig doctor</Code> to
+                    verify your browser is detected correctly.
                 </P>
             ),
         },

--- a/website/src/content/en.tsx
+++ b/website/src/content/en.tsx
@@ -256,10 +256,9 @@ $ sig request https://my-jira.example.com/rest/api/2/myself`}</CodeBlock>
                             way to give an agent access to a single service.
                         </Li>
                         <Li>
-                            <strong>Declarative config</strong> — define{' '}
-                            <Code>extract[]</Code> rules (cookies, localStorage, tokens) and{' '}
-                            <Code>apply[]</Code> rules (headers, body, query) per provider. One config
-                            for all access methods.
+                            <strong>Declarative config</strong> — define <Code>extract[]</Code>{' '}
+                            rules (cookies, localStorage, tokens) and <Code>apply[]</Code> rules
+                            (headers, body, query) per provider. One config for all access methods.
                         </Li>
                         <Li>
                             <strong>Encrypted at rest</strong> — AES-256-GCM. Every credential

--- a/website/src/content/en.tsx
+++ b/website/src/content/en.tsx
@@ -187,9 +187,13 @@ curl https://my-jira.example.com/rest/api/2/myself`}</CodeBlock>
                     </P>
                     <CodeBlock lang="yaml">{`providers:
   my-jira:
-    url: https://my-jira.example.com
-    strategy: cookie
-    requiredCookies: [SESSION]`}</CodeBlock>
+    domains: [my-jira.example.com]
+    entryUrl: https://my-jira.example.com/
+    strategy: browser
+    extract:
+      - { from: cookies, name: session, key: "*" }
+    apply:
+      - { in: header, name: Cookie, value: "\${session}" }`}</CodeBlock>
 
                     <P>
                         <strong>
@@ -252,10 +256,10 @@ $ sig request https://my-jira.example.com/rest/api/2/myself`}</CodeBlock>
                             way to give an agent access to a single service.
                         </Li>
                         <Li>
-                            <strong>4 auth strategies</strong> — <Code>cookie</Code> (browser SSO),{' '}
-                            <Code>oauth2</Code> (Bearer/JWT), <Code>api-token</Code> (static keys),{' '}
-                            <Code>basic</Code> (username/password). Auto-detected or forced with{' '}
-                            <Code>--strategy</Code>.
+                            <strong>Declarative config</strong> — define{' '}
+                            <Code>extract[]</Code> rules (cookies, localStorage, tokens) and{' '}
+                            <Code>apply[]</Code> rules (headers, body, query) per provider. One config
+                            for all access methods.
                         </Li>
                         <Li>
                             <strong>Encrypted at rest</strong> — AES-256-GCM. Every credential

--- a/website/src/content/zh.tsx
+++ b/website/src/content/zh.tsx
@@ -229,9 +229,9 @@ $ sig run my-api -- node sync_data.js`}</CodeBlock>
                             AI 代理既能完成任务又无法窃取秘密。
                         </Li>
                         <Li>
-                            <strong>声明式配置</strong> — 每个提供者定义{' '}
-                            <Code>extract[]</Code> 规则（cookie、localStorage、令牌）和{' '}
-                            <Code>apply[]</Code> 规则（header、body、query）。一份配置适用所有访问方式。
+                            <strong>声明式配置</strong> — 每个提供者定义 <Code>extract[]</Code>{' '}
+                            规则（cookie、localStorage、令牌）和 <Code>apply[]</Code>{' '}
+                            规则（header、body、query）。一份配置适用所有访问方式。
                         </Li>
                         <Li>
                             <strong>加密存储</strong> — 所有凭证使用 AES-256-GCM

--- a/website/src/content/zh.tsx
+++ b/website/src/content/zh.tsx
@@ -173,21 +173,19 @@ sig proxy start`}</CodeBlock>
                     <CodeBlock lang="bash">{`# 步骤一：在 ~/.sig/config.yaml 中配置提供者
 providers:
   my-jira:
-    url: https://jira.example.com
-    strategy: cookie
-    requiredCookies: [SESSION]
-  grafana:
-    url: https://grafana.example.com
-    strategy: bearer
-  my-api:
-    url: https://api.example.com
-    strategy: api-token
+    domains: [jira.example.com]
+    entryUrl: https://jira.example.com/
+    strategy: browser
+    extract:
+      - { from: cookies, name: session, key: "*" }
+    apply:
+      - { in: header, name: Cookie, value: "\${session}" }
 
 # 步骤二：认证一次（浏览器 SSO，无头→可视自动切换）
 $ sig login https://jira.example.com
 → chromium 无头模式启动 …
 ⚠ 检测到登录页面 — 切换为可视模式
-✓ 捕获 4 个 cookie · 2 个 x-header
+✓ 捕获 4 个 cookie
 ✓ 加密存储至 ~/.sig/credentials/my-jira.json
 
 # 步骤三：AI 代理替你工作
@@ -231,10 +229,9 @@ $ sig run my-api -- node sync_data.js`}</CodeBlock>
                             AI 代理既能完成任务又无法窃取秘密。
                         </Li>
                         <Li>
-                            <strong>4 种认证策略</strong> — <Code>cookie</Code>（浏览器 SSO）、
-                            <Code>oauth2</Code>（Bearer/JWT）、<Code>api-token</Code>（静态密钥）、
-                            <Code>basic</Code>（用户名/密码）。自动检测或通过{' '}
-                            <Code>--strategy</Code> 手动指定。
+                            <strong>声明式配置</strong> — 每个提供者定义{' '}
+                            <Code>extract[]</Code> 规则（cookie、localStorage、令牌）和{' '}
+                            <Code>apply[]</Code> 规则（header、body、query）。一份配置适用所有访问方式。
                         </Li>
                         <Li>
                             <strong>加密存储</strong> — 所有凭证使用 AES-256-GCM


### PR DESCRIPTION
## Summary

- Rewrite all documentation, skill guides, and config templates to use the declarative config model (`strategy: browser` + `extract[]` + `apply[]`)
- Remove old strategy references (`cookie`/`oauth2`/`api-token`/`basic` with nested `config:`) across 16 files
- Add "How sig login works" explanation to sigcli-auth skill guide
- Focus docs on **how to use** rather than implementation details

## Changed files

**Skills (12 files):** sigcli-auth SKILL.md + config-template.yaml, outlook, x, youtube, hackernews, v2ex, bilibili, linkedin, reddit, zhihu

**Website (4 files):** docs.tsx, docs-zh.tsx, en.tsx, zh.tsx

**Root:** README.md

## Test plan

- [ ] Verify `grep -r "strategy: cookie\|strategy: oauth2" skills/ website/src/` returns nothing
- [ ] Website builds without new errors (`pnpm --filter website build`)
- [ ] Config template YAML is valid
- [ ] All skill SKILL.md files have correct extract/apply format