### PR TITLE
fix(cli): harden security and reliability across core subsystems

### DIFF
--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -70,6 +70,9 @@ export async function runLogin(
 
         if (status.valid) {
             process.stderr.write(` valid (skipping login)\n`);
+            if (provider.autoProvisioned) {
+                await addProviderToConfig(provider.id, toProviderEntry(provider));
+            }
             const credResult = await auth.getExtractedCreds(provider.id);
             if (isOk(credResult)) {
                 process.stdout.write(

--- a/cli/src/crypto/encryption.ts
+++ b/cli/src/crypto/encryption.ts
@@ -1,8 +1,13 @@
+import { execFile } from 'node:child_process';
 import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
 import fs from 'node:fs/promises';
+import { platform } from 'node:os';
 import path from 'node:path';
+import { promisify } from 'node:util';
 
 import { expandHome } from '../utils/path.js';
+
+const execFileAsync = promisify(execFile);
 
 export interface EncryptedEnvelope {
     version: 1;
@@ -65,6 +70,22 @@ export async function generateEncryptionKey(sigDir?: string): Promise<Buffer> {
     const key = randomBytes(32);
     const keyPath = path.join(dir, KEY_FILE);
     await fs.writeFile(keyPath, key.toString('base64') + '\n', { mode: 0o400 });
+
+    if (platform() === 'win32') {
+        const user = process.env.USERNAME ?? process.env.USER ?? '';
+        if (user) {
+            try {
+                await execFileAsync('icacls', [
+                    keyPath,
+                    '/inheritance:r',
+                    '/grant:r',
+                    `${user}:(R)`,
+                ]);
+            } catch {
+                // Best-effort on Windows
+            }
+        }
+    }
 
     return key;
 }

--- a/cli/src/proxy/proxy-server.ts
+++ b/cli/src/proxy/proxy-server.ts
@@ -299,11 +299,19 @@ async function handleConnectMitm(
         proxyReq.end();
     };
 
+    const MAX_HEADER_SIZE = 64 * 1024;
+    const parseTimeout = setTimeout(() => tlsServer.destroy(), 30_000);
+
     tlsServer.on('data', (chunk: Buffer) => {
         chunks.push(chunk);
         const accumulated = Buffer.concat(chunks);
 
         if (!headersParsed) {
+            if (accumulated.length > MAX_HEADER_SIZE) {
+                clearTimeout(parseTimeout);
+                tlsServer.destroy();
+                return;
+            }
             const headerEnd = accumulated.indexOf('\r\n\r\n');
             if (headerEnd === -1) return;
 
@@ -334,6 +342,7 @@ async function handleConnectMitm(
 
         const bodyReceived = accumulated.length - headerEndOffset;
         if (bodyReceived >= expectedBodyLen) {
+            clearTimeout(parseTimeout);
             tlsServer.removeAllListeners('data');
             const bodyBuf =
                 expectedBodyLen > 0

--- a/cli/src/proxy/proxy-state.ts
+++ b/cli/src/proxy/proxy-state.ts
@@ -4,8 +4,7 @@ import { join } from 'node:path';
 import { expandHome } from '../utils/path.js';
 
 const PROXY_DIR = expandHome('~/.sig/proxy');
-const PID_FILE = join(PROXY_DIR, 'proxy.pid');
-const PORT_FILE = join(PROXY_DIR, 'proxy.port');
+const STATE_FILE = join(PROXY_DIR, 'state.json');
 
 export interface ProxyState {
     pid: number;
@@ -14,23 +13,25 @@ export interface ProxyState {
 
 export async function writeState(state: ProxyState): Promise<void> {
     await mkdir(PROXY_DIR, { recursive: true });
-    await writeFile(PID_FILE, String(state.pid));
-    await writeFile(PORT_FILE, String(state.port));
+    await writeFile(STATE_FILE, JSON.stringify(state));
 }
 
 export async function readState(): Promise<ProxyState | null> {
     try {
-        const pid = parseInt(await readFile(PID_FILE, 'utf8'), 10);
-        const port = parseInt(await readFile(PORT_FILE, 'utf8'), 10);
-        if (isNaN(pid) || isNaN(port)) return null;
-        return { pid, port };
+        const raw = await readFile(STATE_FILE, 'utf8');
+        const state = JSON.parse(raw) as ProxyState;
+        if (!state.pid || !state.port) return null;
+        return state;
     } catch {
         return null;
     }
 }
 
 export async function clearState(): Promise<void> {
-    await Promise.allSettled([unlink(PID_FILE), unlink(PORT_FILE)]);
+    await unlink(STATE_FILE).catch(() => {});
+    // Clean up legacy files
+    await unlink(join(PROXY_DIR, 'proxy.pid')).catch(() => {});
+    await unlink(join(PROXY_DIR, 'proxy.port')).catch(() => {});
 }
 
 export async function isRunning(): Promise<boolean> {
@@ -40,6 +41,7 @@ export async function isRunning(): Promise<boolean> {
         process.kill(state.pid, 0);
         return true;
     } catch {
+        await clearState();
         return false;
     }
 }

--- a/cli/src/storage/directory-storage.ts
+++ b/cli/src/storage/directory-storage.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import lockfile from 'proper-lockfile';
@@ -192,14 +193,15 @@ export class DirectoryStorage implements IStorage {
     }
 
     private async atomicWrite(filePath: string, data: ProviderFile): Promise<void> {
+        const tmpPath = `${filePath}.tmp.${randomBytes(8).toString('hex')}`;
         try {
             const plaintext = JSON.stringify(data, null, 2);
             const envelope = encrypt(plaintext, this.encryptionKey);
             const content = JSON.stringify(envelope, null, 2);
-            const tmpPath = `${filePath}.tmp.${process.pid}`;
             await fs.writeFile(tmpPath, content, { encoding: 'utf-8', mode: 0o600 });
             await fs.rename(tmpPath, filePath);
         } catch (e: unknown) {
+            await fs.unlink(tmpPath).catch(() => {});
             throw new StorageError('write', (e as Error).message);
         }
     }

--- a/cli/src/strategies/browser/browser-strategy.ts
+++ b/cli/src/strategies/browser/browser-strategy.ts
@@ -191,10 +191,14 @@ export class BrowserStrategy implements IStrategy {
                 killProcess(browser);
             }
         };
+        const sigHandler = () => {
+            cleanup();
+            process.exit(130);
+        };
 
         process.on('exit', cleanup);
-        process.on('SIGINT', cleanup);
-        process.on('SIGTERM', cleanup);
+        process.on('SIGINT', sigHandler);
+        process.on('SIGTERM', sigHandler);
 
         let cdpClient: CdpWsClient | undefined;
 
@@ -213,8 +217,8 @@ export class BrowserStrategy implements IStrategy {
             cdpClient?.close();
             cleanup();
             process.removeListener('exit', cleanup);
-            process.removeListener('SIGINT', cleanup);
-            process.removeListener('SIGTERM', cleanup);
+            process.removeListener('SIGINT', sigHandler);
+            process.removeListener('SIGTERM', sigHandler);
         }
     }
 
@@ -280,6 +284,18 @@ export class BrowserStrategy implements IStrategy {
             await new Promise((r) => setTimeout(r, pollInterval));
         }
 
+        if (provider.required?.length) {
+            const missing = checkRequired(provider.required, credentials);
+            if (missing.length > 0) {
+                throw new BrowserTimeoutError(
+                    `extract (missing: ${missing.join(', ')})`,
+                    this.browserConfig.visibleTimeout,
+                );
+            }
+        }
+        if (Object.keys(credentials).length === 0) {
+            throw new BrowserTimeoutError('extract', this.browserConfig.visibleTimeout);
+        }
         return { credentials, expiresAt };
     }
 

--- a/cli/src/strategies/browser/cdp-ws.ts
+++ b/cli/src/strategies/browser/cdp-ws.ts
@@ -150,7 +150,17 @@ export function connectCdpWs(wsUrl: string): Promise<CdpWsClient> {
         ].join('\r\n');
 
         const socket = net.createConnection({ host, port });
-        socket.on('error', reject);
+
+        const UPGRADE_TIMEOUT = 10_000;
+        const upgradeTimer = setTimeout(() => {
+            socket.destroy();
+            reject(new Error('CDP WebSocket upgrade timed out'));
+        }, UPGRADE_TIMEOUT);
+
+        socket.on('error', (e) => {
+            clearTimeout(upgradeTimer);
+            reject(e);
+        });
 
         // State machine
         let upgradeComplete = false;
@@ -222,6 +232,7 @@ export function connectCdpWs(wsUrl: string): Promise<CdpWsClient> {
                 upgradeComplete = true;
                 // Everything after the headers is WS frame data
                 rawBuf = rawBuf.subarray(headerEnd + 4);
+                clearTimeout(upgradeTimer);
                 resolve(client);
                 // Fall through to process any WS frames already in buffer
             }

--- a/cli/src/sync/transports/ssh.ts
+++ b/cli/src/sync/transports/ssh.ts
@@ -77,7 +77,19 @@ export class SshTransport implements ISyncTransport {
     }
 
     private remotePath(remote: RemoteConfig): string {
-        return remote.path ?? DEFAULT_REMOTE_PATH;
+        const p = remote.path ?? DEFAULT_REMOTE_PATH;
+        if (!/^[a-zA-Z0-9._~/-]+$/.test(p)) {
+            throw new Error(
+                `Invalid remote path: "${p}" — only alphanumeric, ., _, ~, -, / allowed`,
+            );
+        }
+        return p;
+    }
+
+    private validateFilename(filename: string): void {
+        if (!/^[a-zA-Z0-9_.-]+\.json$/.test(filename)) {
+            throw new Error(`Invalid credential filename: "${filename}"`);
+        }
     }
 
     private remoteCredentialsPath(remote: RemoteConfig): string {
@@ -101,6 +113,7 @@ export class SshTransport implements ISyncTransport {
 
             for (const file of files) {
                 const filename = path.basename(file);
+                if (!/^[a-zA-Z0-9_.-]+\.json$/.test(filename)) continue;
                 try {
                     const { stdout: content } = await execFileAsync('ssh', [
                         ...this.sshArgs(remote),
@@ -134,6 +147,7 @@ export class SshTransport implements ISyncTransport {
 
     /** Read a single credential from remote */
     async readRemote(remote: RemoteConfig, filename: string): Promise<StoredCredential | null> {
+        this.validateFilename(filename);
         const target = this.remoteTarget(remote);
         const rpath = this.remoteCredentialsPath(remote);
 
@@ -171,6 +185,7 @@ export class SshTransport implements ISyncTransport {
         filename: string,
         stored: StoredCredential,
     ): Promise<void> {
+        this.validateFilename(filename);
         const rpath = this.remoteCredentialsPath(remote);
 
         const data = {


### PR DESCRIPTION
## Summary

- **SSH command injection**: Validate `remote.path` and filenames in SSH transport to reject shell metacharacters
- **Proxy DoS**: Add 64KB header size limit and 30s parse timeout to MITM handler
- **Signal handler leak**: Dedicated `sigHandler` that exits after cleanup; properly removed in `finally`
- **Timeout behavior**: Throw `BrowserTimeoutError` on polling timeout instead of returning empty credentials
- **Windows file permissions**: Use `icacls` to restrict encryption key access on Windows
- **Atomic write collision**: Use `crypto.randomBytes` for temp file suffix instead of predictable `process.pid`
- **WebSocket hang**: Add 10s upgrade timeout in CDP WebSocket client
- **Stale proxy state**: Consolidate to single `state.json`, auto-clear stale PID on `isRunning()` failure

## Test plan

- [x] `pnpm --filter @sigcli/cli build` compiles cleanly
- [x] `pnpm --filter @sigcli/cli test` — all 335 tests pass
- [ ] `sig login` with real provider (verify CDP flow + timeout behavior)
- [ ] `sig sync push` with valid remote path works; path with `;` is rejected
- [ ] `sig proxy start/stop` — state.json lifecycle correct
- [ ] Kill proxy with `kill -9`, then `sig proxy status` reports not running