### PR TITLE
fix(cli): block-style YAML for auto-provisioned providers + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,44 +46,35 @@ in your browser         -->   credentials locally          -->  on your behalf
 
 ## Provider Configuration
 
-Most enterprise and SSO sites work with zero config — `sig login <url>` detects cookies automatically. Public sites with tracking cookies need a little more.
+Most enterprise/SSO sites work with zero config. Public sites need a bit more. Here's the progression from simple to advanced:
 
-### Zero config (auto-provision)
+### 1. Zero config (auto-provision)
 
-For internal tools, wikis, and SSO-protected systems, just run:
+For SSO-protected internal tools, just run:
 
 ```bash
 sig login https://jira.example.com
 ```
 
-sig opens a real browser, you log in normally, and it captures whatever session cookies are set. No config required.
+sig opens a real browser, you log in, and it captures session cookies automatically. No config file needed.
 
-### Adding `required` to validate cookies
+### 2. Adding `required` cookies
 
-Many public sites (social media, forums, video platforms) set tracking cookies for **all visitors** — logged in or not. Without `required`, sig can't tell auth cookies from tracking cookies and may capture a credential-less session.
-
-Add `required` to list the cookies that must be present for the session to be considered authenticated:
+Public sites set tracking cookies to **all visitors**. Without `required`, sig can't tell auth cookies from junk. Add `required` to validate:
 
 ```yaml
-providers:
-    bilibili:
-        domains: [www.bilibili.com]
-        entryUrl: https://www.bilibili.com/
-        strategy: browser
-        required: ['cookie.SESSDATA', 'cookie.bili_jct']
-        extract:
-            - from: cookies
-              as: cookie
-              match: '*'
-        apply:
-            - in: header
-              name: Cookie
-              value: '${cookie}'
+bilibili:
+    domains: [www.bilibili.com]
+    entryUrl: https://www.bilibili.com/
+    strategy: browser
+    required: ['cookie.SESSDATA', 'cookie.bili_jct']
+    extract:
+        - { from: cookies, as: cookie, match: '*' }
+    apply:
+        - { in: header, name: Cookie, value: '${cookie}' }
 ```
 
-When the `required` cookies are missing, sig falls back from headless to CDP (your real browser) where you're actually authenticated.
-
-Common sites and their required cookies:
+When required cookies are missing, sig falls back from headless to your real browser where you're logged in.
 
 | Site        | Required Cookies               |
 | ----------- | ------------------------------ |
@@ -94,11 +85,46 @@ Common sites and their required cookies:
 | LinkedIn    | `JSESSIONID`, `li_at`          |
 | V2EX        | `A2`                           |
 | Zhihu       | `z_c0`                         |
-| Hacker News | `user`                         |
 
-### localStorage extraction (advanced)
+### 3. Multiple domains
 
