### PR TITLE
fix(cli): implement cookie name filtering and fix config parsing

### DIFF
--- a/cli/config/config.example.yaml
+++ b/cli/config/config.example.yaml
@@ -52,13 +52,12 @@ storage:
 #   apply[]:   { in, name, value } — how to inject into HTTP requests
 #
 # Optional fields:
-#   ttl          — credential lifetime (e.g. "12h", "7d")
-#   required[]   — completion criteria in "name.field" format
-#   cookiePaths  — extra URL paths to query cookies from
-#   loginMode    — auto|cdp|headless|visible
-#   loginPatterns — URL patterns that indicate a login page
-#   networkProxy — SOCKS proxy for browser (e.g. socks5h://127.0.0.1:1080)
-#   waitUntil    — page load condition override
+#   ttl             — credential lifetime (e.g. "12h", "7d")
+#   required[]      — completion criteria in "name.field" format
+#   cookiePaths     — extra URL paths to query cookies from
+#   waitUntil       — page load condition override (load|networkidle|domcontentloaded|commit)
+#   loginUrlPatterns — URL substrings that indicate a login page (e.g. /login, /auth/sso)
+#   networkProxy    — SOCKS proxy for browser (e.g. socks5h://127.0.0.1:1080)
 
 providers:
     # ---------------------------------------------------------------------------
@@ -109,7 +108,6 @@ providers:
     #   entryUrl: https://www.reddit.com/login
     #   strategy: browser
     #   ttl: "7d"
-    #   loginMode: cdp
     #   networkProxy: socks5h://127.0.0.1:1080
     #   required:
     #     - session.reddit_session

--- a/cli/src/auth-manager.ts
+++ b/cli/src/auth-manager.ts
@@ -74,7 +74,7 @@ export class AuthManager {
                     required: entry.required,
                     cookiePaths: entry.cookiePaths,
                     ttl: entry.ttl,
-                    loginMode: entry.loginMode,
+
                     loginPatterns: entry.loginPatterns,
                     waitUntil: entry.waitUntil,
                 }) as ProviderConfig,

--- a/cli/src/auth-manager.ts
+++ b/cli/src/auth-manager.ts
@@ -75,7 +75,7 @@ export class AuthManager {
                     cookiePaths: entry.cookiePaths,
                     ttl: entry.ttl,
 
-                    loginPatterns: entry.loginPatterns,
+                    loginUrlPatterns: entry.loginUrlPatterns,
                     waitUntil: entry.waitUntil,
                 }) as ProviderConfig,
         );

--- a/cli/src/config/generator.ts
+++ b/cli/src/config/generator.ts
@@ -62,7 +62,10 @@ storage:
 #         name: Cookie
 #         value: "\${session}"
 #     # ttl: 12h                         # Optional: credential lifetime
-#     # loginMode: cdp                   # Optional: auto|cdp|headless|visible
+#     # waitUntil: networkidle           # Optional: load|networkidle|domcontentloaded|commit
+#     # loginPatterns:                   # Optional: custom URL patterns to detect login pages
+#     #   - /login
+#     #   - /auth/sso
 #     # required:                        # Optional: wait for specific cookies
 #     #   - session.my_cookie
 providers: {}

--- a/cli/src/config/generator.ts
+++ b/cli/src/config/generator.ts
@@ -63,7 +63,7 @@ storage:
 #         value: "\${session}"
 #     # ttl: 12h                         # Optional: credential lifetime
 #     # waitUntil: networkidle           # Optional: load|networkidle|domcontentloaded|commit
-#     # loginPatterns:                   # Optional: custom URL patterns to detect login pages
+#     # loginUrlPatterns:                   # Optional: custom URL patterns to detect login pages
 #     #   - /login
 #     #   - /auth/sso
 #     # required:                        # Optional: wait for specific cookies

--- a/cli/src/config/schema.ts
+++ b/cli/src/config/schema.ts
@@ -73,7 +73,7 @@ export interface ProviderEntry {
     cookiePaths?: string[];
     ttl?: string;
     networkProxy?: string;
-    loginMode?: string;
+
     loginPatterns?: string[];
     waitUntil?: WaitUntilValue;
 }

--- a/cli/src/config/schema.ts
+++ b/cli/src/config/schema.ts
@@ -74,6 +74,6 @@ export interface ProviderEntry {
     ttl?: string;
     networkProxy?: string;
 
-    loginPatterns?: string[];
+    loginUrlPatterns?: string[];
     waitUntil?: WaitUntilValue;
 }

--- a/cli/src/config/validator.ts
+++ b/cli/src/config/validator.ts
@@ -318,16 +318,6 @@ function validateProviderEntry(id: string, raw: Record<string, unknown>): string
         }
     }
 
