### PR TITLE
chore: remove misleading --force flag from login help

### DIFF
--- a/cli/src/cli-router.ts
+++ b/cli/src/cli-router.ts
@@ -87,7 +87,6 @@ Authentication:
     --client-id <id>                OAuth2 client ID
     --client-secret <secret>        OAuth2 client secret
     --scope <scopes>                OAuth2 scopes (space-separated)
-    --force                         Skip stored credentials, force re-auth
     --mode <mode>                   Login mode: headless|visible|auto (default: auto)
     --network-proxy <url>           Proxy for browser or token requests
   logout [provider]                 Clear credentials (all if none specified)


### PR DESCRIPTION
## Summary
- Remove `--force` from `sig login` help text — the flag was documented but never parsed
- `sig login` always forces re-auth unconditionally (hardcoded `force: true`), making the flag misleading

## Test plan
- [x] Build passes
- [x] All 490 tests pass