-Some apps (Microsoft Teams, Slack) store tokens in localStorage instead of cookies. sig supports `from: localStorage` extraction rules for these cases. See the full guide at **[sigcli.ai](https://sigcli.ai)**.
+Some sites use multiple domains (e.g. x.com migrated from twitter.com). List all domains so sig captures cookies from both:
+
+```yaml
+x:
+    domains: [x.com, twitter.com]
+    entryUrl: https://x.com/
+    strategy: browser
+    networkProxy: socks5://127.0.0.1:3333
+    required: ['cookie.ct0', 'cookie.auth_token']
+    extract:
+        - { from: cookies, as: cookie, match: '*' }
+    apply:
+        - { in: header, name: Cookie, value: '${cookie}' }
+```
+
+### 4. localStorage extraction (advanced)
+
+Some apps store tokens in localStorage instead of cookies. Use `from: localStorage` with `match` (key pattern) and `jsonPath` (nested field):
+
+```yaml
+app-slack:
+    domains: [your-org.enterprise.slack.com]
+    entryUrl: https://app.slack.com/client/YOUR_TEAM_ID
+    strategy: browser
+    required: ['session.d', 'xoxc-token']
+    extract:
+        - { from: cookies, as: session, match: '*' }
+        - from: localStorage
+          as: xoxc-token
+          match: localConfig_v2
+          jsonPath: teams.YOUR_TEAM_ID.token
+    apply:
+        - { in: header, name: Cookie, value: '${session}' }
+        - { in: header, name: Authorization, value: 'Bearer ${xoxc-token}' }
+```
+
+Full guide with debugging tips at **[sigcli.ai](https://sigcli.ai)**.
 
 ## AI Agent Skills
 

--- a/README.md
+++ b/README.md
@@ -44,20 +44,6 @@ in your browser         -->   credentials locally          -->  on your behalf
 
 **sig login** opens a real browser to the provider's entry URL. You log in normally — SSO, MFA, SAML, anything. Once authenticated, sig extracts credentials (cookies, localStorage tokens) based on your config's `extract[]` rules, encrypts them with AES-256-GCM, and stores them locally. When your agent needs to make a request, `apply[]` rules control how credentials are injected into HTTP headers, body, or query params.
 
-### Config Example
-
-```yaml
-providers:
-    my-jira:
-        domains: [jira.example.com]
-        entryUrl: https://jira.example.com/
-        strategy: browser
-        extract:
-            - { from: cookies, as: session, match: '*' }
-        apply:
-            - { in: header, name: Cookie, value: '${session}' }
-```
-
 ## Provider Configuration
 
 Most enterprise and SSO sites work with zero config — `sig login <url>` detects cookies automatically. Public sites with tracking cookies need a little more.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,62 @@ providers:
             - { in: header, name: Cookie, value: '${session}' }
 ```
 
+## Provider Configuration
+
+Most enterprise and SSO sites work with zero config — `sig login <url>` detects cookies automatically. Public sites with tracking cookies need a little more.
+
+### Zero config (auto-provision)
+
+For internal tools, wikis, and SSO-protected systems, just run:
+
+```bash
+sig login https://jira.example.com
+```
+
+sig opens a real browser, you log in normally, and it captures whatever session cookies are set. No config required.
+
+### Adding `required` to validate cookies
+
+Many public sites (social media, forums, video platforms) set tracking cookies for **all visitors** — logged in or not. Without `required`, sig can't tell auth cookies from tracking cookies and may capture a credential-less session.
+
+Add `required` to list the cookies that must be present for the session to be considered authenticated:
+
+```yaml
+providers:
+    bilibili:
+        domains: [www.bilibili.com]
+        entryUrl: https://www.bilibili.com/
+        strategy: browser
+        required: ['cookie.SESSDATA', 'cookie.bili_jct']
+        extract:
+            - from: cookies
+              as: cookie
+              match: '*'
+        apply:
+            - in: header
+              name: Cookie
+              value: '${cookie}'
+```
+
+When the `required` cookies are missing, sig falls back from headless to CDP (your real browser) where you're actually authenticated.
+
+Common sites and their required cookies:
+
+| Site        | Required Cookies               |
+| ----------- | ------------------------------ |
+| Bilibili    | `SESSDATA`, `bili_jct`         |
+| Reddit      | `reddit_session`, `token_v2`   |
+| X (Twitter) | `ct0`, `auth_token`            |
+| YouTube     | `SAPISID`, `__Secure-3PAPISID` |
+| LinkedIn    | `JSESSIONID`, `li_at`          |
+| V2EX        | `A2`                           |
+| Zhihu       | `z_c0`                         |
+| Hacker News | `user`                         |
+
+### localStorage extraction (advanced)
+
+Some apps (Microsoft Teams, Slack) store tokens in localStorage instead of cookies. sig supports `from: localStorage` extraction rules for these cases. See the full guide at **[sigcli.ai](https://sigcli.ai)**.
+
 ## AI Agent Skills
 
 Pre-built Python scripts that let AI agents operate 14+ web services — email, chat, forums, video platforms, social networks, and more. Each skill includes scripts + documentation that agents read and execute autonomously.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,24 @@ For SSO-protected internal tools, just run:
 sig login https://jira.example.com
 ```
 
-sig opens a real browser, you log in, and it captures session cookies automatically. No config file needed.
+sig opens a real browser, you log in, and it writes config automatically:
+
+```yaml
+# ~/.sig/config.yaml (auto-generated)
+jira-example:
+    domains:
+        - jira.example.com
+    entryUrl: https://jira.example.com/
+    strategy: browser
+    extract:
+        - from: cookies
+          as: session
+          match: '*'
+    apply:
+        - in: header
+          name: Cookie
+          value: '${session}'
+```
 
 ### 2. Adding `required` cookies
 
@@ -64,14 +81,21 @@ Public sites set tracking cookies to **all visitors**. Without `required`, sig c
 
 ```yaml
 bilibili:
-    domains: [www.bilibili.com]
+    domains:
+        - www.bilibili.com
     entryUrl: https://www.bilibili.com/
     strategy: browser
-    required: ['cookie.SESSDATA', 'cookie.bili_jct']
+    required:
+        - cookie.SESSDATA
+        - cookie.bili_jct
     extract:
-        - { from: cookies, as: cookie, match: '*' }
+        - from: cookies
+          as: cookie
+          match: '*'
     apply:
-        - { in: header, name: Cookie, value: '${cookie}' }
+        - in: header
+          name: Cookie
+          value: '${cookie}'
 ```
 
 When required cookies are missing, sig falls back from headless to your real browser where you're logged in.
@@ -92,15 +116,23 @@ Some sites use multiple domains (e.g. x.com migrated from twitter.com). List all
 
 ```yaml
 x:
-    domains: [x.com, twitter.com]
+    domains:
+        - x.com
+        - twitter.com
     entryUrl: https://x.com/
     strategy: browser
     networkProxy: socks5://127.0.0.1:3333
-    required: ['cookie.ct0', 'cookie.auth_token']
+    required:
+        - cookie.ct0
+        - cookie.auth_token
     extract:
-        - { from: cookies, as: cookie, match: '*' }
+        - from: cookies
+          as: cookie
+          match: '*'
     apply:
-        - { in: header, name: Cookie, value: '${cookie}' }
+        - in: header
+          name: Cookie
+          value: '${cookie}'
 ```
 
 ### 4. localStorage extraction (advanced)
@@ -109,19 +141,28 @@ Some apps store tokens in localStorage instead of cookies. Use `from: localStora
 
 ```yaml
 app-slack:
-    domains: [your-org.enterprise.slack.com]
+    domains:
+        - your-org.enterprise.slack.com
     entryUrl: https://app.slack.com/client/YOUR_TEAM_ID
     strategy: browser
-    required: ['session.d', 'xoxc-token']
+    required:
+        - session.d
+        - xoxc-token
     extract:
-        - { from: cookies, as: session, match: '*' }
+        - from: cookies
+          as: session
+          match: '*'
         - from: localStorage
           as: xoxc-token
           match: localConfig_v2
           jsonPath: teams.YOUR_TEAM_ID.token
     apply:
-        - { in: header, name: Cookie, value: '${session}' }
-        - { in: header, name: Authorization, value: 'Bearer ${xoxc-token}' }
+        - in: header
+          name: Cookie
+          value: '${session}'
+        - in: header
+          name: Authorization
+          value: 'Bearer ${xoxc-token}'
 ```
 
 Full guide with debugging tips at **[sigcli.ai](https://sigcli.ai)**.

--- a/cli/src/config/loader.ts
+++ b/cli/src/config/loader.ts
@@ -6,7 +6,7 @@
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import YAML from 'yaml';
+import YAML, { isCollection } from 'yaml';
 
 import { ConfigError, err, type AuthError, type Result } from '../types/index.js';
 import type { ProviderEntry, SigConfig } from './schema.js';
@@ -87,8 +87,25 @@ export async function addProviderToConfig(id: string, entry: ProviderEntry): Pro
     if (!doc.getIn(['providers'])) {
         doc.setIn(['providers'], doc.createNode({}));
     }
-    doc.setIn(['providers', id], doc.createNode(entry, { flow: false }));
+    const providersNode = doc.getIn(['providers'], true);
+    if (isCollection(providersNode)) providersNode.flow = false;
+    const providerNode = doc.createNode(entry);
+    setBlockStyle(providerNode);
+    doc.setIn(['providers', id], providerNode);
     await fs.writeFile(CONFIG_PATH, doc.toString(), 'utf-8');
+}
+
+function setBlockStyle(node: unknown): void {
+    if (isCollection(node)) {
+        node.flow = false;
+        for (const item of node.items) {
+            if (typeof item === 'object' && item !== null) {
+                if ('value' in item) setBlockStyle(item.value);
+                if ('key' in item) setBlockStyle(item.key);
+                setBlockStyle(item);
+            }
+        }
+    }
 }
 
 /**

--- a/website/src/content/docs-zh.tsx
+++ b/website/src/content/docs-zh.tsx
@@ -1322,15 +1322,15 @@ providers:
                         <Code>required</Code> 字段
                     </SectionHeading>
                     <P>
-                        <Code>required</Code>{' '}
-                        字段用于验证提取的凭证中是否包含特定的 cookie，只有通过验证才会存储。
-                        如果不使用此字段，sigcli 可能会将追踪 cookie 或游客 cookie
-                        存储为有效凭证——大多数公开网站会对所有访客设置这类无用的 cookie。
+                        <Code>required</Code> 字段用于验证提取的凭证中是否包含特定的
+                        cookie，只有通过验证才会存储。 如果不使用此字段，sigcli 可能会将追踪 cookie
+                        或游客 cookie 存储为有效凭证——大多数公开网站会对所有访客设置这类无用的
+                        cookie。
                     </P>
                     <P>
-                        <strong>格式：</strong>{' '}
-                        <Code>{"required: [\"<as>.<cookie_name>\"]"}</Code> —— 前缀是 extract
-                        规则中的 <Code>as</Code> 名称，后缀是必须存在于提取值中的 cookie 名称。
+                        <strong>格式：</strong> <Code>{'required: ["<as>.<cookie_name>"]'}</Code> ——
+                        前缀是 extract 规则中的 <Code>as</Code> 名称，后缀是必须存在于提取值中的
+                        cookie 名称。
                     </P>
                     <CodeBlock lang="yaml">{`# 要求 "cookie" 提取结果中包含两个特定 cookie
 required: ["cookie.reddit_session", "cookie.token_v2"]
@@ -1342,19 +1342,17 @@ required: ["access_token"]`}</CodeBlock>
                     </P>
                     <List>
                         <Li>无头提取立即被拒绝——sigcli 不会存储结果。</Li>
-                        <Li>
-                            sigcli 回退到 CDP（真实浏览器，用户实际已登录）并重新检查。
-                        </Li>
+                        <Li>sigcli 回退到 CDP（真实浏览器，用户实际已登录）并重新检查。</Li>
                         <Li>
                             如果 CDP 也未通过 required 检查，认证失败并显示明确的错误信息，
                             列出缺失的 cookie。
                         </Li>
                     </List>
                     <P>
-                        <strong>何时使用：</strong>为任何公共网站（社交媒体、论坛、新闻网站）的提供者添加{' '}
-                        <Code>required</Code>。这些网站会对所有访客设置 cookie；没有{' '}
-                        <Code>required</Code>，自动创建的提供者会将这些无用的游客 cookie
-                        存储为登录成功。
+                        <strong>何时使用：</strong>
+                        为任何公共网站（社交媒体、论坛、新闻网站）的提供者添加 <Code>required</Code>
+                        。这些网站会对所有访客设置 cookie；没有 <Code>required</Code>
+                        ，自动创建的提供者会将这些无用的游客 cookie 存储为登录成功。
                     </P>
                     <CodeBlock lang="yaml">{`reddit:
   domains: [www.reddit.com, reddit.com]
@@ -1438,17 +1436,17 @@ required: ["access_token"]`}</CodeBlock>
                         localStorage 提取
                     </SectionHeading>
                     <P>
-                        部分网站将认证令牌存储在浏览器 localStorage 中而非 cookie 里。
-                        这在 OAuth2/MSAL 流程（Microsoft Teams、Graph API）、Slack
+                        部分网站将认证令牌存储在浏览器 localStorage 中而非 cookie 里。 这在
+                        OAuth2/MSAL 流程（Microsoft Teams、Graph API）、Slack
                         以及现代单页应用中很常见。在 extract 规则中使用{' '}
                         <Code>from: localStorage</Code> 来捕获这些令牌。
                     </P>
 
                     <P>
-                        <strong>工作原理：</strong><Code>match</Code>{' '}
-                        字段指定要查找的 localStorage 键——可以是精确的键名，也可以是使用{' '}
-                        <Code>*</Code> 通配符的 glob 模式。可选的 <Code>jsonPath</Code>{' '}
-                        字段在 localStorage 条目为 JSON 字符串时提取嵌套的值。
+                        <strong>工作原理：</strong>
+                        <Code>match</Code> 字段指定要查找的 localStorage
+                        键——可以是精确的键名，也可以是使用 <Code>*</Code> 通配符的 glob 模式。可选的{' '}
+                        <Code>jsonPath</Code> 字段在 localStorage 条目为 JSON 字符串时提取嵌套的值。
                     </P>
 
                     <CodeBlock lang="yaml">{`extract:
@@ -1469,8 +1467,8 @@ required: ["access_token"]`}</CodeBlock>
                     </P>
                     <List>
                         <Li>
-                            <strong>精确匹配：</strong>{' '}
-                            <Code>match: "localConfig_v2"</Code> — 查找完全匹配的 localStorage 键。
+                            <strong>精确匹配：</strong> <Code>match: "localConfig_v2"</Code> —
+                            查找完全匹配的 localStorage 键。
                         </Li>
                         <Li>
                             <strong>glob 模式：</strong>{' '}
@@ -1481,13 +1479,14 @@ required: ["access_token"]`}</CodeBlock>
                                     'user@tenant.com-login.microsoftonline.com-accesstoken-client_id-graph.microsoft.com-openid'
                                 }
                             </Code>{' '}
