### PR TITLE
chore(skills): rename Signet → SigCLI in all skill docs

### DIFF
--- a/skills/bilibili/SKILL.md
+++ b/skills/bilibili/SKILL.md
@@ -48,7 +48,7 @@ Once valid + proxy detected, go straight to executing the user's request.
 sig run bilibili -- bash -c 'python3 scripts/bilibili_like.py --cookie "$SIG_BILIBILI_COOKIE" --aid 123456'
 ```
 
-The default Signet provider is `bilibili`. The env var is `SIG_BILIBILI_COOKIE`.
+The default SigCLI provider is `bilibili`. The env var is `SIG_BILIBILI_COOKIE`.
 
 If a write script returns auth error, re-authenticate:
 
@@ -56,7 +56,7 @@ If a write script returns auth error, re-authenticate:
 sig login https://www.bilibili.com/
 ```
 
-**Signet provider config:**
+**SigCLI provider config:**
 
 ```yaml
 bilibili:

--- a/skills/hackernews/SKILL.md
+++ b/skills/hackernews/SKILL.md
@@ -48,7 +48,7 @@ Once valid + proxy detected, go straight to executing the user's request.
 sig run hackernews -- bash -c 'python3 scripts/hn_vote.py --cookie "$SIG_HACKERNEWS_COOKIE" --id 12345'
 ```
 
-The default Signet provider is `hackernews`. The env var is `SIG_HACKERNEWS_COOKIE`.
+The default SigCLI provider is `hackernews`. The env var is `SIG_HACKERNEWS_COOKIE`.
 
 If a write script returns auth error, re-authenticate:
 
@@ -58,7 +58,7 @@ sig login hackernews
 
 Then retry the `sig run` command.
 
-**Signet provider config:**
+**SigCLI provider config:**
 
 ```yaml
 hackernews:

--- a/skills/linkedin/SKILL.md
+++ b/skills/linkedin/SKILL.md
@@ -46,7 +46,7 @@ Once valid + proxy detected, go straight to executing the user's request.
 sig run linkedin -- bash -c 'python3 scripts/linkedin_me.py --cookie "$SIG_LINKEDIN_COOKIE"'
 ```
 
-The default Signet provider is `linkedin`. The env var is `SIG_LINKEDIN_COOKIE`.
+The default SigCLI provider is `linkedin`. The env var is `SIG_LINKEDIN_COOKIE`.
 
 > **Note:** If `sig login` creates the provider as `www-linkedin` (from the domain), the env var will be `SIG_WWW_LINKEDIN_COOKIE`. You can rename it: `sig rename www-linkedin linkedin`.
 
@@ -58,7 +58,7 @@ sig login linkedin
 
 This opens the user's real browser via CDP (no automation markers), avoiding LinkedIn's bot detection.
 
