### PR TITLE
fix(browser): reject expired localStorage tokens during extraction

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sigcli/cli",
-    "version": "1.6.5",
+    "version": "1.6.6",
     "description": "General-purpose authentication CLI with pluggable strategies and browser adapters",
     "main": "dist/index.js",
     "type": "module",

--- a/cli/src/strategies/browser/extractors/cdp-storage.ts
+++ b/cli/src/strategies/browser/extractors/cdp-storage.ts
@@ -39,6 +39,11 @@ export class CdpStorageExtractor implements IBrowserExtractor {
                 }
             }
 
+            // If expiresAt is in the past, the token is stale — treat as not found
+            if (expiresAt && new Date(expiresAt).getTime() <= Date.now()) {
+                return null;
+            }
+
             let value = rawValue;
             if (rule.jsonPath) {
                 try {


### PR DESCRIPTION
## Summary

- When extracting a localStorage token with `expiresJsonPath` configured, reject the value if the expiry is in the past
- Prevents headless extraction from silently storing an expired/stale token
- In `auto` mode, this causes proper fallback to visible browser where MSAL can refresh via user interaction
- In visible mode (poll loop), this keeps polling until MSAL refreshes the token instead of returning immediately

## Root cause

MSAL caches access tokens in localStorage. When the token expires and the browser hasn't been used for hours, headless extraction finds the stale token, passes `checkRequired` (the key exists), and stores it as valid. The API then rejects with 401.

## Test plan

- [x] `pnpm test` — 429 tests pass
- [x] Manual: with an expired localStorage token, `sig login --mode auto` now falls back to visible mode instead of storing the expired token
- [x] Manual: fresh token from visible mode works with Teams API (no 401)