-                            的长复合键存储 OAuth2 令牌；glob 模式可以匹配不同租户或客户端 ID 的所有键。
+                            的长复合键存储 OAuth2 令牌；glob 模式可以匹配不同租户或客户端 ID
+                            的所有键。
                         </Li>
                     </List>
 
                     <P>
-                        <strong>jsonPath：</strong>当 localStorage 值是 JSON 字符串且需要提取特定字段时使用。
-                        使用点号表示法遍历嵌套对象：
+                        <strong>jsonPath：</strong>当 localStorage 值是 JSON
+                        字符串且需要提取特定字段时使用。 使用点号表示法遍历嵌套对象：
                     </P>
                     <List>
                         <Li>
@@ -1495,14 +1494,14 @@ required: ["access_token"]`}</CodeBlock>
                             <Code>value.teams.E7RBBBXHB.token</Code>
                         </Li>
                         <Li>
-                            <Code>jsonPath: secret</Code> — 读取顶层 <Code>secret</Code>{' '}
-                            字段（MSAL 令牌对象将原始令牌存储在此处）
+                            <Code>jsonPath: secret</Code> — 读取顶层 <Code>secret</Code> 字段（MSAL
+                            令牌对象将原始令牌存储在此处）
                         </Li>
                     </List>
 
                     <P>
-                        <strong>调试方法：</strong>打开浏览器 DevTools → Application → Local
-                        Storage → 选择对应域名。找到与你的模式匹配的键，然后检查其值以确定正确的{' '}
+                        <strong>调试方法：</strong>打开浏览器 DevTools → Application → Local Storage
+                        → 选择对应域名。找到与你的模式匹配的键，然后检查其值以确定正确的{' '}
                         <Code>jsonPath</Code>。
                     </P>
 

--- a/website/src/content/docs-zh.tsx
+++ b/website/src/content/docs-zh.tsx
@@ -129,6 +129,16 @@ export const pageContent = {
         tocItem('#config-apply', 'apply[] 规则', {
             level: 1,
             parent: '#configuration',
+            prefix: '├ ',
+        }),
+        tocItem('#required-field', 'required 字段', {
+            level: 1,
+            parent: '#configuration',
+            prefix: '├ ',
+        }),
+        tocItem('#localstorage-extraction', 'localStorage 提取', {
+            level: 1,
+            parent: '#configuration',
             prefix: '└ ',
         }),
         tocItem('#browser-adapters', '浏览器适配器'),
@@ -1307,6 +1317,236 @@ providers:
 
   # 注入到查询字符串
   - { in: query, name: api_key, value: "\${api_key}" }`}</CodeBlock>