-**Signet provider config:**
+**SigCLI provider config:**
 
 ```yaml
 linkedin:

--- a/skills/msteams/SKILL.md
+++ b/skills/msteams/SKILL.md
@@ -9,7 +9,7 @@ Send and read messages, search conversations, look up people, check calendar, ge
 
 ## Authentication
 
-This skill requires **two tokens** from Signet for full functionality. Use `sig run` to inject them as environment variables:
+This skill requires **two tokens** from SigCLI for full functionality. Use `sig run` to inject them as environment variables:
 
 **Scripts needing only Chat token** (conversations, messages, send, meetings):
 

--- a/skills/outlook/SKILL.md
+++ b/skills/outlook/SKILL.md
@@ -17,13 +17,13 @@ The Graph API token lacks `Mail.Send` scope (your organization's Azure AD policy
 
 ## Authentication
 
-This skill requires a **Graph API token** from Signet. Use `sig run` to inject it as an environment variable:
+This skill requires a **Graph API token** from SigCLI. Use `sig run` to inject it as an environment variable:
 
 ```bash
 sig run ms-graph -- bash -c 'python3 scripts/outlook_messages.py --graph-token "$SIG_MS_GRAPH_ACCESS_TOKEN" --unread-only --limit 10'
 ```
 
-The default Signet provider is `ms-graph`. The env var name follows the rule: `SIG_<PROVIDER>_<AS>` where `<PROVIDER>` is the provider name uppercased with `-` replaced by `_`, and `<AS>` is the extract rule's `as` field uppercased. For ms-graph with `as: access_token`, the env var is `SIG_MS_GRAPH_ACCESS_TOKEN`.
+The default SigCLI provider is `ms-graph`. The env var name follows the rule: `SIG_<PROVIDER>_<AS>` where `<PROVIDER>` is the provider name uppercased with `-` replaced by `_`, and `<AS>` is the extract rule's `as` field uppercased. For ms-graph with `as: access_token`, the env var is `SIG_MS_GRAPH_ACCESS_TOKEN`.
 
 **Note:** `sig run` injects the raw JWT (without `Bearer` prefix). The scripts add `Bearer` themselves.
 
@@ -35,7 +35,7 @@ sig login https://teams.cloud.microsoft/v2/
 
 Then retry the `sig run` command.
 
-**Signet provider config** (already in `sigcli-auth/SKILL.md`):
+**SigCLI provider config** (already in `sigcli-auth/SKILL.md`):
 
 ```yaml
 ms-graph:

--- a/skills/reddit/SKILL.md
+++ b/skills/reddit/SKILL.md
@@ -48,7 +48,7 @@ Once valid + proxy detected, go straight to executing the user's request.
 sig run reddit -- bash -c 'python3 scripts/reddit_comment.py --cookie "$SIG_REDDIT_COOKIE" --parent t3_1abc --text "Great post!"'
 ```
 
-The default Signet provider is `reddit`. The env var is `SIG_REDDIT_COOKIE`.
+The default SigCLI provider is `reddit`. The env var is `SIG_REDDIT_COOKIE`.
 
 If a write script returns auth error, re-authenticate:
 
@@ -58,7 +58,7 @@ sig login reddit
 
 Then retry the `sig run` command.
 
-**Signet provider config:**
+**SigCLI provider config:**
 
 ```yaml
 reddit:

--- a/skills/slack/scripts/slack_client.py
+++ b/skills/slack/scripts/slack_client.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Shared Slack Web API client for Slack skill scripts.
 
-Handles Signet token extraction, HTTP transport with xoxc/xoxd auth,
+Handles SigCLI token extraction, HTTP transport with xoxc/xoxd auth,
 rate-limit retries, channel resolution, and time-range parsing.
 """
 
@@ -50,7 +50,7 @@ def error_response(code: str, message: str) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Token extraction from Signet
+# Token extraction from SigCLI
 # ---------------------------------------------------------------------------
 
 
@@ -96,7 +96,7 @@ class SlackClient:
 
     Auth is sent as:
     - ``token`` form parameter (xoxc)
-    - ``Cookie`` header (full cookie string from Signet, containing ``d=xoxd-...``)
+    - ``Cookie`` header (full cookie string from SigCLI, containing ``d=xoxd-...``)
     """
 
     def __init__(self, xoxc: str, cookies: str):
@@ -113,7 +113,7 @@ class SlackClient:
 
     @classmethod
     def create(cls) -> SlackClient:
-        """Create a client by extracting credentials from Signet."""
+        """Create a client by extracting credentials from SigCLI."""
         xoxc, cookies = get_slack_credentials()
         return cls(xoxc, cookies)
 

--- a/skills/slack/tests/test_slack_client.py
+++ b/skills/slack/tests/test_slack_client.py
@@ -38,7 +38,7 @@ def _make_sig_result(stdout=VALID_SIG_STDOUT, returncode=0, stderr=""):
 
 
 def _make_client(xoxc="xoxc-test", cookies="d=xoxd-test; other=abc"):
