### PR TITLE
fix(cli): fix headless browser extraction

### DIFF
--- a/cli/src/strategies/browser/browser-strategy.ts
+++ b/cli/src/strategies/browser/browser-strategy.ts
@@ -74,10 +74,11 @@ export class BrowserStrategy implements IStrategy {
     private async tryHeadless(provider: ProviderConfig): Promise<ExtractionResult | null> {
         this.logger.info(`${provider.id}: trying headless`);
         try {
-            // @ts-expect-error - playwright is an optional dependency
-            const pw = await import('playwright').catch(() => null);
+            const pw = await import('playwright-core').catch(() => null);
             if (!pw) {
-                this.logger.info(`${provider.id}: playwright not available, skipping headless`);
+                this.logger.info(
+                    `${provider.id}: playwright-core not available, skipping headless`,
+                );
                 return null;
             }
 
@@ -103,9 +104,8 @@ export class BrowserStrategy implements IStrategy {
                     });
                 }
 
-                const currentUrl = (page.url() as string).toLowerCase();
-                const evaluate: DomEvaluateFn = <T>(expr: string) =>
-                    page.evaluate(expr) as Promise<T>;
+                const currentUrl = page.url().toLowerCase();
+                const evaluate: DomEvaluateFn = <_T>(expr: string) => page.evaluate(expr);
 
                 const authenticated = await this.pageState.isAuthenticated(
                     currentUrl,
@@ -123,7 +123,7 @@ export class BrowserStrategy implements IStrategy {
                 this.logger.info(`${provider.id}: headless authenticated`);
                 const headlessCtx: HeadlessExtractionCtx = {
                     cookies: () => browserCtx.cookies(),
-                    evaluate: <T>(expr: string) => page.evaluate(expr) as Promise<T>,
+                    evaluate: <_T>(expr: string) => page.evaluate(expr),
                 };
 
                 const { credentials, expiresAt } = await this.runHeadlessExtractors(
@@ -143,8 +143,9 @@ export class BrowserStrategy implements IStrategy {
             } finally {
                 await browserCtx.close();
             }
-        } catch {
-            this.logger.warn(`${provider.id}: headless failed, falling back to CDP`);
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            this.logger.warn(`${provider.id}: headless failed (${msg}), falling back to CDP`);
             return null;
         }
     }


### PR DESCRIPTION
## Summary
- Fixed headless browser extraction importing `playwright` (not installed) instead of `playwright-core` (installed dependency) — headless was silently failing on every login
- Added glob pattern support to `HeadlessStorageExtractor` (matching CDP extractor) — enables headless OAuth token extraction for ms-teams/ms-graph
- Fixed `isAuthenticated` domain check to include entryUrl host when it differs from provider domains
- Bumped version to 1.4.0

## Test plan
- [x] `pnpm --filter @sigcli/cli build` passes
- [x] `pnpm --filter @sigcli/cli test` — 335 tests pass
- [x] `sig login jira-tools --force` — headless OK
- [x] `sig login wiki-one --force` — headless OK
- [x] `sig login ms-teams --force` — headless OK (localStorage glob extraction)
- [x] `sig login ms-graph --force` — headless OK (entryUrl domain fix)
- [x] `sig login sap-cats --force` — headless OK
- [x] `sig login sap-leave --force` — headless OK