+
+                    <SectionHeading id="required-field" level={2}>
+                        <Code>required</Code> 字段
+                    </SectionHeading>
+                    <P>
+                        <Code>required</Code>{' '}
+                        字段用于验证提取的凭证中是否包含特定的 cookie，只有通过验证才会存储。
+                        如果不使用此字段，sigcli 可能会将追踪 cookie 或游客 cookie
+                        存储为有效凭证——大多数公开网站会对所有访客设置这类无用的 cookie。
+                    </P>
+                    <P>
+                        <strong>格式：</strong>{' '}
+                        <Code>{"required: [\"<as>.<cookie_name>\"]"}</Code> —— 前缀是 extract
+                        规则中的 <Code>as</Code> 名称，后缀是必须存在于提取值中的 cookie 名称。
+                    </P>
+                    <CodeBlock lang="yaml">{`# 要求 "cookie" 提取结果中包含两个特定 cookie
+required: ["cookie.reddit_session", "cookie.token_v2"]
+
+# 要求 localStorage 令牌存在（只需 as 名称，无需点后缀）
+required: ["access_token"]`}</CodeBlock>
+                    <P>
+                        <strong>缺少必要 cookie 时的行为：</strong>
+                    </P>
+                    <List>
+                        <Li>无头提取立即被拒绝——sigcli 不会存储结果。</Li>
+                        <Li>
+                            sigcli 回退到 CDP（真实浏览器，用户实际已登录）并重新检查。
+                        </Li>
+                        <Li>
+                            如果 CDP 也未通过 required 检查，认证失败并显示明确的错误信息，
+                            列出缺失的 cookie。
+                        </Li>
+                    </List>
+                    <P>
+                        <strong>何时使用：</strong>为任何公共网站（社交媒体、论坛、新闻网站）的提供者添加{' '}
+                        <Code>required</Code>。这些网站会对所有访客设置 cookie；没有{' '}
+                        <Code>required</Code>，自动创建的提供者会将这些无用的游客 cookie
+                        存储为登录成功。
+                    </P>
+                    <CodeBlock lang="yaml">{`reddit:
+  domains: [www.reddit.com, reddit.com]
+  entryUrl: https://www.reddit.com/
+  strategy: browser
+  required: ["cookie.reddit_session", "cookie.token_v2"]
+  extract:
+    - from: cookies
+      as: cookie
+      match: "*"
+  apply:
+    - in: header
+      name: Cookie
+      value: "\${cookie}"`}</CodeBlock>
+                    <P>常见网站及其登录后所需的 cookie：</P>
+                    <div className="w-full max-w-full overflow-x-auto" style={{ padding: '8px 0' }}>
+                        <table
+                            className="w-full"
+                            style={{ borderSpacing: 0, borderCollapse: 'collapse' }}
+                        >
+                            <thead>
+                                <tr>
+                                    {['网站', '必要 Cookie'].map((h) => (
+                                        <th
+                                            key={h}
+                                            className="text-left"
+                                            style={{
+                                                padding: '4px 12px 4px 0',
+                                                fontSize: 'var(--type-table-size)',
+                                                fontFamily: 'var(--font-primary)',
+                                                fontWeight: 400,
+                                                color: 'var(--text-muted)',
+                                                borderBottom: '1px solid var(--page-border)',
+                                            }}
+                                        >
+                                            {h}
+                                        </th>
+                                    ))}
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {[
+                                    ['Bilibili', 'SESSDATA, bili_jct'],
+                                    ['Reddit', 'reddit_session, token_v2'],
+                                    ['X (Twitter)', 'ct0, auth_token'],
+                                    ['YouTube', 'SAPISID, __Secure-3PAPISID'],
+                                    ['LinkedIn', 'JSESSIONID, li_at'],
+                                ].map(([site, cookies]) => (
+                                    <tr key={site}>
+                                        <td
+                                            style={{
+                                                padding: '4px 12px 4px 0',
+                                                fontSize: 'var(--type-table-size)',
+                                                fontFamily: 'var(--font-primary)',
+                                                fontWeight: 475,
+                                                color: 'var(--text-primary)',
+                                                borderBottom: '1px solid var(--page-border)',
+                                            }}
+                                        >
+                                            {site}
+                                        </td>
+                                        <td
+                                            style={{
+                                                padding: '4px 12px 4px 0',
+                                                fontSize: 'var(--type-table-size)',
+                                                fontFamily: 'var(--font-code)',
+                                                fontWeight: 475,
+                                                color: 'var(--text-primary)',
+                                                borderBottom: '1px solid var(--page-border)',
+                                            }}
+                                        >
+                                            {cookies}
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <SectionHeading id="localstorage-extraction" level={2}>
+                        localStorage 提取
+                    </SectionHeading>
+                    <P>
+                        部分网站将认证令牌存储在浏览器 localStorage 中而非 cookie 里。
+                        这在 OAuth2/MSAL 流程（Microsoft Teams、Graph API）、Slack
+                        以及现代单页应用中很常见。在 extract 规则中使用{' '}
+                        <Code>from: localStorage</Code> 来捕获这些令牌。
+                    </P>
+
+                    <P>
+                        <strong>工作原理：</strong><Code>match</Code>{' '}
+                        字段指定要查找的 localStorage 键——可以是精确的键名，也可以是使用{' '}
+                        <Code>*</Code> 通配符的 glob 模式。可选的 <Code>jsonPath</Code>{' '}
+                        字段在 localStorage 条目为 JSON 字符串时提取嵌套的值。
+                    </P>
+
+                    <CodeBlock lang="yaml">{`extract:
+  # 精确键名查找
+  - from: localStorage
+    as: xoxc-token
+    match: "localConfig_v2"
+    jsonPath: "teams.E7RBBBXHB.token"
+
+  # glob 模式（MSAL 使用长复合键存储令牌）
+  - from: localStorage
+    as: access_token
+    match: "*|accesstoken|*graph.microsoft.com*"
+    jsonPath: secret`}</CodeBlock>
+
+                    <P>
+                        <strong>匹配模式：</strong>
+                    </P>
+                    <List>
+                        <Li>
+                            <strong>精确匹配：</strong>{' '}
+                            <Code>match: "localConfig_v2"</Code> — 查找完全匹配的 localStorage 键。
+                        </Li>
+                        <Li>
+                            <strong>glob 模式：</strong>{' '}
+                            <Code>{'match: "*|accesstoken|*graph.microsoft.com*"'}</Code> — 使用{' '}
+                            <Code>*</Code> 通配符匹配键名。MSAL 使用类似{' '}
+                            <Code>
+                                {
+                                    'user@tenant.com-login.microsoftonline.com-accesstoken-client_id-graph.microsoft.com-openid'
+                                }
+                            </Code>{' '}
+                            的长复合键存储 OAuth2 令牌；glob 模式可以匹配不同租户或客户端 ID 的所有键。
+                        </Li>
+                    </List>
+
+                    <P>
+                        <strong>jsonPath：</strong>当 localStorage 值是 JSON 字符串且需要提取特定字段时使用。
+                        使用点号表示法遍历嵌套对象：
+                    </P>
+                    <List>
+                        <Li>
+                            <Code>jsonPath: "teams.E7RBBBXHB.token"</Code> — 提取{' '}
+                            <Code>value.teams.E7RBBBXHB.token</Code>
+                        </Li>
+                        <Li>
+                            <Code>jsonPath: secret</Code> — 读取顶层 <Code>secret</Code>{' '}
+                            字段（MSAL 令牌对象将原始令牌存储在此处）
+                        </Li>
+                    </List>
+
+                    <P>
+                        <strong>调试方法：</strong>打开浏览器 DevTools → Application → Local
+                        Storage → 选择对应域名。找到与你的模式匹配的键，然后检查其值以确定正确的{' '}
+                        <Code>jsonPath</Code>。
+                    </P>
+
+                    <P>
+                        <strong>Microsoft Teams（MSAL OAuth2）：</strong>
+                    </P>
+                    <CodeBlock lang="yaml">{`ms-teams:
+  domains: [teams.cloud.microsoft]
+  entryUrl: https://teams.cloud.microsoft/v2/
+  strategy: browser
+  required: ["access_token"]
+  extract:
+    - from: localStorage
+      as: access_token
+      match: "*|accesstoken|*ic3.teams.office.com*"
+      jsonPath: secret
+  apply:
+    - in: header
+      name: Authorization
+      value: "Bearer \${access_token}"`}</CodeBlock>
+
+                    <P>
+                        <strong>Slack（cookie + localStorage）：</strong>
+                    </P>
+                    <CodeBlock lang="yaml">{`app-slack:
+  domains: [your-org.enterprise.slack.com]
+  entryUrl: https://app.slack.com/client/YOUR_TEAM_ID
+  strategy: browser
+  required: ["session.d", "xoxc-token"]
+  extract:
+    - from: cookies
+      as: session
+      match: "*"
+    - from: localStorage
+      as: xoxc-token
+      match: "localConfig_v2"
+      jsonPath: "teams.YOUR_TEAM_ID.token"
+  apply:
+    - in: header
+      name: Cookie
+      value: "\${session}"
+    - in: header
+      name: Authorization
+      value: "Bearer \${xoxc-token}"`}</CodeBlock>
 
                     <P>
                         <strong>实际示例：</strong>

--- a/website/src/content/docs.tsx
+++ b/website/src/content/docs.tsx
@@ -1121,13 +1121,13 @@ providers:
                     <P>
                         The <Code>required</Code> field validates that extracted credentials contain
                         specific cookies before sigcli accepts and stores them. Without it, sigcli
-                        may happily store tracking or guest cookies that most public websites set for
-                        every visitor — leaving you with useless credentials.
+                        may happily store tracking or guest cookies that most public websites set
+                        for every visitor — leaving you with useless credentials.
                     </P>
                     <P>
-                        <strong>Format:</strong> <Code>{"required: [\"<as>.<cookie_name>\"]"}</Code>{' '}
-                        — the prefix is the <Code>as</Code> name from your extract rule, the suffix
-                        is the cookie name that must be present inside that extracted value.
+                        <strong>Format:</strong> <Code>{'required: ["<as>.<cookie_name>"]'}</Code> —
+                        the prefix is the <Code>as</Code> name from your extract rule, the suffix is
+                        the cookie name that must be present inside that extracted value.
                     </P>
                     <CodeBlock lang="yaml">{`# Require two specific cookies inside the "cookie" extraction
 required: ["cookie.reddit_session", "cookie.token_v2"]

--- a/website/src/content/docs.tsx
+++ b/website/src/content/docs.tsx
@@ -120,6 +120,16 @@ export const pageContent = {
         tocItem('#config-apply', 'apply[] rules', {
             level: 1,
             parent: '#configuration',
+            prefix: '├ ',
+        }),
+        tocItem('#required-field', 'The required field', {
+            level: 1,
+            parent: '#configuration',
+            prefix: '├ ',
+        }),
+        tocItem('#localstorage-extraction', 'localStorage extraction', {
+            level: 1,
+            parent: '#configuration',
             prefix: '└ ',
         }),
         tocItem('#browser-adapters', 'Browser Adapters'),
@@ -1104,6 +1114,241 @@ providers:
 
   # Inject into query string
   - { in: query, name: api_key, value: "\${api_key}" }`}</CodeBlock>
+
+                    <SectionHeading id="required-field" level={2}>
+                        The <Code>required</Code> field
+                    </SectionHeading>
+                    <P>
+                        The <Code>required</Code> field validates that extracted credentials contain
+                        specific cookies before sigcli accepts and stores them. Without it, sigcli
+                        may happily store tracking or guest cookies that most public websites set for
+                        every visitor — leaving you with useless credentials.
+                    </P>
+                    <P>
+                        <strong>Format:</strong> <Code>{"required: [\"<as>.<cookie_name>\"]"}</Code>{' '}
+                        — the prefix is the <Code>as</Code> name from your extract rule, the suffix
+                        is the cookie name that must be present inside that extracted value.
+                    </P>
+                    <CodeBlock lang="yaml">{`# Require two specific cookies inside the "cookie" extraction
+required: ["cookie.reddit_session", "cookie.token_v2"]
+
+# Require a localStorage token (no dot-suffix needed — the as name itself is checked)
+required: ["access_token"]`}</CodeBlock>
+                    <P>
+                        <strong>Behavior when required cookies are missing:</strong>
+                    </P>
+                    <List>
+                        <Li>
+                            Headless extraction is rejected immediately — sigcli does not store the
+                            result.
+                        </Li>
+                        <Li>
+                            Sigcli falls back to CDP (real browser, where you are actually logged
+                            in) and re-checks.
+                        </Li>
+                        <Li>
+                            If CDP also fails the required check, authentication fails with a clear
+                            error message listing the missing cookies.
+                        </Li>
+                    </List>
+                    <P>
+                        <strong>When to use it:</strong> Add <Code>required</Code> to any provider
+                        for a public site (social media, forums, news). These sites set cookies to
+                        all visitors; without <Code>required</Code>, auto-provisioned providers will
+                        store those useless guest cookies as if login succeeded.
+                    </P>
+                    <CodeBlock lang="yaml">{`reddit:
+  domains: [www.reddit.com, reddit.com]
+  entryUrl: https://www.reddit.com/
+  strategy: browser
+  required: ["cookie.reddit_session", "cookie.token_v2"]
+  extract:
+    - from: cookies
+      as: cookie
+      match: "*"
+  apply:
+    - in: header
+      name: Cookie
+      value: "\${cookie}"`}</CodeBlock>
+                    <P>Common sites and the cookies they require after login:</P>
+                    <div className="w-full max-w-full overflow-x-auto" style={{ padding: '8px 0' }}>
+                        <table
+                            className="w-full"
+                            style={{ borderSpacing: 0, borderCollapse: 'collapse' }}
+                        >
+                            <thead>
+                                <tr>
+                                    {['Site', 'Required Cookies'].map((h) => (
+                                        <th
+                                            key={h}
+                                            className="text-left"
+                                            style={{
+                                                padding: '4px 12px 4px 0',
+                                                fontSize: 'var(--type-table-size)',
+                                                fontFamily: 'var(--font-primary)',
+                                                fontWeight: 400,
+                                                color: 'var(--text-muted)',
+                                                borderBottom: '1px solid var(--page-border)',
+                                            }}
+                                        >
+                                            {h}
+                                        </th>
+                                    ))}
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {[
+                                    ['Bilibili', 'SESSDATA, bili_jct'],
+                                    ['Reddit', 'reddit_session, token_v2'],
+                                    ['X (Twitter)', 'ct0, auth_token'],
+                                    ['YouTube', 'SAPISID, __Secure-3PAPISID'],
+                                    ['LinkedIn', 'JSESSIONID, li_at'],
+                                ].map(([site, cookies]) => (
+                                    <tr key={site}>
+                                        <td
+                                            style={{
+                                                padding: '4px 12px 4px 0',
+                                                fontSize: 'var(--type-table-size)',
+                                                fontFamily: 'var(--font-primary)',
+                                                fontWeight: 475,
+                                                color: 'var(--text-primary)',
+                                                borderBottom: '1px solid var(--page-border)',
+                                            }}
+                                        >
+                                            {site}
+                                        </td>
+                                        <td
+                                            style={{
+                                                padding: '4px 12px 4px 0',
+                                                fontSize: 'var(--type-table-size)',
+                                                fontFamily: 'var(--font-code)',
+                                                fontWeight: 475,
+                                                color: 'var(--text-primary)',
+                                                borderBottom: '1px solid var(--page-border)',
+                                            }}
+                                        >
+                                            {cookies}
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <SectionHeading id="localstorage-extraction" level={2}>
+                        localStorage Extraction
+                    </SectionHeading>
+                    <P>
+                        Some sites store auth tokens in browser localStorage instead of cookies.
+                        This is common with OAuth2/MSAL flows (Microsoft Teams, Graph API), Slack,
+                        and modern single-page applications. Use <Code>from: localStorage</Code> in
+                        your extract rules to capture these tokens.
+                    </P>
+
+                    <P>
+                        <strong>How it works:</strong> The <Code>match</Code> field specifies which
+                        localStorage key to look up — either an exact key name or a glob pattern
+                        using <Code>*</Code> wildcards. The optional <Code>jsonPath</Code> field
+                        extracts a nested value when the localStorage entry is a JSON string.
+                    </P>
+
+                    <CodeBlock lang="yaml">{`extract:
+  # Exact key lookup
+  - from: localStorage
+    as: xoxc-token
+    match: "localConfig_v2"
+    jsonPath: "teams.E7RBBBXHB.token"
+
+  # Glob pattern (MSAL stores tokens with long compound keys)
+  - from: localStorage
+    as: access_token
+    match: "*|accesstoken|*graph.microsoft.com*"
+    jsonPath: secret`}</CodeBlock>
+
+                    <P>
+                        <strong>Match patterns:</strong>
+                    </P>
+                    <List>
+                        <Li>
+                            <strong>Exact:</strong> <Code>match: "localConfig_v2"</Code> — looks up
+                            this exact localStorage key.
+                        </Li>
+                        <Li>
+                            <strong>Glob:</strong>{' '}
+                            <Code>{'match: "*|accesstoken|*graph.microsoft.com*"'}</Code> — matches
+                            keys using <Code>*</Code> wildcards. MSAL stores OAuth2 tokens with long
+                            compound keys like{' '}
+                            <Code>
+                                {
+                                    'user@tenant.com-login.microsoftonline.com-accesstoken-client_id-graph.microsoft.com-openid'
+                                }
+                            </Code>
+                            ; a glob pattern matches all of them regardless of tenant or client ID.
+                        </Li>
+                    </List>
+
+                    <P>
+                        <strong>jsonPath:</strong> Used when the localStorage value is a JSON string
+                        and you need a specific field. Uses dot notation to traverse nested objects:
+                    </P>
+                    <List>
+                        <Li>
+                            <Code>jsonPath: "teams.E7RBBBXHB.token"</Code> — traverses{' '}
+                            <Code>value.teams.E7RBBBXHB.token</Code>
+                        </Li>
+                        <Li>
+                            <Code>jsonPath: secret</Code> — reads the top-level <Code>secret</Code>{' '}
+                            field (MSAL token objects store the raw token here)
+                        </Li>
+                    </List>
+
+                    <P>
+                        <strong>Debugging:</strong> Open browser DevTools → Application → Local
+                        Storage → select the domain. Find the key that matches your pattern, then
+                        inspect the value to determine the correct <Code>jsonPath</Code>.
+                    </P>
+
+                    <P>
+                        <strong>Microsoft Teams (MSAL OAuth2):</strong>
+                    </P>
+                    <CodeBlock lang="yaml">{`ms-teams:
+  domains: [teams.cloud.microsoft]
+  entryUrl: https://teams.cloud.microsoft/v2/
+  strategy: browser
+  required: ["access_token"]
+  extract:
+    - from: localStorage
+      as: access_token
+      match: "*|accesstoken|*ic3.teams.office.com*"
+      jsonPath: secret
+  apply:
+    - in: header
+      name: Authorization
+      value: "Bearer \${access_token}"`}</CodeBlock>
+
+                    <P>
+                        <strong>Slack (cookie + localStorage):</strong>
+                    </P>
+                    <CodeBlock lang="yaml">{`app-slack:
+  domains: [your-org.enterprise.slack.com]
+  entryUrl: https://app.slack.com/client/YOUR_TEAM_ID
+  strategy: browser
+  required: ["session.d", "xoxc-token"]
+  extract:
+    - from: cookies
+      as: session
+      match: "*"
+    - from: localStorage
+      as: xoxc-token
+      match: "localConfig_v2"
+      jsonPath: "teams.YOUR_TEAM_ID.token"
+  apply:
+    - in: header
+      name: Cookie
+      value: "\${session}"
+    - in: header
+      name: Authorization
+      value: "Bearer \${xoxc-token}"`}</CodeBlock>
 
                     <P>
                         <strong>Real-world examples:</strong>


### PR DESCRIPTION
## Summary
- Fix auto-provision to write clean block-style YAML instead of inline JSON format
- Add provider configuration guide to README (required cookies, progressive approach)
- Add dedicated `required` field and localStorage extraction docs to website

## Test plan
- [x] `pnpm --filter @sigcli/cli build` — clean
- [x] `pnpm --filter @sigcli/cli test` — 390/390 pass
- [x] `pnpm --filter website build` — clean
- [x] Manual: `sig init --force && sig login <url>` produces block-style YAML