### PR TITLE
fix(windows): ACL protection for sensitive files + wmic deprecation fallback

### DIFF
--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -6,6 +6,7 @@ import { credentialToEnvVars } from '../utils/credential-env.js';
 import { ExitCode } from '../utils/exit-codes.js';
 import { killProcess } from '../utils/process-kill.js';
 import { extractSensitiveValues, redactOutput } from '../utils/redact.js';
+import { restrictFileWindows } from '../utils/restrict-windows.js';
 import { AuditAction, AuditStatus, logAuditEvent } from '../audit/audit-log.js';
 import type { AuthManager } from '../auth-manager.js';
 
@@ -101,6 +102,7 @@ export async function runRun(
                     .join('\n') + '\n';
         }
         writeFileSync(mount, content, { encoding: 'utf8', mode: 0o600 });
+        restrictFileWindows(mount).catch(() => {});
     }
 
     await logAuditEvent({

--- a/cli/src/crypto/encryption.ts
+++ b/cli/src/crypto/encryption.ts
@@ -1,13 +1,9 @@
-import { execFile } from 'node:child_process';
 import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
 import fs from 'node:fs/promises';
-import { platform } from 'node:os';
 import path from 'node:path';
-import { promisify } from 'node:util';
 
 import { expandHome } from '../utils/path.js';
-
-const execFileAsync = promisify(execFile);
+import { restrictFileWindows } from '../utils/restrict-windows.js';
 
 export interface EncryptedEnvelope {
     version: 1;
@@ -70,22 +66,7 @@ export async function generateEncryptionKey(sigDir?: string): Promise<Buffer> {
     const key = randomBytes(32);
     const keyPath = path.join(dir, KEY_FILE);
     await fs.writeFile(keyPath, key.toString('base64') + '\n', { mode: 0o400 });
-
-    if (platform() === 'win32') {
-        const user = process.env.USERNAME ?? process.env.USER ?? '';
-        if (user) {
-            try {
-                await execFileAsync('icacls', [
-                    keyPath,
-                    '/inheritance:r',
-                    '/grant:r',
-                    `${user}:(R)`,
-                ]);
-            } catch {
-                // Best-effort on Windows
-            }
-        }
-    }
+    await restrictFileWindows(keyPath, '(R)');
 
     return key;
 }

--- a/cli/src/proxy/ca-manager.ts
+++ b/cli/src/proxy/ca-manager.ts
@@ -15,6 +15,7 @@ import {
 
 import type { ILogger } from '../types/index.js';
 import { createNoopLogger } from '../utils/logger.js';
+import { restrictFileWindows } from '../utils/restrict-windows.js';
 
 cryptoProvider.set(webcrypto as Crypto);
 
@@ -103,6 +104,7 @@ export class CaManager {
 
         const keyDer = await webcrypto.subtle.exportKey('pkcs8', keys.privateKey);
         await writeFile(keyPath, bufToPem('EC PRIVATE KEY', keyDer), { mode: 0o400 });
+        await restrictFileWindows(keyPath);
         await writeFile(crtPath, cert.toString('pem'), { mode: 0o644 });
 
         this.caCert = cert;

--- a/cli/src/storage/directory-storage.ts
+++ b/cli/src/storage/directory-storage.ts
@@ -12,6 +12,7 @@ import {
 } from '../types/index.js';
 import { decrypt, encrypt, isEncryptedEnvelope } from '../crypto/encryption.js';
 import { createNoopLogger } from '../utils/logger.js';
+import { restrictFileWindows } from '../utils/restrict-windows.js';
 import { sanitizeId } from '../utils/sanitize.js';
 
 interface ProviderFile {
@@ -233,6 +234,7 @@ export class DirectoryStorage implements IStorage {
             const content = JSON.stringify(envelope, null, 2);
             await fs.writeFile(tmpPath, content, { encoding: 'utf-8', mode: 0o600 });
             await fs.rename(tmpPath, filePath);
+            await restrictFileWindows(filePath);
         } catch (e: unknown) {
             await fs.unlink(tmpPath).catch(() => {});
             throw new StorageError('write', (e as Error).message);

--- a/cli/src/strategies/browser/cdp-state.ts
+++ b/cli/src/strategies/browser/cdp-state.ts
@@ -358,19 +358,37 @@ async function findOrphanPortUnix(dataDir: string, logger: ILogger): Promise<num
 }
 
 async function findOrphanPortWindows(dataDir: string, logger: ILogger): Promise<number | null> {
+    const escapedDir = dataDir.replace(/\\/g, '\\\\');
+
+    // Try wmic first (available on Windows 10 / Server 2022 and earlier)
     try {
         const output = execSync(
-            `wmic process where "CommandLine like '%--user-data-dir=${dataDir.replace(/\\/g, '\\\\')}%'" get CommandLine /format:list`,
+            `wmic process where "CommandLine like '%--user-data-dir=${escapedDir}%'" get CommandLine /format:list`,
             { encoding: 'utf-8', timeout: 5000 },
         );
         const match = output.match(/--remote-debugging-port=(\d+)/);
         if (match) {
             const port = parseInt(match[1], 10);
-            logger.info(`found orphan CDP port ${port} from process list`);
+            logger.info(`found orphan CDP port ${port} from wmic`);
             return port;
         }
     } catch {
-        // No matching process
+        // wmic unavailable or no match — try PowerShell fallback
+        try {
+            const psCmd = `Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*--user-data-dir=${escapedDir}*' } | Select-Object -ExpandProperty CommandLine`;
+            const output = execSync(`powershell -NoProfile -Command "${psCmd}"`, {
+                encoding: 'utf-8',
+                timeout: 10000,
+            });
+            const match = output.match(/--remote-debugging-port=(\d+)/);
+            if (match) {
+                const port = parseInt(match[1], 10);
+                logger.info(`found orphan CDP port ${port} from PowerShell`);
+                return port;
+            }
+        } catch {
+            // No matching process on either method
+        }
     }
     return null;
 }
@@ -400,14 +418,32 @@ async function getPidForPort(port: number): Promise<number | null> {
 
 async function killOrphanByDataDir(dataDir: string, logger: ILogger): Promise<void> {
     if (process.platform === 'win32') {
+        const escapedDir = dataDir.replace(/\\/g, '\\\\');
+        let killed = false;
+
+        // Try wmic first
         try {
             execSync(
-                `wmic process where "CommandLine like '%--user-data-dir=${dataDir.replace(/\\/g, '\\\\')}%'" call terminate`,
+                `wmic process where "CommandLine like '%--user-data-dir=${escapedDir}%'" call terminate`,
                 { stdio: 'ignore', timeout: 5000 },
             );
             logger.info(`killed orphan browser via wmic`);
+            killed = true;
         } catch {
-            logger.warn(`failed to kill orphan via wmic`);
+            // wmic unavailable — try PowerShell fallback
+        }
+
+        if (!killed) {
+            try {
+                const psCmd = `Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*--user-data-dir=${escapedDir}*' } | Invoke-CimMethod -MethodName Terminate`;
+                execSync(`powershell -NoProfile -Command "${psCmd}"`, {
+                    stdio: 'ignore',
+                    timeout: 10000,
+                });
+                logger.info(`killed orphan browser via PowerShell`);
+            } catch {
+                logger.warn(`failed to kill orphan browser`);
+            }
         }
     } else {
         try {

--- a/cli/src/utils/restrict-windows.ts
+++ b/cli/src/utils/restrict-windows.ts
@@ -1,0 +1,31 @@
+import { execFile } from 'node:child_process';
+import { platform } from 'node:os';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Restrict a file to current-user-only access on Windows via icacls.
+ * Removes inherited ACLs and grants only the current user.
+ * No-op on non-Windows platforms. Best-effort — failures are silently ignored.
+ *
+ * @param permission - Windows ACL permission: '(R)' for read-only (keys), '(F)' for full control (mutable credentials)
+ */
+export async function restrictFileWindows(
+    filePath: string,
+    permission: '(R)' | '(F)' = '(F)',
+): Promise<void> {
+    if (platform() !== 'win32') return;
+    const user = process.env.USERNAME ?? process.env.USER;
+    if (!user) return;
+    try {
+        await execFileAsync('icacls', [
+            filePath,
+            '/inheritance:r',
+            '/grant:r',
+            `${user}:${permission}`,
+        ]);
+    } catch {
+        // best-effort: icacls may fail on network drives or non-NTFS
+    }
+}


### PR DESCRIPTION
## Summary

Fixes two medium-severity Windows issues found during first-time Windows Server 2022 testing.

## Changes

### 1. Windows ACL protection for sensitive files

Previously only `encryption.key` had `icacls` protection. Now all sensitive files get Windows ACL lockdown (inheritance removed, current-user-only access):

- **New utility**: `cli/src/utils/restrict-windows.ts` — shared `restrictFileWindows(path, permission)` helper
- **Credential files** (`directory-storage.ts`): `(F)` full control, user-only
- **CA private key** (`ca-manager.ts`): `(F)` full control, user-only
- **Mount files** (`run.ts`): `(F)` full control, user-only (fire-and-forget)
- **Encryption key** (`encryption.ts`): `(R)` read-only, user-only (refactored to shared utility)

The permission parameter distinguishes immutable keys `(R)` from files the app needs to overwrite/delete `(F)`. Both remove inheritance and restrict to current user.

### 2. PowerShell fallback for deprecated `wmic`

`wmic.exe` is deprecated and removed on Windows 11. Orphan browser detection in `cdp-state.ts` now falls back to `Get-CimInstance` via PowerShell when wmic fails:

- `findOrphanPortWindows()`: wmic -> PowerShell `Get-CimInstance Win32_Process | Select-Object -ExpandProperty CommandLine`
- `killOrphanByDataDir()`: wmic -> PowerShell `Get-CimInstance Win32_Process | Invoke-CimMethod -MethodName Terminate`

## Testing environment

- **OS**: Windows Server 2022 Standard 10.0.20348
- **Node**: v20.18.1
- **Browser**: Microsoft Edge
- **Shell**: PowerShell 5.1

## Verification (Windows Server 2022)

```
> icacls %USERPROFILE%\.sig\encryption.key
<USERNAME>:(R)

> icacls %USERPROFILE%\.sig\credentials\provider.json
<USERNAME>:(F)

> icacls %USERPROFILE%\.sig\proxy\ca.key
<USERNAME>:(F)
```

### E2E manual tests passed

| Command | Result |
|---------|--------|
| `sig --version` | 1.6.9 |
| `sig doctor` | All checks passed |
| `sig init --force --yes` | Config + encryption key with `(R)` ACL |
| `sig login <url>` | Browser automation, cookie extraction, credential stored with `(F)` ACL |
| `sig status` | Shows valid credential with expiry |
| `sig get <provider>` | Returns masked cookie header |
| `sig request <url>` | 200 OK, authenticated response |
| `sig run <provider> -- cmd /c echo %SIG_*%` | Env vars injected into subprocess |
| `sig providers` | Lists auto-provisioned provider |
| `sig login --force` (re-auth) | Reused browser session, fast re-auth (5s) |

- All 481 unit tests pass
- No-op on non-Windows platforms (early return)
- Best-effort: failures silently ignored (network drives, non-NTFS)