### PR TITLE
fix(browser): detect login page in headless before extracting stale credentials

### DIFF
--- a/cli/src/strategies/browser/browser-strategy.ts
+++ b/cli/src/strategies/browser/browser-strategy.ts
@@ -131,6 +131,20 @@ export class BrowserStrategy implements IStrategy {
                     this.browserConfig.headlessTimeout,
                 );
                 this.logger.info(`${provider.id}: headless navigated to entryUrl`);
+
+                // If page landed on a login/SSO page, session is stale — fall back
+                const currentUrl = await this.getCdpPageUrl(cdpClient, sessionId);
+                const evaluate = this.makeCdpEvaluator(cdpClient, sessionId);
+                const authenticated = await this.pageState.isAuthenticated(
+                    currentUrl,
+                    provider.domains,
+                    evaluate,
+                    provider.loginUrlPatterns,
+                );
+                if (!authenticated) {
+                    this.logger.info(`${provider.id}: headless landed on login page, falling back`);
+                    return null;
+                }
             }
 
             const credentials: ExtractedCredentials = {};


### PR DESCRIPTION
## Summary

- When headless browser navigates to a provider's entryUrl and the session is expired, the server redirects to an SSO/login page
- Previously sigcli would extract stale cookies from the browser jar regardless, silently storing invalid credentials
- Now checks if the page landed on a login/SSO page (using existing `PageStateChecker`) before extracting
- If login page detected, returns `null` to trigger fallback to visible mode (or clean failure with `--mode headless`)

## Test plan

- [x] `sig login https://bdc-cockpit-rel-hc-ga.rel.hanacloudservices.cloud.sap/ --mode headless` — detects SSO redirect, logs "headless landed on login page, falling back"
- [x] `sig login https://teams.cloud.microsoft/v2/` — cached token still works (no regression)
- [x] All 429 unit tests pass