### PR TITLE
fix(browser): harden validate() and login for 3-phase flow

### DIFF
--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -92,7 +92,7 @@ export async function runLogin(
     // Step 4: Authenticate (3-phase cascade: no-nav → headless → visible)
     process.stderr.write(`[sig] Authenticating with "${provider.name}"...\n`);
     const result = await auth.getExtractedCreds(provider.id, {
-        force: true,
+        ...(flags.force === true ? { force: true } : {}),
         ...(networkProxy !== undefined ? { networkProxy } : {}),
         ...(loginMode !== undefined ? { loginMode } : {}),
     });

--- a/cli/src/strategies/browser/browser-strategy.ts
+++ b/cli/src/strategies/browser/browser-strategy.ts
@@ -21,14 +21,14 @@ import { parseDuration } from '../../utils/duration.js';
 import { createNoopLogger } from '../../utils/logger.js';
 import { expandHome } from '../../utils/path.js';
 import { killProcess } from '../../utils/process-kill.js';
-import { findFreePort, waitForBrowserReady } from './browser-lifecycle.js';
+import { findFreePort, removeSingletonLock, waitForBrowserReady } from './browser-lifecycle.js';
 import { acquireBrowser, releaseBrowser } from './cdp-state.js';
 import { attachToPageTarget, connectCdpWs, type CdpWsClient } from './cdp-ws.js';
 import { CdpCookieExtractor } from './extractors/cdp-cookie.js';
 import { CdpStorageExtractor } from './extractors/cdp-storage.js';
 
 const TRACKING_COOKIE_TTL_MS = 60_000;
-const EXISTING_STATE_TIMEOUT = 5000;
+const EXISTING_STATE_TIMEOUT = 15000;
 const LOGIN_PAGE_SETTLE_MS = 5000;
 const POLL_INTERVAL_MS = 3000;
 
@@ -93,6 +93,7 @@ export class BrowserStrategy implements IStrategy {
         const args = this.headlessArgs(dataDir, port);
         args.push('about:blank');
 
+        removeSingletonLock(dataDir);
         return this.withHeadlessBrowser(
             execPath,
             args,
@@ -124,6 +125,7 @@ export class BrowserStrategy implements IStrategy {
         const args = this.headlessArgs(dataDir, port, provider.networkProxy);
         args.push(provider.entryUrl);
 
+        removeSingletonLock(dataDir);
         return this.withHeadlessBrowser(
             execPath,
             args,

--- a/cli/src/utils/credential-validator.ts
+++ b/cli/src/utils/credential-validator.ts
@@ -16,10 +16,10 @@ import { buildUserAgent } from './http.js';
  *
  * Rules:
  *   - empty credentials → false
- *   - 401/403 → false
+ *   - 401/403 → retry once, then false
  *   - 3xx redirect to login URL → false
  *   - 2xx → true
- *   - network error → true (optimistic)
+ *   - network error → false
  */
 export async function validate(
     provider: ProviderConfig,
@@ -30,32 +30,42 @@ export async function validate(
     const url = provider.validateUrl ?? provider.entryUrl;
     if (!url) return true;
 
-    try {
-        const headers = ApplyEngine.applyRules(provider.apply, credentials).headers;
-        const dispatcher = provider.networkProxy
-            ? createProxyDispatcher(provider.networkProxy)
-            : undefined;
+    const headers = ApplyEngine.applyRules(provider.apply, credentials).headers;
+    const dispatcher = provider.networkProxy
+        ? createProxyDispatcher(provider.networkProxy)
+        : undefined;
 
-        const res = await fetch(url, {
-            method: 'GET',
-            headers: { ...headers, [HttpHeader.USER_AGENT]: buildUserAgent() },
-            redirect: 'manual',
-            dispatcher,
-            signal: AbortSignal.timeout(10_000),
-        });
+    for (let attempt = 0; attempt < 2; attempt++) {
+        try {
+            const res = await fetch(url, {
+                method: 'GET',
+                headers: { ...headers, [HttpHeader.USER_AGENT]: buildUserAgent() },
+                redirect: 'manual',
+                dispatcher,
+                signal: AbortSignal.timeout(10_000),
+            });
 
-        if (res.status === 401 || res.status === 403) return false;
+            if (res.status === 401 || res.status === 403) {
+                if (attempt === 0) {
+                    await new Promise((r) => setTimeout(r, 1000));
+                    continue;
+                }
+                return false;
+            }
 
-        if (res.status >= 300 && res.status < 400) {
-            if (provider.validateUrl) return false;
-            const location = (res.headers.get('location') ?? '').toLowerCase();
-            return !LOGIN_URL_PATTERNS.some((p) => location.includes(p));
+            if (res.status >= 300 && res.status < 400) {
+                if (provider.validateUrl) return false;
+                const location = (res.headers.get('location') ?? '').toLowerCase();
+                return !LOGIN_URL_PATTERNS.some((p) => location.includes(p));
+            }
+
+            return true;
+        } catch {
+            return false;
         }
-
-        return true;
-    } catch {
-        return true;
     }
+
+    return false;
 }
 
 /**

--- a/cli/tests/unit/utils/credential-validator.test.ts
+++ b/cli/tests/unit/utils/credential-validator.test.ts
@@ -1,0 +1,127 @@
+import http from 'node:http';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { ProviderConfig } from '../../../src/types/index.js';
+import { validate } from '../../../src/utils/credential-validator.js';
+
+function makeProvider(port: number, overrides: Partial<ProviderConfig> = {}): ProviderConfig {
+    return {
+        id: 'test',
+        name: 'test',
+        strategy: 'browser',
+        domains: ['127.0.0.1'],
+        entryUrl: `http://127.0.0.1:${port}/`,
+        extract: [],
+        apply: [{ in: 'header', name: 'Cookie', value: '${session}' }],
+        ...overrides,
+    } as ProviderConfig;
+}
+
+describe('validate()', () => {
+    let server: http.Server;
+    let port: number;
+
+    afterEach(() => {
+        server?.close();
+    });
+
+    function startServer(handler: http.RequestListener): Promise<void> {
+        server = http.createServer(handler);
+        return new Promise((r) =>
+            server.listen(0, '127.0.0.1', () => {
+                port = (server.address() as { port: number }).port;
+                r();
+            }),
+        );
+    }
+
+    it('returns false for empty credentials', async () => {
+        expect(await validate(makeProvider(0), {})).toBe(false);
+        expect(await validate(makeProvider(0), null as any)).toBe(false);
+    });
+
+    it('returns true when no entryUrl/validateUrl configured', async () => {
+        const provider = { ...makeProvider(0), entryUrl: '', validateUrl: undefined } as any;
+        expect(await validate(provider, { session: 'abc' })).toBe(true);
+    });
+
+    it('returns true on 200 response', async () => {
+        await startServer((_req, res) => {
+            res.writeHead(200);
+            res.end('OK');
+        });
+        expect(await validate(makeProvider(port), { session: 'valid' })).toBe(true);
+    });
+
+    it('returns false on persistent 401', async () => {
+        await startServer((_req, res) => {
+            res.writeHead(401);
+            res.end();
+        });
+        expect(await validate(makeProvider(port), { session: 'expired' })).toBe(false);
+    });
+
+    it('returns false on persistent 403', async () => {
+        await startServer((_req, res) => {
+            res.writeHead(403);
+            res.end();
+        });
+        expect(await validate(makeProvider(port), { session: 'expired' })).toBe(false);
+    });
+
+    it('retries once on transient 401 then succeeds', async () => {
+        let count = 0;
+        await startServer((_req, res) => {
+            count++;
+            if (count === 1) {
+                res.writeHead(401);
+                res.end();
+            } else {
+                res.writeHead(200);
+                res.end('OK');
+            }
+        });
+        expect(await validate(makeProvider(port), { session: 'valid' })).toBe(true);
+        expect(count).toBe(2);
+    });
+
+    it('returns false on redirect to login URL', async () => {
+        await startServer((_req, res) => {
+            res.writeHead(302, { Location: 'https://sso.example.com/login?redirect=/' });
+            res.end();
+        });
+        expect(await validate(makeProvider(port), { session: 'expired' })).toBe(false);
+    });
+
+    it('returns true on redirect to non-login URL', async () => {
+        await startServer((_req, res) => {
+            res.writeHead(302, { Location: 'https://example.com/dashboard' });
+            res.end();
+        });
+        expect(await validate(makeProvider(port), { session: 'valid' })).toBe(true);
+    });
+
+    it('returns false on any redirect when validateUrl is set', async () => {
+        await startServer((_req, res) => {
+            res.writeHead(302, { Location: 'https://example.com/dashboard' });
+            res.end();
+        });
+        const provider = makeProvider(port, {
+            validateUrl: `http://127.0.0.1:${port}/api/me`,
+        });
+        expect(await validate(provider, { session: 'expired' })).toBe(false);
+    });
+
+    it('returns false on network error (DNS failure)', async () => {
+        const provider = makeProvider(0, { entryUrl: 'https://nonexistent.invalid/' });
+        expect(await validate(provider, { session: 'stale' })).toBe(false);
+    });
+
+    it('returns true on 503 (server error treated as valid)', async () => {
+        await startServer((_req, res) => {
+            res.writeHead(503);
+            res.end();
+        });
+        expect(await validate(makeProvider(port), { session: 'valid' })).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

Fix 5 bugs identified in the 3-phase login refactor (#151), per Pylon's review:

- **Bug #1** — Phase 1 timeout too short: `EXISTING_STATE_TIMEOUT` 5s → 15s. Ensures validate() HTTP probe completes within tryExistingState budget.
- **Bug #2** — Stale credentials accepted on network error: `validate()` now returns `false` on network failure instead of optimistically `true`. Prevents VPN-down scenarios from caching expired cookies.
- **Bug #5** — SingletonLock not cleaned: Call `removeSingletonLock(dataDir)` before headless browser spawn to handle prior crash residue.
- **Bug #6** — Transient 401 causes false timeout: `validate()` retries once (1s delay) on 401/403 before rejecting, tolerating intermittent server errors.
- **Bug #7** — `sig login` not idempotent: Remove unconditional `force: true` from login command. Cached valid credentials are reused; `--force` flag still available for explicit re-extraction.

## Test Results

| Bug | Before | After |
|-----|--------|-------|
| #1 Phase 1 timeout | 5s budget, validate could exceed | 15s budget, reliable |
| #2 Network error | returns true (accepts stale) | returns false |
| #5 SingletonLock | not cleaned before spawn | cleaned |
| #6 Transient 401 | immediate reject | retry once, then reject |
| #7 `sig login` timing | 48s (always re-extracts) | 0.18s (cached) / 7s (--force) |

## New Tests

Added `credential-validator.test.ts` (11 tests) covering:
- Empty credentials → false
- No URL configured → true (skip probe)
- 200 → true
- Persistent 401/403 → false (after retry)
- Transient 401 → retry → true
- Redirect to login URL → false
- Redirect to non-login URL → true
- validateUrl + any redirect → false
- Network error → false
- 503 → true (server error ≠ auth failure)

```
Test Files  31 passed (31)
     Tests  440 passed (440)
```

## Test plan

- [x] All 440 unit tests pass
- [x] `sig login <provider>` uses cache (0.18s)
- [x] `sig login <provider> --force` re-extracts (7s)
- [x] `sig get <provider>` still works with valid creds
- [x] Network error no longer accepts stale credentials
- [x] Transient 401 retried and succeeds on recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)