-    // Validate loginMode
-    const VALID_LOGIN_MODES = ['auto', 'cdp', 'headless', 'visible'];
-    if (raw.loginMode !== undefined) {
-        if (typeof raw.loginMode !== 'string' || !VALID_LOGIN_MODES.includes(raw.loginMode)) {
-            errors.push(
-                `Provider "${id}": loginMode must be one of: ${VALID_LOGIN_MODES.join(', ')}`,
-            );
-        }
-    }
-
     return errors;
 }
 
@@ -343,6 +333,11 @@ function parseProviderEntry(raw: Record<string, unknown>): ProviderEntry {
         ...(Array.isArray(raw.cookiePaths) ? { cookiePaths: raw.cookiePaths } : {}),
         ...(typeof raw.ttl === 'string' ? { ttl: raw.ttl } : {}),
         ...(typeof raw.networkProxy === 'string' ? { networkProxy: raw.networkProxy } : {}),
-        ...(typeof raw.loginMode === 'string' ? { loginMode: raw.loginMode } : {}),
+        ...(Array.isArray(raw.loginPatterns)
+            ? { loginPatterns: raw.loginPatterns as string[] }
+            : {}),
+        ...(typeof raw.waitUntil === 'string'
+            ? { waitUntil: raw.waitUntil as ProviderEntry['waitUntil'] }
+            : {}),
     };
 }

