### PR TITLE
fix(validate): require all extract rules to produce values

### DIFF
--- a/cli/src/utils/credential-validator.ts
+++ b/cli/src/utils/credential-validator.ts
@@ -16,6 +16,7 @@ import { buildUserAgent } from './http.js';
  *
  * Rules:
  *   - empty credentials → false
+ *   - not all extract rules produced values → false
  *   - 401/403 → false
  *   - 3xx redirect to login URL → false
  *   - 2xx → true
@@ -26,6 +27,8 @@ export async function validate(
     credentials: ExtractedCredentials,
 ): Promise<boolean> {
     if (!credentials || Object.keys(credentials).length === 0) return false;
+
+    if (!provider.extract.every((rule) => !!credentials[rule.as])) return false;
 
     const url = provider.validateUrl ?? provider.entryUrl;
     if (!url) return true;


### PR DESCRIPTION
## Summary

- `validate()` now returns false if any extract rule has no corresponding value in the credentials map
- Fixes incomplete credential extraction for providers with localStorage rules (e.g. Slack)

## Root Cause

Phase 1 (`tryExistingState`) opens `about:blank` — cookies extract fine (browser-wide CDP API) but localStorage is origin-scoped and returns null. The HTTP probe against `entryUrl` passes with cookies alone, so validation succeeds with incomplete credentials.

Similarly in Phase 2/3, the poll loop would accept credentials as soon as cookies validated, before localStorage was populated by page JS.

## Fix

One-line addition to `validate()`:

```typescript
if (!provider.extract.every((rule) => !!credentials[rule.as])) return false;
```

## Test plan

- [x] `pnpm --filter @sigcli/cli test` — 429 tests pass
- [x] Clean browser data + `sig login app-slack` — waits for both cookie and xoxc-token
- [x] SSO sites (jira, wiki) — still work (all extract rules are cookie-only)
- [x] `sig get app-slack` shows both Cookie and Authorization headers populated