### PR TITLE
fix(browser): close CDP connection leaks in poll loop

### DIFF
--- a/cli/src/strategies/browser/browser-strategy.ts
+++ b/cli/src/strategies/browser/browser-strategy.ts
@@ -9,7 +9,6 @@ import {
     type AuthError,
     type ExtractedCredentials,
     type ExtractRule,
-    type IBrowserExtractor,
     type ILogger,
     type IStrategy,
     type ProviderConfig,
@@ -38,7 +37,8 @@ export class BrowserStrategy implements IStrategy {
     readonly name = 'browser';
     readonly needsBrowser = true;
 
-    private readonly cdpExtractors: Map<string, IBrowserExtractor>;
+    private readonly cookieExtractor: CdpCookieExtractor;
+    private readonly storageExtractor: CdpStorageExtractor;
     private readonly headlessExtractors: Map<string, IHeadlessExtractor>;
     private readonly browserConfig: BrowserConfig;
     private readonly pageState: IPageStateChecker;
@@ -52,9 +52,8 @@ export class BrowserStrategy implements IStrategy {
         this.browserConfig = browserConfig;
         this.pageState = pageStateChecker ?? new PageStateChecker();
         this.logger = logger ?? createNoopLogger();
-        this.cdpExtractors = new Map();
-        this.cdpExtractors.set('cookies', new CdpCookieExtractor());
-        this.cdpExtractors.set('localStorage', new CdpStorageExtractor());
+        this.cookieExtractor = new CdpCookieExtractor();
+        this.storageExtractor = new CdpStorageExtractor();
         this.headlessExtractors = new Map();
         this.headlessExtractors.set('cookies', new HeadlessCookieExtractor());
         this.headlessExtractors.set('localStorage', new HeadlessStorageExtractor());
@@ -266,53 +265,65 @@ export class BrowserStrategy implements IStrategy {
 
         while (Date.now() < deadline) {
             const sessionId = await attachToPageTarget(cdp).catch(() => null);
-            const currentUrl = await this.getCdpPageUrl(cdp, sessionId);
-            const evaluate = this.makeCdpEvaluator(cdp, sessionId);
+            try {
+                if (sessionId) {
+                    await cdp.send('Runtime.enable', {}, sessionId).catch(() => {});
+                }
+                const currentUrl = await this.getCdpPageUrl(cdp, sessionId);
+                const evaluate = this.makeCdpEvaluator(cdp, sessionId);
 
-            for (const rule of provider.extract) {
-                const extractor = this.cdpExtractors.get(rule.from);
-                if (!extractor) continue;
-                try {
-                    const result = await extractor.extract(
-                        cdp,
-                        rule,
-                        provider.domains,
-                        provider.cookiePaths,
-                    );
-                    if (result) {
-                        credentials[result.name] = result.value;
-                        if (result.cookies?.length) {
-                            const expiries = result.cookies
-                                .filter((c) => c.expires > 0)
-                                .map((c) => c.expires * 1000);
-                            if (expiries.length > 0) {
-                                expiresAt = new Date(Math.min(...expiries)).toISOString();
+                for (const rule of provider.extract) {
+                    try {
+                        let result: {
+                            name: string;
+                            value: string;
+                            cookies?: Array<{ name: string; expires: number }>;
+                        } | null = null;
+                        if (rule.from === 'cookies') {
+                            result = await this.cookieExtractor.extract(
+                                cdp,
+                                rule,
+                                provider.domains,
+                            );
+                        } else if (rule.from === 'localStorage' && sessionId) {
+                            result = await this.storageExtractor.extract(cdp, sessionId, rule);
+                        }
+                        if (result) {
+                            credentials[result.name] = result.value;
+                            if (result.cookies?.length) {
+                                const expiries = result.cookies
+                                    .filter((c) => c.expires > 0)
+                                    .map((c) => c.expires * 1000);
+                                if (expiries.length > 0) {
+                                    expiresAt = new Date(Math.min(...expiries)).toISOString();
+                                }
                             }
                         }
+                    } catch {
+                        // Transient failure — keep polling
                     }
-                } catch {
-                    // Transient failure — keep polling
                 }
-            }
 
-            if (provider.required?.length) {
-                if (checkRequired(provider.required, credentials).length === 0) {
-                    return { credentials, expiresAt };
+                if (provider.required?.length) {
+                    if (checkRequired(provider.required, credentials).length === 0) {
+                        return { credentials, expiresAt };
+                    }
+                } else {
+                    const authenticated = await this.pageState.isAuthenticated(
+                        currentUrl,
+                        provider.domains,
+                        evaluate,
+                        provider.loginUrlPatterns,
+                    );
+                    if (authenticated && Object.keys(credentials).length > 0) {
+                        return { credentials, expiresAt };
+                    }
                 }
-            } else {
-                const authenticated = await this.pageState.isAuthenticated(
-                    currentUrl,
-                    provider.domains,
-                    evaluate,
-                    provider.loginUrlPatterns,
-                );
-                if (authenticated && Object.keys(credentials).length > 0) {
-                    return { credentials, expiresAt };
+            } finally {
+                if (sessionId) {
+                    await cdp.send('Runtime.disable', {}, sessionId).catch(() => {});
+                    await cdp.send('Target.detachFromTarget', { sessionId }).catch(() => {});
                 }
-            }
-
-            if (sessionId) {
-                await cdp.send('Target.detachFromTarget', { sessionId }).catch(() => {});
             }
             await new Promise((r) => setTimeout(r, pollInterval));
         }
@@ -335,7 +346,6 @@ export class BrowserStrategy implements IStrategy {
     private async getCdpPageUrl(cdp: CdpWsClient, sessionId: string | null): Promise<string> {
         if (!sessionId) return '';
         try {
-            await cdp.send('Runtime.enable', {}, sessionId).catch(() => {});
             const result = (await cdp.send(
                 'Runtime.evaluate',
                 { expression: 'window.location.href', returnByValue: true },

--- a/cli/src/strategies/browser/cdp-ws.ts
+++ b/cli/src/strategies/browser/cdp-ws.ts
@@ -173,6 +173,8 @@ export function connectCdpWs(wsUrl: string): Promise<CdpWsClient> {
         >();
         let nextId = 1;
 
+        const CDP_REQUEST_TIMEOUT = 10_000;
+
         const client: CdpWsClient = {
             send(
                 method: string,
@@ -181,7 +183,24 @@ export function connectCdpWs(wsUrl: string): Promise<CdpWsClient> {
             ): Promise<unknown> {
                 return new Promise<unknown>((res, rej) => {
                     const id = nextId++;
-                    pending.set(id, { resolve: res, reject: rej });
+                    const timer = setTimeout(() => {
+                        pending.delete(id);
+                        rej(
+                            new Error(
+                                `CDP request timed out: ${method} (${CDP_REQUEST_TIMEOUT}ms)`,
+                            ),
+                        );
+                    }, CDP_REQUEST_TIMEOUT);
+                    pending.set(id, {
+                        resolve: (v: unknown) => {
+                            clearTimeout(timer);
+                            res(v);
+                        },
+                        reject: (e: Error) => {
+                            clearTimeout(timer);
+                            rej(e);
+                        },
+                    });
                     const msg = JSON.stringify({
                         id,
                         method,

--- a/cli/src/strategies/browser/extractors/cdp-cookie.ts
+++ b/cli/src/strategies/browser/extractors/cdp-cookie.ts
@@ -27,7 +27,6 @@ export class CdpCookieExtractor implements IBrowserExtractor {
         cdp: CdpWsClient,
         rule: ExtractRule,
         domains: string[],
-        _cookiePaths?: string[],
     ): Promise<{ name: string; value: string; cookies: CdpCookie[] } | null> {
         const result = (await cdp.send('Storage.getCookies', {
             browserContextId: undefined,

--- a/cli/src/strategies/browser/extractors/cdp-storage.ts
+++ b/cli/src/strategies/browser/extractors/cdp-storage.ts
@@ -1,56 +1,44 @@
 import dlv from 'dlv';
 
-import type { ExtractRule, IBrowserExtractor } from '../../../types/index.js';
-import { attachToPageTarget, type CdpWsClient } from '../cdp-ws.js';
+import type { ExtractRule } from '../../../types/index.js';
+import type { CdpWsClient } from '../cdp-ws.js';
 
 /**
  * Extracts values from browser localStorage via CDP Runtime.evaluate.
+ * Requires an active session with Runtime already enabled.
  *
  * key: "localConfig_v2.teams.E7RBBBXHB.token" — dot-path into a localStorage entry
  * key: "msal.*.accesstoken.*" — glob pattern for matching localStorage keys
- *
- * Output value: the resolved string value.
  */
-export class CdpStorageExtractor implements IBrowserExtractor {
-    readonly type = 'localStorage' as const;
-
+export class CdpStorageExtractor {
     async extract(
         cdp: CdpWsClient,
+        sessionId: string,
         rule: ExtractRule,
-        _domains: string[],
     ): Promise<{ name: string; value: string } | null> {
-        const sessionId = await attachToPageTarget(cdp);
-        if (!sessionId) return null;
+        const { storageKey, jsonPath } = this.parseKey(rule.key);
 
-        try {
-            await cdp.send('Runtime.enable', {}, sessionId).catch(() => {});
-
-            const { storageKey, jsonPath } = this.parseKey(rule.key);
-
-            let value: string | null;
-            if (storageKey.includes('*')) {
-                value = await this.extractByPattern(cdp, sessionId, storageKey);
-            } else {
-                value = await this.extractByKey(cdp, sessionId, storageKey);
-            }
-
-            if (!value) return null;
-
-            if (jsonPath) {
-                try {
-                    const parsed = JSON.parse(value);
-                    const resolved = dlv(parsed, jsonPath);
-                    if (resolved == null) return null;
-                    value = String(resolved);
-                } catch {
-                    return null;
-                }
-            }
-
-            return { name: rule.name, value };
-        } finally {
-            await cdp.send('Target.detachFromTarget', { sessionId }).catch(() => {});
+        let value: string | null;
+        if (storageKey.includes('*')) {
+            value = await this.extractByPattern(cdp, sessionId, storageKey);
+        } else {
+            value = await this.extractByKey(cdp, sessionId, storageKey);
         }
+
+        if (!value) return null;
+
+        if (jsonPath) {
+            try {
+                const parsed = JSON.parse(value);
+                const resolved = dlv(parsed, jsonPath);
+                if (resolved == null) return null;
+                value = String(resolved);
+            } catch {
+                return null;
+            }
+        }
+
+        return { name: rule.name, value };
     }
 
     private parseKey(key: string): { storageKey: string; jsonPath?: string } {
@@ -61,9 +49,6 @@ export class CdpStorageExtractor implements IBrowserExtractor {
         if (dotIndex === -1) {
             return { storageKey: key };
         }
-        // Check if first segment is a plausible localStorage key
-        // localStorage keys often contain underscores, camelCase, etc.
-        // If the full key has no glob, treat first segment as key, rest as jsonPath
         const firstSegment = key.slice(0, dotIndex);
         const rest = key.slice(dotIndex + 1);
         return { storageKey: firstSegment, jsonPath: rest };
@@ -121,15 +106,12 @@ export class CdpStorageExtractor implements IBrowserExtractor {
             const matches = JSON.parse(raw) as (string | null)[];
             if (!matches?.length) return null;
 
-            // Extract value from JSON entries using common patterns (secret field, or raw JWT)
-
             for (const entry of matches) {
                 if (!entry) continue;
                 const jwt = this.extractJwtFromEntry(entry);
                 if (jwt) return jwt;
             }
 
-            // Fallback: return first non-null match as-is
             return matches.find((m) => m != null) ?? null;
         } catch {
             return raw;
@@ -137,7 +119,6 @@ export class CdpStorageExtractor implements IBrowserExtractor {
     }
 
     private extractJwtFromEntry(entry: string): string | null {
-        // If entry is JSON with a "secret" field containing a JWT, extract it
         try {
             const parsed = JSON.parse(entry);
             if (parsed?.secret && typeof parsed.secret === 'string') {
@@ -146,7 +127,6 @@ export class CdpStorageExtractor implements IBrowserExtractor {
                 }
             }
         } catch {
-            // Not JSON — check if the entry itself is a JWT
             if (entry.startsWith('eyJ') && entry.includes('.')) {
                 return entry;
             }

--- a/cli/src/types/interfaces/browser-extractor.ts
+++ b/cli/src/types/interfaces/browser-extractor.ts
@@ -1,12 +1,6 @@
 import type { CdpWsClient } from '../../strategies/browser/cdp-ws.js';
 import type { ExtractRule } from '../types.js';
 
-/**
- * Sub-extractor that runs inside a browser session via CDP.
- * BrowserSource dispatches to these based on extract[].from.
- *
- * Implementations: CookieExtractor, StorageExtractor, EvalExtractor
- */
 export interface IBrowserExtractor {
     readonly type: 'cookies' | 'localStorage' | 'eval';
 
@@ -14,7 +8,6 @@ export interface IBrowserExtractor {
         cdp: CdpWsClient,
         rule: ExtractRule,
         domains: string[],
-        cookiePaths?: string[],
     ): Promise<{
         name: string;
         value: string;


### PR DESCRIPTION
## Summary

- Wrap poll iteration in `try/finally` to always detach CDP session on every exit path (fixes leaked sessions on successful early return)
- Pass caller's `sessionId` into `CdpStorageExtractor` to eliminate double-attach per iteration
- Call `Runtime.disable` before detach to stop unbounded event accumulation
- Add 10s per-request timeout to `CdpWsClient.send()` to prevent hung promises when browser becomes unresponsive

## Test plan

- [x] `pnpm --filter @sigcli/cli build` — clean
- [x] `pnpm --filter @sigcli/cli test` — 335 tests pass
- [ ] Live test with instrumented CDP client confirms 0 leaked sessions

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)