### PR TITLE
fix(browser): headless navigation + suppress logs for read commands

### DIFF
--- a/cli/src/cli-router.ts
+++ b/cli/src/cli-router.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 import { Command, isOk } from './types/index.js';
 import { getConfigPath, loadConfig } from './config/loader.js';
 import { ExitCode } from './utils/exit-codes.js';
+import { createNoopLogger, createOperationalLogger } from './utils/logger.js';
 import { AuthManager } from './auth-manager.js';
 import { runCompletion } from './commands/completion.js';
 import { runDoctor } from './commands/doctor.js';
@@ -140,6 +141,7 @@ Setup:
 Security: proxy ≥ request > run > get. Full docs at https://sigcli.ai/docs/#security
 
 Global options:
+  --verbose                    Show debug output to stderr
   --help                       Show this help
 `;
 
@@ -202,7 +204,16 @@ export async function run(args: string[]): Promise<void> {
         }
         const config = configResult.value;
 
-        auth = await AuthManager.create(config);
+        const VERBOSE_COMMANDS: ReadonlySet<string> = new Set([
+            Command.LOGIN,
+            Command.REQUEST,
+            Command.RUN,
+            Command.SYNC,
+            Command.PROXY,
+        ]);
+        const verbose = flags.verbose === true || VERBOSE_COMMANDS.has(command);
+        const logger = verbose ? createOperationalLogger() : createNoopLogger();
+        auth = await AuthManager.create(config, logger);
     }
 
     switch (command) {

--- a/cli/src/strategies/browser/browser-strategy.ts
+++ b/cli/src/strategies/browser/browser-strategy.ts
@@ -102,6 +102,19 @@ export class BrowserStrategy implements IStrategy {
             cdpClient = await connectCdpWs(wsUrl);
             this.logger.info(`${provider.id}: headless CDP connected`);
 
+            // Navigate to entryUrl so the server can set session cookies (e.g. JSESSIONID)
+            const sessionId = await attachToPageTarget(cdpClient);
+            if (sessionId) {
+                await cdpClient.send('Page.navigate', { url: provider.entryUrl }, sessionId);
+                await this.waitForPageReady(
+                    cdpClient,
+                    sessionId,
+                    provider.waitUntil ?? this.browserConfig.waitUntil,
+                    this.browserConfig.headlessTimeout,
+                );
+                this.logger.info(`${provider.id}: headless navigated to entryUrl`);
+            }
+
             const credentials: ExtractedCredentials = {};
             let expiresAt: string | undefined;
 
@@ -329,8 +342,35 @@ export class BrowserStrategy implements IStrategy {
             return result?.result?.value as T;
         };
     }
-}
 
-// =========================================================================
-// Helpers
-// =========================================================================
+    private async waitForPageReady(
+        cdp: CdpWsClient,
+        sessionId: string,
+        waitUntil: string,
+        timeout: number,
+    ): Promise<void> {
+        const deadline = Date.now() + timeout;
+        const targetState = waitUntil === 'domcontentloaded' ? 'interactive' : 'complete';
+
+        if (waitUntil === 'commit') {
+            await new Promise((r) => setTimeout(r, 500));
+            return;
+        }
+
+        while (Date.now() < deadline) {
+            try {
+                await cdp.send('Runtime.enable', {}, sessionId).catch(() => {});
+                const result = (await cdp.send(
+                    'Runtime.evaluate',
+                    { expression: 'document.readyState', returnByValue: true },
+                    sessionId,
+                )) as { result?: { value?: string } };
+                const state = result?.result?.value;
+                if (state === 'complete' || state === targetState) return;
+            } catch {
+                // Page may be mid-navigation
+            }
+            await new Promise((r) => setTimeout(r, 300));
+        }
+    }
+}

--- a/cli/tests/unit/cli/help-text.test.ts
+++ b/cli/tests/unit/cli/help-text.test.ts
@@ -106,10 +106,10 @@ describe('CLI help text grouping (#9)', () => {
         expect(output).toContain('--remote');
     });
 
-    it('help output does not mention --verbose', async () => {
+    it('help output mentions --verbose', async () => {
         await run(['help']);
         const output = stdoutChunks.join('');
-        expect(output).not.toContain('--verbose');
+        expect(output).toContain('--verbose');
     });
 
     it('--help flag on any command shows help text', async () => {


### PR DESCRIPTION
## Summary
- Headless extraction now navigates to `entryUrl` before reading cookies, fixing sites like Jira that only set session cookies (JSESSIONID) after a server round-trip
- Suppresses `[sig]` operational logs for read-only commands (`status`, `providers`, `get`, `logout`, `watch`, `rename`, `remove`) — logs only show for interactive commands (`login`, `request`, `run`, `sync`, `proxy`) or with `--verbose`
- Adds `--verbose` global flag to opt-in to debug logs on any command

## Test plan
- [x] `sig login jira-tools --force` extracts JSESSIONID
- [x] `sig request jira.tools.sap/rest/api/2/myself` returns 200
- [x] `sig status` / `sig providers` / `sig get` — no `[sig]` log noise
- [x] `sig status --verbose` — shows logs
- [x] `sig login` — still shows operational logs by default
- [x] v2ex/reddit headless — no regression (fallback works correctly)
- [x] All 363 tests pass