### PR TITLE
feat(cli): add always-on operational logging

### DIFF
--- a/cli/src/auth-manager.ts
+++ b/cli/src/auth-manager.ts
@@ -27,7 +27,7 @@ import { checkRequired } from './strategies/browser/required-checker.js';
 import { PromptStrategy } from './strategies/prompt/index.js';
 import { ApplyEngine, type ApplyResult } from './apply/apply-engine.js';
 import { parseDuration } from './utils/duration.js';
-import { createConsoleLogger } from './utils/logger.js';
+import { createNoopLogger, createOperationalLogger } from './utils/logger.js';
 import { expandHome } from './utils/path.js';
 
 /**
@@ -39,10 +39,10 @@ export class AuthManager {
     readonly storage: IStorage;
     readonly config: SigConfig;
     readonly browserAvailable: boolean;
+    readonly logger: ILogger;
 
     private readonly providers: IProviderRegistry;
     private readonly browserConfig: BrowserConfig;
-    private readonly logger: ILogger;
     private readonly strategies = new Map<string, IStrategy>();
 
     private constructor(
@@ -50,16 +50,19 @@ export class AuthManager {
         providers: IProviderRegistry,
         browserConfig: BrowserConfig,
         config: SigConfig,
+        logger: ILogger,
     ) {
         this.storage = storage;
         this.providers = providers;
         this.browserConfig = browserConfig;
         this.config = config;
         this.browserAvailable = config.mode !== 'browserless';
-        this.logger = createConsoleLogger();
+        this.logger = logger;
     }
 
-    static async create(config: SigConfig): Promise<AuthManager> {
+    static async create(config: SigConfig, logger?: ILogger): Promise<AuthManager> {
+        const log = logger ?? createOperationalLogger();
+
         const providerConfigs = Object.entries(config.providers).map(
             ([id, entry]) =>
                 ({
@@ -84,18 +87,22 @@ export class AuthManager {
 
         const credDir = expandHome(config.storage.credentialsDir);
         const encryptionKey = await loadEncryptionKey();
-        const storage = new CachedStorage(new DirectoryStorage(credDir, encryptionKey), {
+        const storage = new CachedStorage(new DirectoryStorage(credDir, encryptionKey, log), {
             ttlMs: 5000,
         });
 
-        const manager = new AuthManager(storage, providerRegistry, config.browser, config);
+        const manager = new AuthManager(storage, providerRegistry, config.browser, config, log);
 
         if (manager.browserAvailable) {
-            manager.registerStrategy(new BrowserStrategy(config.browser));
+            manager.registerStrategy(new BrowserStrategy(config.browser, undefined, log));
         }
         manager.registerStrategy(new PromptStrategy());
 
         return manager;
+    }
+
+    static async createWithNoopLogger(config: SigConfig): Promise<AuthManager> {
+        return AuthManager.create(config, createNoopLogger());
     }
 
     registerStrategy(strategy: IStrategy): void {
@@ -157,7 +164,7 @@ export class AuthManager {
             const existingIds = new Set(this.providers.list().map((p) => p.id));
             const provider = createDefaultProvider(input, existingIds);
             this.providers.register(provider);
-            this.logger.info(`Auto-provisioned provider "${provider.id}" for ${input}`);
+            this.logger.info(`auto-provisioned "${provider.id}" for ${input}`);
             return ok(provider);
         }
 
@@ -220,14 +227,24 @@ export class AuthManager {
 
     private async getCached(provider: ProviderConfig): Promise<ExtractedCredentials | null> {
         const stored = await this.storage.get(provider.id);
-        if (!stored) return null;
+        if (!stored) {
+            this.logger.info(`${provider.id}: cache miss`);
+            return null;
+        }
 
         const creds = stored.values;
-        if (!creds || Object.keys(creds).length === 0) return null;
+        if (!creds || Object.keys(creds).length === 0) {
+            this.logger.info(`${provider.id}: cache miss (empty)`);
+            return null;
+        }
 
         const expiresAt = this.computeExpiresAt(stored, provider);
-        if (expiresAt && Date.now() >= expiresAt.getTime()) return null;
+        if (expiresAt && Date.now() >= expiresAt.getTime()) {
+            this.logger.info(`${provider.id}: cache expired`);
+            return null;
+        }
 
+        this.logger.info(`${provider.id}: cache hit`);
         return creds;
     }
 
@@ -258,14 +275,19 @@ export class AuthManager {
             );
         }
 
-        this.logger.info(`Authenticating with "${provider.id}"...`);
+        this.logger.info(`${provider.id}: authenticating via ${provider.strategy}`);
+        const startTime = Date.now();
 
         const extractResult = await strategy.extract(provider);
-        if (!isOk(extractResult)) return extractResult;
+        if (!isOk(extractResult)) {
+            this.logger.error(`${provider.id}: auth failed — ${extractResult.error.message}`);
+            return extractResult;
+        }
 
         if (provider.required?.length) {
             const unmet = checkRequired(provider.required, extractResult.value.credentials);
             if (unmet.length > 0) {
+                this.logger.error(`${provider.id}: required fields not met — ${unmet.join(', ')}`);
                 return err(
                     new CredentialNotFoundError(`Required fields not met: ${unmet.join(', ')}`),
                 );
@@ -281,6 +303,8 @@ export class AuthManager {
         };
         await this.storage.set(provider.id, storedEntry);
 
+        const elapsed = Date.now() - startTime;
+        this.logger.info(`${provider.id}: authenticated (${elapsed}ms)`);
         return ok(extractResult.value.credentials);
     }
 }

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -44,6 +44,7 @@ export async function runLogin(
         return;
     }
     const provider = resolved.value;
+    auth.logger.info(`login: provider="${provider.id}" strategy=${provider.strategy}`);
 
     const networkProxy =
         typeof flags['network-proxy'] === 'string' ? flags['network-proxy'] : undefined;
@@ -137,6 +138,7 @@ export async function runLogin(
         provider: provider.id,
         metadata: { strategy: provider.strategy },
     });
+    auth.logger.info(`login: success`);
     process.stderr.write(`Authenticated with "${provider.name}".\n`);
     process.stdout.write(
         formatJson({

--- a/cli/src/commands/request.ts
+++ b/cli/src/commands/request.ts
@@ -118,6 +118,8 @@ export async function runRequest(
         }
     }
 
+    auth.logger.info(`request: ${httpMethod} ${url} via ${provider.id}`);
+
     const fetchOptions: RequestInit = { method: httpMethod, headers: requestHeaders };
     if (finalBody && ['POST', 'PUT', 'PATCH'].includes(httpMethod)) {
         fetchOptions.body = finalBody;
@@ -125,6 +127,7 @@ export async function runRequest(
 
     try {
         const response = await fetch(finalUrl, fetchOptions);
+        auth.logger.info(`request: ${response.status} ${response.statusText}`);
         const responseBody = await response.text();
 
         let formattedBody: string;

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -81,6 +81,10 @@ export async function runRun(
         allSecrets.push(...extractSensitiveValues(credResult.value));
     }
 
+    auth.logger.info(
+        `run: injecting ${providers.length} provider(s), ${Object.keys(allEnv).length} env var(s)`,
+    );
+
     const secrets = [...new Set(allSecrets)];
     const mount = typeof flags['mount'] === 'string' ? flags['mount'] : undefined;
     const mountFormat = typeof flags['mount-format'] === 'string' ? flags['mount-format'] : 'env';
@@ -106,6 +110,7 @@ export async function runRun(
     });
 
     const [cmd, ...args] = cmdArgs;
+    auth.logger.info(`run: exec ${cmd}`);
     let redactionNoticeShown = false;
 
     const child = spawn(cmd, args, {

--- a/cli/src/commands/sync.ts
+++ b/cli/src/commands/sync.ts
@@ -53,7 +53,13 @@ export async function runSync(
         remote = remotes[0];
     }
 
-    const engine = new SyncEngine(auth.storage, remote, auth.config, new SshTransport());
+    const engine = new SyncEngine(
+        auth.storage,
+        remote,
+        auth.config,
+        new SshTransport(),
+        auth.logger,
+    );
     const force = flags.force === true;
     const provider = typeof flags.provider === 'string' ? [flags.provider] : undefined;
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -121,6 +121,9 @@ export {
 } from './types/index.js';
 export type { WaitUntilValue } from './types/index.js';
 
+// Logger
+export { createConsoleLogger, createOperationalLogger, createNoopLogger } from './utils/logger.js';
+
 // Utilities
 export { decodeJwt, isJwtExpired, getJwtExpiresAt } from './utils/jwt.js';
 export { parseDuration, formatDuration } from './utils/duration.js';

--- a/cli/src/proxy/ca-manager.ts
+++ b/cli/src/proxy/ca-manager.ts
@@ -13,6 +13,9 @@ import {
     X509CertificateGenerator,
 } from '@peculiar/x509';
 
+import type { ILogger } from '../types/index.js';
+import { createNoopLogger } from '../utils/logger.js';
+
 cryptoProvider.set(webcrypto as Crypto);
 
 const MAX_CACHE = 200;
@@ -44,9 +47,11 @@ export class CaManager {
     private caPrivKey: CryptoKey | null = null;
     private readonly leafCache = new Map<string, LeafEntry>();
     private readonly proxyDir: string;
+    private readonly logger: ILogger;
 
-    constructor(proxyDir: string) {
+    constructor(proxyDir: string, logger?: ILogger) {
         this.proxyDir = proxyDir;
+        this.logger = logger ?? createNoopLogger();
     }
 
     async ensureCa(): Promise<void> {
@@ -67,6 +72,7 @@ export class CaManager {
 
             this.caCert = new X509Certificate(crtPem);
             this.caPrivKey = privKey;
+            this.logger.info('ca: loaded existing CA');
             return;
         } catch {
             // Generate a fresh CA below
@@ -101,6 +107,7 @@ export class CaManager {
 
         this.caCert = cert;
         this.caPrivKey = keys.privateKey;
+        this.logger.info('ca: generated new CA');
     }
 
     async leafCertFor(hostname: string): Promise<{ cert: string; key: string }> {
@@ -145,6 +152,7 @@ export class CaManager {
             if (oldest !== undefined) this.leafCache.delete(oldest);
         }
         this.leafCache.set(hostname, entry);
+        this.logger.info(`ca: generated cert for ${hostname}`);
 
         return { cert: entry.cert, key: entry.key };
     }

--- a/cli/src/proxy/daemon.ts
+++ b/cli/src/proxy/daemon.ts
@@ -1,4 +1,5 @@
 import { parseDuration } from '../utils/duration.js';
+import { createOperationalLogger } from '../utils/logger.js';
 import { expandHome } from '../utils/path.js';
 import type { AuthManager } from '../auth-manager.js';
 import { getWatchConfig, getWatchProviders } from '../watch/watch-config.js';
@@ -15,21 +16,13 @@ export interface DaemonOptions {
 }
 
 export async function startDaemon(opts: DaemonOptions, signal: AbortSignal): Promise<void> {
+    const logger = createOperationalLogger();
     const proxyDir = expandHome('~/.sig/proxy');
-    const caManager = new CaManager(proxyDir);
-    const server = new ProxyServer({ port: opts.port, auth: opts.auth, caManager });
+    const caManager = new CaManager(proxyDir, logger);
+    const server = new ProxyServer({ port: opts.port, auth: opts.auth, caManager, logger });
 
     const { port } = await server.start();
     await writeState({ pid: process.pid, port });
-
-    const logger = {
-        debug: (msg: string) => process.stderr.write(`[proxy] ${msg}\n`),
-        info: (msg: string) => process.stderr.write(`[proxy] ${msg}\n`),
-        warn: (msg: string) => process.stderr.write(`[proxy] WARN: ${msg}\n`),
-        error: (msg: string) => process.stderr.write(`[proxy] ERROR: ${msg}\n`),
-    };
-
-    process.stderr.write(`[proxy] Listening on 127.0.0.1:${port}\n`);
 
     // Graceful shutdown
     const cleanup = async () => {

--- a/cli/src/proxy/proxy-server.ts
+++ b/cli/src/proxy/proxy-server.ts
@@ -3,8 +3,9 @@ import * as https from 'node:https';
 import * as net from 'node:net';
 import * as tls from 'node:tls';
 
-import { isOk } from '../types/index.js';
+import { isOk, type ILogger } from '../types/index.js';
 import { ApplyEngine } from '../apply/apply-engine.js';
+import { createNoopLogger } from '../utils/logger.js';
 import type { AuthManager } from '../auth-manager.js';
 import type { CaManager } from './ca-manager.js';
 
@@ -40,9 +41,12 @@ async function applyInjection(
     bodyBuffer: Buffer | undefined,
     contentType: string | undefined,
     auth: AuthManager,
+    logger: ILogger,
 ): Promise<{ headers: http.OutgoingHttpHeaders; body: Buffer | undefined; url: string }> {
     const provider = resolveProvider(url, auth);
     if (!provider) return { headers: baseHeaders, body: bodyBuffer, url };
+
+    logger.info(`proxy: injecting credentials for ${provider.id}`);
 
     const credResult = await auth.getExtractedCreds(provider.id);
     if (!isOk(credResult)) return { headers: baseHeaders, body: bodyBuffer, url };
@@ -96,6 +100,7 @@ async function handlePlainHttp(
     req: http.IncomingMessage,
     res: http.ServerResponse,
     auth: AuthManager,
+    logger: ILogger,
 ): Promise<void> {
     const rawUrl = req.url ?? '/';
     const targetUrl = rawUrl.startsWith('http') ? rawUrl : `http://${req.headers.host}${rawUrl}`;
@@ -111,6 +116,9 @@ async function handlePlainHttp(
     const contentType = req.headers['content-type'];
 
     const provider = resolveProvider(targetUrl, auth);
+    if (provider) {
+        logger.info(`proxy: ${req.method} ${targetUrl} → ${provider.id}`);
+    }
     const hasBodyRule = provider?.apply?.some((r) => r.in === 'body') ?? false;
 
     if (hasBodyRule) {
@@ -123,7 +131,7 @@ async function handlePlainHttp(
             headers,
             body,
             url: injectedUrl,
-        } = await applyInjection(targetUrl, baseHeaders, bodyBuffer, contentType, auth);
+        } = await applyInjection(targetUrl, baseHeaders, bodyBuffer, contentType, auth, logger);
 
         const injParsed = new URL(injectedUrl);
         const outHeaders =
@@ -157,6 +165,7 @@ async function handlePlainHttp(
             undefined,
             contentType,
             auth,
+            logger,
         );
 
         const injParsed = new URL(injectedUrl);
@@ -190,7 +199,9 @@ async function handleConnectMitm(
     port: number,
     auth: AuthManager,
     caManager: CaManager,
+    logger: ILogger,
 ): Promise<void> {
+    logger.info(`proxy: MITM ${hostname}:${port}`);
     let leafCert: { cert: string; key: string };
     try {
         leafCert = await caManager.leafCertFor(hostname);
@@ -233,6 +244,7 @@ async function handleConnectMitm(
                 bodyBuf ?? Buffer.alloc(0),
                 contentType,
                 auth,
+                logger,
             );
             const outHeaders = {
                 ...result.headers,
@@ -269,6 +281,7 @@ async function handleConnectMitm(
             undefined,
             contentType,
             auth,
+            logger,
         );
         const injPath = new URL(injectedUrl).pathname + new URL(injectedUrl).search;
 
@@ -358,6 +371,7 @@ export interface ProxyServerOptions {
     port: number;
     auth: AuthManager;
     caManager: CaManager;
+    logger?: ILogger;
 }
 
 export class ProxyServer {
@@ -365,14 +379,16 @@ export class ProxyServer {
     private _port: number;
     private readonly auth: AuthManager;
     private readonly caManager: CaManager;
+    private readonly logger: ILogger;
 
     constructor(opts: ProxyServerOptions) {
         this._port = opts.port;
         this.auth = opts.auth;
         this.caManager = opts.caManager;
+        this.logger = opts.logger ?? createNoopLogger();
         this.server = http.createServer();
         this.server.on('request', (req, res) => {
-            handlePlainHttp(req, res, this.auth).catch(() => {
+            handlePlainHttp(req, res, this.auth, this.logger).catch(() => {
                 if (!res.headersSent) res.writeHead(500);
                 res.end();
             });
@@ -394,6 +410,7 @@ export class ProxyServer {
                     port,
                     this.auth,
                     this.caManager,
+                    this.logger,
                 ).catch(() => {
                     clientSocket.destroy();
                 });
@@ -409,6 +426,7 @@ export class ProxyServer {
             this.server.listen(this._port, '127.0.0.1', () => {
                 const addr = this.server.address();
                 this._port = typeof addr === 'object' && addr ? addr.port : this._port;
+                this.logger.info(`proxy: listening on 127.0.0.1:${this._port}`);
                 resolve({ port: this._port });
             });
             this.server.once('error', reject);

--- a/cli/src/storage/directory-storage.ts
+++ b/cli/src/storage/directory-storage.ts
@@ -4,11 +4,13 @@ import lockfile from 'proper-lockfile';
 
 import {
     StorageError,
+    type ILogger,
     type IStorage,
     type StoredCredential,
     type StoredEntry,
 } from '../types/index.js';
 import { decrypt, encrypt, isEncryptedEnvelope } from '../crypto/encryption.js';
+import { createNoopLogger } from '../utils/logger.js';
 import { sanitizeId } from '../utils/sanitize.js';
 
 interface ProviderFile {
@@ -29,15 +31,21 @@ interface ProviderFile {
  * (write to tmp + rename) for safe concurrent access.
  */
 export class DirectoryStorage implements IStorage {
+    private readonly logger: ILogger;
+
     constructor(
         private readonly dirPath: string,
         private readonly encryptionKey: Buffer,
-    ) {}
+        logger?: ILogger,
+    ) {
+        this.logger = logger ?? createNoopLogger();
+    }
 
     async get(providerId: string): Promise<StoredCredential | null> {
         const filePath = this.filePathFor(providerId);
         try {
             const data = await this.readFile(filePath);
+            this.logger.info(`storage: read ${providerId}`);
             return this.toStoredCredential(data);
         } catch (e: unknown) {
             if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
@@ -63,15 +71,17 @@ export class DirectoryStorage implements IStorage {
         await this.withLock(filePath, async () => {
             await this.atomicWrite(filePath, data);
         });
+        this.logger.info(`storage: write ${providerId}`);
     }
 
     async delete(providerId: string): Promise<void> {
         const filePath = this.filePathFor(providerId);
         try {
             await fs.unlink(filePath);
+            this.logger.info(`storage: delete ${providerId}`);
         } catch (e: unknown) {
             if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
-                return; // No-op if not found
+                return;
             }
             throw new StorageError('delete', (e as Error).message);
         }
@@ -156,6 +166,9 @@ export class DirectoryStorage implements IStorage {
             raw = JSON.parse(plaintext) as Record<string, unknown>;
         } else {
             raw = parsed as Record<string, unknown>;
+            if (raw.providerId) {
+                this.logger.warn(`storage: ${raw.providerId as string} is unencrypted (legacy)`);
+            }
         }
 
         if (!raw.version || !raw.providerId) {

--- a/cli/src/strategies/browser/browser-strategy.ts
+++ b/cli/src/strategies/browser/browser-strategy.ts
@@ -10,6 +10,7 @@ import {
     type ExtractedCredentials,
     type ExtractRule,
     type IBrowserExtractor,
+    type ILogger,
     type IStrategy,
     type ProviderConfig,
     type Result,
@@ -20,6 +21,7 @@ import type {
     IHeadlessExtractor,
 } from '../../types/interfaces/headless-extractor.js';
 import type { ExtractionResult } from '../../types/interfaces/strategy.js';
+import { createNoopLogger } from '../../utils/logger.js';
 import { expandHome } from '../../utils/path.js';
 import { killProcess } from '../../utils/process-kill.js';
 import { findFreePort, removeSingletonLock, waitForBrowserReady } from './browser-lifecycle.js';
@@ -40,10 +42,16 @@ export class BrowserStrategy implements IStrategy {
     private readonly headlessExtractors: Map<string, IHeadlessExtractor>;
     private readonly browserConfig: BrowserConfig;
     private readonly pageState: IPageStateChecker;
+    private readonly logger: ILogger;
 
-    constructor(browserConfig: BrowserConfig, pageStateChecker?: IPageStateChecker) {
+    constructor(
+        browserConfig: BrowserConfig,
+        pageStateChecker?: IPageStateChecker,
+        logger?: ILogger,
+    ) {
         this.browserConfig = browserConfig;
         this.pageState = pageStateChecker ?? new PageStateChecker();
+        this.logger = logger ?? createNoopLogger();
         this.cdpExtractors = new Map();
         this.cdpExtractors.set('cookies', new CdpCookieExtractor());
         this.cdpExtractors.set('localStorage', new CdpStorageExtractor());
@@ -53,6 +61,7 @@ export class BrowserStrategy implements IStrategy {
     }
 
     async extract(provider: ProviderConfig): Promise<Result<ExtractionResult, AuthError>> {
+        this.logger.info(`${provider.id}: starting browser extraction`);
         const headlessResult = await this.tryHeadless(provider);
         if (headlessResult) return ok(headlessResult);
         return this.extractViaCdp(provider);
@@ -63,12 +72,19 @@ export class BrowserStrategy implements IStrategy {
     // =========================================================================
 
     private async tryHeadless(provider: ProviderConfig): Promise<ExtractionResult | null> {
+        this.logger.info(`${provider.id}: trying headless`);
         try {
             // @ts-expect-error - playwright is an optional dependency
             const pw = await import('playwright').catch(() => null);
-            if (!pw) return null;
+            if (!pw) {
+                this.logger.info(`${provider.id}: playwright not available, skipping headless`);
+                return null;
+            }
 
             const dataDir = expandHome(this.browserConfig.browserDataDir);
+            this.logger.info(
+                `${provider.id}: headless launch (channel=${this.browserConfig.channel})`,
+            );
             const browserCtx = await pw.chromium.launchPersistentContext(dataDir, {
                 headless: true,
                 channel: this.browserConfig.channel,
@@ -97,8 +113,14 @@ export class BrowserStrategy implements IStrategy {
                     evaluate,
                     provider.loginUrlPatterns,
                 );
-                if (!authenticated) return null;
+                if (!authenticated) {
+                    this.logger.info(
+                        `${provider.id}: headless not authenticated, falling back to CDP`,
+                    );
+                    return null;
+                }
 
+                this.logger.info(`${provider.id}: headless authenticated`);
                 const headlessCtx: HeadlessExtractionCtx = {
                     cookies: () => browserCtx.cookies(),
                     evaluate: <T>(expr: string) => page.evaluate(expr) as Promise<T>,
@@ -114,11 +136,15 @@ export class BrowserStrategy implements IStrategy {
                     if (checkRequired(provider.required, credentials).length > 0) return null;
                 }
 
+                this.logger.info(
+                    `${provider.id}: headless extracted ${Object.keys(credentials).length} credential(s)`,
+                );
                 return { credentials, expiresAt };
             } finally {
                 await browserCtx.close();
             }
         } catch {
+            this.logger.warn(`${provider.id}: headless failed, falling back to CDP`);
             return null;
         }
     }
@@ -174,6 +200,8 @@ export class BrowserStrategy implements IStrategy {
             return err(new BrowserError(`Failed to find free port: ${(e as Error).message}`));
         }
 
+        this.logger.info(`${provider.id}: CDP port ${cdpPort}`);
+
         const browserArgs: string[] = [
             `--remote-debugging-port=${cdpPort}`,
             `--user-data-dir=${dataDir}`,
@@ -199,12 +227,17 @@ export class BrowserStrategy implements IStrategy {
         let cdpClient: CdpWsClient | undefined;
 
         try {
+            this.logger.info(`${provider.id}: launching browser for CDP`);
             browser = spawn(execPath, browserArgs, { detached: false, stdio: 'ignore' });
 
             const wsUrl = await waitForBrowserReady(cdpPort, this.browserConfig.visibleTimeout);
             cdpClient = await connectCdpWs(wsUrl);
+            this.logger.info(`${provider.id}: CDP connected`);
 
             const result = await this.pollUntilComplete(cdpClient, provider);
+            this.logger.info(
+                `${provider.id}: extraction complete (${Object.keys(result.credentials).length} credentials)`,
+            );
             return ok(result);
         } catch (e) {
             if (e instanceof BrowserTimeoutError) return err(e);

--- a/cli/src/sync/sync-engine.ts
+++ b/cli/src/sync/sync-engine.ts
@@ -1,23 +1,27 @@
 import fs from 'node:fs/promises';
 import YAML from 'yaml';
 
-import type { IStorage } from '../types/index.js';
+import type { ILogger, IStorage } from '../types/index.js';
 import { getConfigPath } from '../config/loader.js';
 import type { SigConfig } from '../config/schema.js';
+import { createNoopLogger } from '../utils/logger.js';
 import { sanitizeId } from '../utils/sanitize.js';
 import type { ISyncTransport } from './interfaces/transport.js';
 import type { RemoteConfig, SyncResult } from './types.js';
 
 export class SyncEngine {
     private readonly transport: ISyncTransport;
+    private readonly logger: ILogger;
 
     constructor(
         private readonly storage: IStorage,
         private readonly remote: RemoteConfig,
         private readonly config: SigConfig,
         transport: ISyncTransport,
+        logger?: ILogger,
     ) {
         this.transport = transport;
+        this.logger = logger ?? createNoopLogger();
     }
 
     async push(providerIds?: string[], force = false): Promise<SyncResult> {
@@ -34,6 +38,8 @@ export class SyncEngine {
         const toPush = providerIds
             ? localEntries.filter((e) => providerIds.includes(e.providerId))
             : localEntries;
+
+        this.logger.info(`sync push: ${toPush.length} provider(s) to ${this.remote.name}`);
 
         if (toPush.length === 0) {
             // Still sync config even if no credentials to push
@@ -55,6 +61,7 @@ export class SyncEngine {
                     const localTime = new Date(entry.updatedAt).getTime();
                     const remoteTime = new Date(remoteEntry.updatedAt).getTime();
                     if (remoteTime > localTime) {
+                        this.logger.info(`sync push: ${entry.providerId} skipped (remote newer)`);
                         result.skipped.push(entry.providerId);
                         continue;
                     }
@@ -64,6 +71,7 @@ export class SyncEngine {
                 if (!stored) continue;
 
                 await this.transport.writeRemote(this.remote, filename, stored);
+                this.logger.info(`sync push: ${entry.providerId} pushed`);
                 result.pushed.push(entry.providerId);
             } catch (e: unknown) {
                 result.errors.push({
@@ -94,6 +102,8 @@ export class SyncEngine {
             ? remoteEntries.filter((e) => providerIds.includes(e.providerId))
             : remoteEntries;
 
+        this.logger.info(`sync pull: ${toPull.length} provider(s) from ${this.remote.name}`);
+
         if (toPull.length === 0) {
             // Still sync config even if no credentials to pull
             result.configSynced = await this.syncConfigPull(providerIds);
@@ -109,6 +119,9 @@ export class SyncEngine {
                         const localTime = new Date(local.updatedAt).getTime();
                         const remoteTime = new Date(entry.updatedAt).getTime();
                         if (localTime > remoteTime) {
+                            this.logger.info(
+                                `sync pull: ${entry.providerId} skipped (local newer)`,
+                            );
                             result.skipped.push(entry.providerId);
                             continue;
                         }
@@ -125,6 +138,7 @@ export class SyncEngine {
                 }
 
                 await this.storage.set(entry.providerId, stored);
+                this.logger.info(`sync pull: ${entry.providerId} pulled`);
                 result.pulled.push(entry.providerId);
             } catch (e: unknown) {
                 result.errors.push({
@@ -215,6 +229,9 @@ export class SyncEngine {
             }
 
             await this.transport.writeRemoteConfig(this.remote, doc.toString());
+            this.logger.info(
+                `sync: config pushed (${Object.keys(localProviders).length} providers)`,
+            );
             return { providers: Object.keys(localProviders) };
         } catch (e: unknown) {
             return { providers: [], error: (e as Error).message };
@@ -267,6 +284,9 @@ export class SyncEngine {
             doc.setIn(['providers'], doc.createNode(merged));
 
             await fs.writeFile(configPath, doc.toString(), 'utf-8');
+            this.logger.info(
+                `sync: config pulled (${Object.keys(remoteProviders).length} providers)`,
+            );
             return { providers: Object.keys(remoteProviders) };
         } catch (e: unknown) {
             return { providers: [], error: (e as Error).message };

--- a/cli/src/utils/logger.ts
+++ b/cli/src/utils/logger.ts
@@ -24,3 +24,33 @@ export function createConsoleLogger(): ILogger {
         },
     };
 }
+
+export function createOperationalLogger(): ILogger {
+    return {
+        debug() {},
+        info(message: string, ...args: unknown[]) {
+            process.stderr.write(
+                `[sig] ${message}${args.length ? ' ' + args.map(String).join(' ') : ''}\n`,
+            );
+        },
+        warn(message: string, ...args: unknown[]) {
+            process.stderr.write(
+                `[sig] WARN: ${message}${args.length ? ' ' + args.map(String).join(' ') : ''}\n`,
+            );
+        },
+        error(message: string, ...args: unknown[]) {
+            process.stderr.write(
+                `[sig] ERROR: ${message}${args.length ? ' ' + args.map(String).join(' ') : ''}\n`,
+            );
+        },
+    };
+}
+
+export function createNoopLogger(): ILogger {
+    return {
+        debug() {},
+        info() {},
+        warn() {},
+        error() {},
+    };
+}


### PR DESCRIPTION
## Summary

- Add comprehensive operational logging across all CLI components
- Logs are always-on to stderr with `[sig]` prefix — no `--verbose` flag needed
- Never logs credential values, tokens, cookies, or secrets
- All logger params are optional (defaults to noop) — zero impact on existing tests

## Changes

**New utilities** (`src/utils/logger.ts`):
- `createOperationalLogger()` — suppresses debug, outputs info/warn/error
- `createNoopLogger()` — all methods no-op (for tests)

**Logger injected into:**
- `AuthManager` — cache hit/miss/expired, auth timing, auto-provisioning
- `BrowserStrategy` — headless/CDP flow steps, launch, extraction results
- `DirectoryStorage` — read/write/delete, legacy unencrypted file warning
- `SyncEngine` — push/pull counts, per-provider results, conflict skips
- `ProxyServer` — matched request interception, MITM decisions
- `CaManager` — CA/cert generation
- Commands (`login`, `request`, `run`, `sync`) — operation context

## Test plan

- [x] `pnpm --filter @sigcli/cli build` passes (tsc)
- [x] `pnpm --filter @sigcli/cli test` passes (335/335 tests)
- [x] `prettier --check` passes on all modified files
- [x] `eslint` passes (0 errors, only pre-existing `any` warnings from Playwright)