### PR TITLE
fix(x-skill): use plain session for transaction ID bootstrap

### DIFF
--- a/skills/x/scripts/x_client.py
+++ b/skills/x/scripts/x_client.py
@@ -285,10 +285,14 @@ class XClient:
         if self._ct is not None:
             return
         try:
-            home = self._session.get("https://x.com", timeout=TIMEOUT)
+            # Use a plain session without Bearer/Auth headers — X returns 401
+            # on the home page when Authorization header is present with cookie.
+            plain = requests.Session()
+            plain.headers.update({"User-Agent": USER_AGENT})
+            home = plain.get("https://x.com", timeout=TIMEOUT)
             soup = bs4.BeautifulSoup(home.content, "html.parser")
             ondemand_url = get_ondemand_file_url(response=soup)
-            ondemand_resp = self._session.get(ondemand_url, timeout=TIMEOUT)
+            ondemand_resp = plain.get(ondemand_url, timeout=TIMEOUT)
             self._ct = ClientTransaction(home_page_response=soup, ondemand_file_response=ondemand_resp.text)
         except Exception:
             self._ct = None


### PR DESCRIPTION
## Summary
- Use a plain `requests.Session` (no Bearer/Auth headers) when fetching X homepage and ondemand.s bundle for ClientTransaction init
- X returns 401 when both `Authorization: Bearer` and `Cookie` headers are present on the homepage request

## Test plan
- [ ] Run x_search.py or any script that triggers `_ensure_ct()` — verify x-client-transaction-id header is generated without 401 errors