-    """Create a SlackClient without calling Signet."""
+    """Create a SlackClient without calling SigCLI."""
     return mod.SlackClient(xoxc, cookies)
 
 

--- a/skills/v2ex/SKILL.md
+++ b/skills/v2ex/SKILL.md
@@ -46,7 +46,7 @@ This skill uses **cookie-based authentication** for full read/write access to V2
 sig run v2ex -- bash -c 'python3 scripts/v2ex_hot.py --cookie "$SIG_V2EX_COOKIE"'
 ```
 
-The default Signet provider is `v2ex`. The env var is `SIG_V2EX_COOKIE`.
+The default SigCLI provider is `v2ex`. The env var is `SIG_V2EX_COOKIE`.
 
 **Read-only operations** (hot topics, latest, topic detail, node info, member profile, search) work **without authentication** via the public V2EX API v1. The `--cookie` argument is optional for these scripts.
 
@@ -60,7 +60,7 @@ sig login https://www.v2ex.com/
 
 Then retry the `sig run` command.
 
-**Signet provider config:**
+**SigCLI provider config:**
 
 ```yaml
 v2ex:

--- a/skills/youtube/SKILL.md
+++ b/skills/youtube/SKILL.md
@@ -48,7 +48,7 @@ Once valid + proxy detected, go straight to executing the user's request.
 sig run youtube -- bash -c 'python3 scripts/youtube_like.py --cookie "$SIG_YOUTUBE_COOKIE" --video dQw4w9WgXcQ'
 ```
 
-The default Signet provider is `youtube`. The env var is `SIG_YOUTUBE_COOKIE`.
+The default SigCLI provider is `youtube`. The env var is `SIG_YOUTUBE_COOKIE`.
 
 > **Note:** If `sig login` creates the provider as `www-youtube` (from the domain), the env var will be `SIG_WWW_YOUTUBE_COOKIE`. You can rename it: `sig rename www-youtube youtube`.
 
@@ -58,7 +58,7 @@ If a write script returns auth error, re-authenticate:
 sig login youtube
 ```
 
-**Signet provider config:**
+**SigCLI provider config:**
 
 ```yaml
 youtube:

--- a/skills/zhihu/SKILL.md
+++ b/skills/zhihu/SKILL.md
@@ -46,7 +46,7 @@ This skill uses **cookie-based authentication** for access to Zhihu. Use `sig ru
 sig run zhihu -- bash -c 'python3 scripts/zhihu_hot.py --cookie "$SIG_ZHIHU_COOKIE"'
 ```
 
-The default Signet provider is `zhihu`. The env var is `SIG_ZHIHU_COOKIE`.
+The default SigCLI provider is `zhihu`. The env var is `SIG_ZHIHU_COOKIE`.
 
 **All operations require authentication** — Zhihu's API enforces cookie-based auth on all endpoints.
 
@@ -58,7 +58,7 @@ sig login https://www.zhihu.com/
 
 Then retry the `sig run` command.
 
-**Signet provider config:**
+**SigCLI provider config:**
 
 ```yaml
 zhihu:


### PR DESCRIPTION
## Summary

- Replaces all 23 occurrences of the old project name "Signet" with "SigCLI" across the `skills/` directory
- Affects 9 SKILL.md files and 2 Python files (slack client + test)

## Files changed

- `skills/bilibili/SKILL.md`
- `skills/hackernews/SKILL.md`
- `skills/linkedin/SKILL.md`
- `skills/msteams/SKILL.md`
- `skills/outlook/SKILL.md`
- `skills/reddit/SKILL.md`
- `skills/slack/scripts/slack_client.py`
- `skills/slack/tests/test_slack_client.py`
- `skills/v2ex/SKILL.md`
- `skills/youtube/SKILL.md`
- `skills/zhihu/SKILL.md`

## Test plan

- [x] `grep -ri signet skills/` returns zero matches after change
- [x] No code logic affected — documentation/comment-only changes