--- a/cli/src/config/validator.ts
+++ b/cli/src/config/validator.ts
@@ -333,8 +333,8 @@ function parseProviderEntry(raw: Record<string, unknown>): ProviderEntry {
         ...(Array.isArray(raw.cookiePaths) ? { cookiePaths: raw.cookiePaths } : {}),
         ...(typeof raw.ttl === 'string' ? { ttl: raw.ttl } : {}),
         ...(typeof raw.networkProxy === 'string' ? { networkProxy: raw.networkProxy } : {}),
-        ...(Array.isArray(raw.loginPatterns)
-            ? { loginPatterns: raw.loginPatterns as string[] }
+        ...(Array.isArray(raw.loginUrlPatterns)
+            ? { loginUrlPatterns: raw.loginUrlPatterns as string[] }
             : {}),
         ...(typeof raw.waitUntil === 'string'
             ? { waitUntil: raw.waitUntil as ProviderEntry['waitUntil'] }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -110,7 +110,6 @@ export {
     SyncSubcommand,
     WatchSubcommand,
     WaitUntil,
-    LoginMode,
     CredentialTypeName,
     LOGIN_URL_PATTERNS,
     HttpHeader,
@@ -120,7 +119,7 @@ export {
     SIG_DIR,
     CONFIG_FILENAME,
 } from './types/index.js';
-export type { WaitUntilValue, LoginModeValue } from './types/index.js';
+export type { WaitUntilValue } from './types/index.js';
 
 // Utilities
 export { decodeJwt, isJwtExpired, getJwtExpiresAt } from './utils/jwt.js';

--- a/cli/src/strategies/browser/browser-strategy.ts
+++ b/cli/src/strategies/browser/browser-strategy.ts
@@ -95,7 +95,7 @@ export class BrowserStrategy implements IStrategy {
                     currentUrl,
                     provider.domains,
                     evaluate,
-                    provider.loginPatterns,
+                    provider.loginUrlPatterns,
                 );
                 if (!authenticated) return null;
 
@@ -267,7 +267,7 @@ export class BrowserStrategy implements IStrategy {
                     currentUrl,
                     provider.domains,
                     evaluate,
-                    provider.loginPatterns,
+                    provider.loginUrlPatterns,
                 );
                 if (authenticated && Object.keys(credentials).length > 0) {
                     return { credentials, expiresAt };

--- a/cli/src/strategies/browser/extractors/cdp-cookie.ts
+++ b/cli/src/strategies/browser/extractors/cdp-cookie.ts
@@ -35,8 +35,14 @@ export class CdpCookieExtractor implements IBrowserExtractor {
 
         if (!result?.cookies?.length) return null;
 
-        const filtered = this.filterByDomain(result.cookies, domains);
+        let filtered = this.filterByDomain(result.cookies, domains);
         if (!filtered.length) return null;
+
+        if (rule.key !== '*') {
+            const names = new Set(rule.key.split(',').map((n) => n.trim()));
+            filtered = filtered.filter((c) => names.has(c.name));
+            if (!filtered.length) return null;
+        }
 
         const serialized = filtered.map((c) => `${c.name}=${c.value}`).join('; ');
 

--- a/cli/src/strategies/browser/extractors/headless-cookie.ts
+++ b/cli/src/strategies/browser/extractors/headless-cookie.ts
@@ -14,12 +14,18 @@ export class HeadlessCookieExtractor implements IHeadlessExtractor {
         domains: string[],
     ): Promise<ExtractorResult | null> {
         const cookies = await ctx.cookies();
-        const filtered = cookies.filter((c) => {
+        let filtered = cookies.filter((c) => {
             const d = c.domain.startsWith('.') ? c.domain.slice(1) : c.domain;
             return domains.some((pd) => d === pd || pd.endsWith('.' + d) || d.endsWith('.' + pd));
         });
 
         if (!filtered.length) return null;
+
+        if (rule.key !== '*') {
+            const names = new Set(rule.key.split(',').map((n) => n.trim()));
+            filtered = filtered.filter((c) => names.has(c.name));
+            if (!filtered.length) return null;
+        }
 
         const value = filtered.map((c) => `${c.name}=${c.value}`).join('; ');
         const cookieMeta = filtered

--- a/cli/src/strategies/browser/page-state-checker.ts
+++ b/cli/src/strategies/browser/page-state-checker.ts
@@ -10,7 +10,7 @@ export interface IPageStateChecker {
         url: string,
         domains: string[],
         evaluate: DomEvaluateFn,
-        loginPatterns?: string[],
+        loginUrlPatterns?: string[],
     ): Promise<boolean>;
 }
 
@@ -30,10 +30,10 @@ export class PageStateChecker implements IPageStateChecker {
         url: string,
         domains: string[],
         evaluate: DomEvaluateFn,
-        loginPatterns?: string[],
+        loginUrlPatterns?: string[],
     ): Promise<boolean> {
         if (!this.isOnProviderDomain(url, domains)) return false;
-        const isLogin = await this.loginDetector.isLoginPage(url, evaluate, loginPatterns);
+        const isLogin = await this.loginDetector.isLoginPage(url, evaluate, loginUrlPatterns);
         return !isLogin;
     }
 }

--- a/cli/src/types/constants.ts
+++ b/cli/src/types/constants.ts
@@ -142,18 +142,6 @@ export const APP_NAME = 'sig';
 export const APP_VERSION = pkg.version;
 
 /**
- * Login mode for browser authentication.
- * Controls which browser phases are attempted.
- */
-export const LoginMode = {
-    AUTO: 'auto',
-    CDP: 'cdp',
-    HEADLESS: 'headless',
-    VISIBLE: 'visible',
-} as const;
-export type LoginModeValue = (typeof LoginMode)[keyof typeof LoginMode];
-
-/**
  * Default configuration directory and filename.
  */
 export const SIG_DIR = '.sig';

--- a/cli/src/types/index.ts
+++ b/cli/src/types/index.ts
@@ -53,11 +53,10 @@ export {
     OutputFormat,
     APP_NAME,
     APP_VERSION,
-    LoginMode,
     SIG_DIR,
     CONFIG_FILENAME,
 } from './constants.js';
-export type { WaitUntilValue, OutputFormatValue, LoginModeValue } from './constants.js';
+export type { WaitUntilValue, OutputFormatValue } from './constants.js';
 
 export type { IStrategy, ExtractedCredentials } from './interfaces/strategy.js';
 export type { IBrowserExtractor } from './interfaces/browser-extractor.js';

--- a/cli/src/types/types.ts
+++ b/cli/src/types/types.ts
@@ -29,7 +29,7 @@ export interface ProviderConfig {
     strategy: string; // Strategy name: "browser" | "prompt"
     autoProvisioned?: boolean; // True if created by auto-provision (not from config file)
     networkProxy?: string; // Browser network proxy, e.g. "socks5://127.0.0.1:1080"
-    loginMode?: string; // Login mode: auto|cdp|headless|visible
+
     extract: ExtractRule[];
     apply: ApplyRule[];
     required?: string[];

--- a/cli/src/types/types.ts
+++ b/cli/src/types/types.ts
@@ -35,7 +35,7 @@ export interface ProviderConfig {
     required?: string[];
     cookiePaths?: string[];
     ttl?: string;
-    loginPatterns?: string[];
+    loginUrlPatterns?: string[];
     waitUntil?: string;
 }
 


### PR DESCRIPTION
## Summary

- Implement `rule.key` filtering in `CdpCookieExtractor` and `HeadlessCookieExtractor`: when key is not `"*"`, parse as comma-separated cookie names and filter results accordingly
- Fix `parseProviderEntry()` to include `loginPatterns` and `waitUntil` fields that were silently dropped from YAML config
- Remove dead `loginMode` config field (parsed/validated but never consumed at runtime)
- Update config generator example to document `waitUntil` and `loginPatterns` options

## Test plan

- [x] `pnpm --filter @sigcli/cli build` — compiles cleanly
- [x] `pnpm --filter @sigcli/cli test` — 335 tests pass
- [ ] CI passes on this PR