### PR TITLE
fix(cli): include version: 2 in sync push generated config

### DIFF
--- a/cli/src/config/loader.ts
+++ b/cli/src/config/loader.ts
@@ -57,6 +57,7 @@ export async function loadConfig(): Promise<Result<SigConfig, AuthError>> {
  */
 export async function saveConfig(config: SigConfig): Promise<void> {
     const filtered = {
+        version: 2,
         ...config,
         providers: Object.fromEntries(
             Object.entries(config.providers).filter(

--- a/cli/src/sync/sync-engine.ts
+++ b/cli/src/sync/sync-engine.ts
@@ -177,6 +177,7 @@ export class SyncEngine {
             if (remoteYaml === null) {
                 // Create a full config so the remote passes validation
                 doc = new YAML.Document({
+                    version: 2,
                     mode: 'browserless',
                     browser: {
                         browserDataDir: '~/.sig/browser-data',
@@ -203,6 +204,9 @@ export class SyncEngine {
                 doc.setIn(['providers'], doc.createNode(merged));
 
                 // Ensure required sections exist so remote passes validation
+                if (!doc.getIn(['version'])) {
+                    doc.setIn(['version'], 2);
+                }
                 if (!doc.getIn(['mode'])) {
                     doc.setIn(['mode'], 'browserless');
                 }

--- a/cli/tests/unit/sync/sync-engine.test.ts
+++ b/cli/tests/unit/sync/sync-engine.test.ts
@@ -56,9 +56,10 @@ const testRemote: RemoteConfig = {
 };
 
 const testConfig: SigConfig = {
+    mode: 'browser',
     browser: {
         browserDataDir: '~/.sig/browser-data',
-        channel: 'chrome',
+        execPath: '',
         headlessTimeout: 30000,
         visibleTimeout: 120000,
         waitUntil: 'load',
@@ -69,21 +70,28 @@ const testConfig: SigConfig = {
     providers: {
         jira: {
             domains: ['jira.example.com'],
-            strategy: 'cookie',
-            config: { ttl: '12h' },
+            entryUrl: 'https://jira.example.com/',
+            strategy: 'browser',
+            ttl: '12h',
+            extract: [{ from: 'cookies', as: 'session', match: '*' }],
+            apply: [{ in: 'header', name: 'Cookie', value: '${session}' }],
         },
         github: {
             domains: ['github.com', 'api.github.com'],
-            strategy: 'api-token',
-            config: { headerName: 'Authorization', headerPrefix: 'Bearer' },
+            entryUrl: 'https://github.com/',
+            strategy: 'browser',
+            extract: [{ from: 'cookies', as: 'session', match: '*' }],
+            apply: [{ in: 'header', name: 'Cookie', value: '${session}' }],
         },
     },
 };
 
 const remoteConfigYaml = `# SigCLI config
+version: 2
+mode: browserless
 browser:
   browserDataDir: ~/.sig/browser-data
-  channel: chrome
+  execPath: ""
   headlessTimeout: 30000
   visibleTimeout: 120000
   waitUntil: load
@@ -93,13 +101,24 @@ providers:
   existing-remote:
     domains:
       - remote.example.com
-    strategy: cookie
+    entryUrl: https://remote.example.com/
+    strategy: browser
+    extract:
+      - from: cookies
+        as: session
+        match: "*"
+    apply:
+      - in: header
+        name: Cookie
+        value: \${session}
 `;
 
 const localConfigYaml = `# SigCLI config
+version: 2
+mode: browser
 browser:
   browserDataDir: ~/.sig/browser-data
-  channel: chrome
+  execPath: ""
   headlessTimeout: 30000
   visibleTimeout: 120000
   waitUntil: load
@@ -109,7 +128,16 @@ providers:
   local-only:
     domains:
       - local.example.com
-    strategy: cookie
+    entryUrl: https://local.example.com/
+    strategy: browser
+    extract:
+      - from: cookies
+        as: session
+        match: "*"
+    apply:
+      - in: header
+        name: Cookie
+        value: \${session}
 `;
 
 describe('SyncEngine', () => {


### PR DESCRIPTION
## Summary
- `sig sync push` was generating remote `config.yaml` without the `version: 2` field, producing invalid config on the remote machine
- Added `version: 2` to both new and existing remote configs during push
- `saveConfig()` also now includes `version: 2` when writing local config
- Updated test fixtures to use v2 format (proper `strategy: 'browser'`, `extract`/`apply` arrays)

## Test plan
- [x] All 363 tests pass
- [x] `sig sync push` to a new remote generates config with `version: 2`
- [x] `sig sync push` to an existing remote without version adds `version: 2`