### PR TITLE
feat: add sigcli skill for Claude Code guidance

### DIFF
--- a/skills/sigcli/SKILL.md
+++ b/skills/sigcli/SKILL.md
@@ -1,0 +1,373 @@
+---
+name: sigcli
+description: Guide Claude to use SigCLI correctly — check auth, login, get credentials, configure providers, and onboard new websites. Trigger when using sig commands, editing ~/.sig/config.yaml, or needing authenticated API access.
+---
+
+# SigCLI
+
+Reference for using SigCLI correctly. Prevents common mistakes like inventing flags, using redacted output, or misconfiguring providers.
+
+## Constraints
+
+These are the most common mistakes. Read them FIRST.
+
+1. **`sig get` MUST use `--no-redaction` to get usable values.** Without it, output is `****`. This is the #1 mistake.
+2. **Never invent commands.** The ONLY commands are: `init`, `doctor`, `login`, `logout`, `get`, `request`, `status`, `providers`, `rename`, `remove`, `remote`, `sync`, `watch`, `proxy`, `run`, `completion`.
+3. **Never invent flags.** See Command Reference below for exact flags per command.
+4. **Never invent config fields.** There is NO `requiredCookies`, `loginUrl`, `cookies`, `headers`, `authUrl`, `token`, `credentials`, or `session` field. See Provider Config Schema for the exact list.
+5. **`sig login` two forms:**
+    - `sig login <provider>` — provider already configured in config.yaml
+    - `sig login https://example.com` — auto-provision (creates provider automatically). Use `--as` for a meaningful name: `sig login https://example.com --as example`
+6. **`sig run` output is redacted.** It injects `SIG_<PROVIDER>_<KEY>` env vars into the child process, but redacts them in stdout. Use `env | grep SIG_` inside the child to discover var names.
+7. **`sig get --format` only accepts:** `json`, `header`, `value`. Not `cookie-jar`, `env`, `raw`, etc.
+8. **Provider config `extract` and `apply` are ARRAYS** (list of objects), not single objects.
+9. **Don't modify existing provider configs** unless explicitly asked by the user.
+
+## Command Reference
+
+| Command      | Usage                                  | Key Flags                                                                                                                                       |
+| ------------ | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `init`       | `sig init`                             | `--remote`, `--yes`, `--force`                                                                                                                  |
+| `doctor`     | `sig doctor`                           | —                                                                                                                                               |
+| `login`      | `sig login <provider>`                 | `--strategy oauth2`, `--token-url`, `--client-id`, `--client-secret`, `--scope`, `--force`, `--mode auto\|headless\|visible`, `--network-proxy` |
+| `logout`     | `sig logout [provider]`                | —                                                                                                                                               |
+| `get`        | `sig get <provider>`                   | `--format json\|header\|value`, `--no-redaction`                                                                                                |
+| `request`    | `sig request <url>`                    | `--method`, `--body`, `--header "K: V"`, `--format json\|body\|headers`                                                                         |
+| `status`     | `sig status [provider]`                | `--format json\|yaml\|table\|plain`                                                                                                             |
+| `providers`  | `sig providers`                        | `--format json\|yaml\|table\|plain`                                                                                                             |
+| `rename`     | `sig rename <old> <new>`               | —                                                                                                                                               |
+| `remove`     | `sig remove <provider>`                | `--keep-config`, `--force`                                                                                                                      |
+| `remote`     | `sig remote add\|remove\|list`         | **add:** `<name> <host>` `--user`, `--path`, `--ssh-key`                                                                                        |
+| `sync`       | `sig sync push\|pull [remote]`         | `--provider`, `--force`                                                                                                                         |
+| `watch`      | `sig watch add\|remove\|set-interval`  | **add:** `<provider>` `--auto-sync`                                                                                                             |
+| `proxy`      | `sig proxy start\|stop\|status\|trust` | **start:** `--port`                                                                                                                             |
+| `run`        | `sig run [providers...] -- <cmd>`      | `--expand-cookies`, `--mount <path>`, `--mount-format env\|json`                                                                                |
+| `completion` | `sig completion <shell>`               | bash, zsh, fish                                                                                                                                 |
+
+Global: `--verbose`, `--help`
+
+## Common Patterns
+
+### Check if auth is valid
+
+```bash
+sig status <provider>
+# Look for "valid": true in JSON output
+```
+
+### Get credentials for use
+
+```bash
+# JSON with headers (most common)
+sig get <provider> --no-redaction
+
+# Just the cookie/token string
+sig get <provider> --no-redaction --format value
+
+# Inject into another command
+sig run <provider> -- <command>
+```
+
+### Login when expired
+
+```bash
+sig login <provider>                 # auto mode (headless first, then visible)
+sig login <provider> --mode visible  # force open browser — USE THIS for first-time public site login
+```
+
+Note: Do NOT use `--force` unless you specifically want to discard existing credentials and re-authenticate from scratch. Without `--force`, `sig login` reuses existing valid credentials if available.
+
+### Make an authenticated request
+
+```bash
+sig request https://api.example.com/endpoint --method GET
+```
+
+## Onboarding a New Provider
+
+When the user wants to authenticate to a new website, follow these steps:
+
+### Step 1: Try auto-provision first
+
+```bash
+sig login https://example.com --as my-site
+```
+
+This auto-provisions a basic config (domains, entryUrl, extract all cookies, apply as Cookie header).
+
+**If it works** (you get a chance to log in, `sig status my-site` shows `valid: true`) → done.
+
+**If the browser closes immediately without letting you log in** — this happens on public sites (Weibo, Reddit, X, Bilibili) where the homepage returns 200 without auth. sigcli thinks it's already authenticated because there's no redirect.
+
+**Fix:** Add a `validateUrl` to the auto-provisioned config. Don't rewrite the config — just add the one field:
+
+```bash
+# Check what was auto-provisioned
+grep -A15 "my-site:" ~/.sig/config.yaml
+```
+
+Edit `~/.sig/config.yaml` and add a `validateUrl` under the provider — a URL that redirects or returns 401 when not logged in:
+
+```yaml
+  my-site:
+    domains:
+      - example.com
+    entryUrl: https://example.com/
+    validateUrl: https://example.com/notifications  # ADD THIS
+    strategy: browser
+    ...
+```
+
+Then login again:
+
+```bash
+sig login my-site
+```
+
+Now sigcli keeps the browser open until validateUrl confirms you're authenticated.
+
+Verify after login:
+
+```bash
+sig status my-site              # should show valid: true
+sig request <validateUrl>       # should return authenticated response (not redirect/401)
+```
+
+### Step 2: Figure out validateUrl or validateRule
+
+**validateUrl** — an endpoint that returns non-2xx (or redirects) when NOT logged in:
+
+- Check if the site has `/api/me`, `/api/user`, `/notifications`, `/rest/auth/1/session`
+- The URL must return 2xx ONLY when authenticated
+
+```yaml
+validateUrl: https://example.com/api/me
+```
+
+**validateRule** — when the endpoint always returns 200 but body differs:
+
+- Use a JS expression that evaluates to truthy when authenticated
+- Available variables in the sandbox:
+    - `res.status` — HTTP status code (number)
+    - `res.body` — parsed JSON (if response is valid JSON) or raw string
+    - `res.headers` — object (e.g. `{ location: "..." }`)
+- The expression is wrapped in `(...)` and evaluated — must return truthy for "authenticated"
+- Common pitfall: `res.body && res.body.name` fails because empty objects `{}` are truthy. Be specific about what field proves authentication.
+
+```yaml
+validateUrl: https://example.com/api/me
+validateRule: 'res.body.name !== undefined'
+```
+
+More examples:
+
+```yaml
+# Douyin: API returns {status_code: 0} when authenticated
+validateRule: "res.body.status_code === 0"
+
+# Site returns {logged_in: true/false}
+validateRule: "res.body.logged_in === true"
+
+# Reddit /api/me.json: returns {} when not logged in, {name: "user"} when logged in
+validateRule: "typeof res.body.name === 'string'"
+```
+
+**How to discover validateUrl and validateRule:**
+
+**Prerequisites:** You should know at least one authenticated API endpoint of the target site (e.g. from docs, DevTools network tab, or common patterns).
+
+**Step 1: Login first (auto-provision handles basics)**
+
+```bash
+sig login https://new-website.com --as new-site
+```
+
+**Step 2: Verify with a known API**
+
+```bash
+sig request https://new-website.com/my/api
+```
+
+If this works (returns authenticated data), you have a good `validateUrl` candidate. Add it to the config.
+
+**Step 3: If `sig request` fails, find a suitable validateUrl**
+
+A good validateUrl must be:
+
+- **GET** method (validation only does GET)
+- **Callable with just the `apply` rules** — sigcli builds the request using your `extract` + `apply` config. If the API needs headers beyond Cookie (e.g. CSRF token), those must be in your `extract`/`apply` rules too.
+- **Distinguishes authenticated from unauthenticated** — the validation logic is:
+
+How sigcli decides "authenticated" (in order):
+
+1. If `validateRule` exists → evaluate it (overrides everything below)
+2. Status 401/403/406/429 → **invalid**
+3. Status 3xx (redirect):
+    - With explicit `validateUrl` → **any redirect = invalid** (strict)
+    - Without `validateUrl` (entryUrl fallback) → only invalid if redirect goes to `/login`, `/signin`, `/auth`, `/sso`
+4. Body < 4KB with JS redirect (`window.location=`, `<meta http-equiv="refresh">`) → **invalid**
+5. Otherwise → **valid**
+
+**Best validateUrl candidates** (in order of preference):
+
+1. A page that **redirects to login** when unauthenticated — e.g. `/notifications`, `/settings`, `/account`, `/prefs/friends`. This is the cleanest: any 3xx = invalid.
+2. An API that **returns 401/403** when unauthenticated — e.g. `/api/me`, `/api/v4/me`, `/voyager/api/me`.
+3. An API that returns 200 always but **different body** — needs `validateRule` (last resort).
+
+Common patterns that work as validateUrl:
+| Pattern | Why it works |
+|---------|-------------|
+| `/notifications` | Redirects to login without auth (V2EX, Xiaohongshu) |
+| `/account`, `/settings`, `/prefs/friends` | Redirects to login without auth (YouTube, Reddit) |
+| `/api/me`, `/api/v4/me`, `/voyager/api/me` | Returns 401 without auth (Zhihu, LinkedIn) |
+| `/i/api/2/notifications/all.json` | Returns 401/403 without auth (X — but needs csrf header) |
+
+If the API needs extra headers (e.g. CSRF token), extract them:
+
+```yaml
+extract:
+    - from: cookies
+      as: cookie
+      match: '*'
+    - from: cookies
+      as: csrf_token
+      match: 'csrf_token_cookie_name'
+apply:
+    - in: header
+      name: Cookie
+      value: '${cookie}'
+    - in: header
+      name: x-csrf-token
+      value: '${csrf_token}'
+```
+
+Some APIs need a hardcoded app-level token (e.g. X's public Bearer token):
+
+```yaml
+apply:
+    - in: header
+      name: authorization
+      value: 'Bearer AAAAAA...' # hardcoded public app token
+```
+
+**Step 4: If validateUrl always returns 200 (rare), add validateRule**
+
+This only happens when the endpoint returns 200 for both authenticated and unauthenticated but with different body content. Compare:
+
+```bash
+# With auth
+sig request https://new-website.com/api/check
+
+# Without auth (raw curl)
+curl https://new-website.com/api/check
+```
+
+Write a rule based on the difference. The rule sandbox has:
+
+- `res.status` — HTTP status (number)
+- `res.body` — auto-parsed JSON if valid, otherwise raw string
+- `res.headers` — response headers object
+
+```yaml
+# Douyin: returns {status_code: 0} when authenticated, {status_code: -1} otherwise
+validateRule: "res.body.status_code === 0"
+
+# Reddit /api/me.json: returns {} when not logged in, {name: "user"} when logged in
+validateRule: "typeof res.body.name === 'string'"
+```
+
+Common pitfall: `res.body && res.body.name` — empty objects `{}` are truthy! Always check a specific field value.
+
+### Step 3: Handle special extraction
+
+**Extract specific cookies** (when you need individual values):
+
+```yaml
+extract:
+    - from: cookies
+      as: cookie
+      match: '*' # full cookie string
+    - from: cookies
+      as: csrf_token
+      match: 'csrf_token' # single cookie by name
+```
+
+**Extract from localStorage** (for SPA tokens):
+
+```yaml
+extract:
+    - from: localStorage
+      as: access_token
+      match: 'auth_key_pattern'
+      jsonPath: token # if the value is JSON, extract a field
+```
+
+### Step 4: Test
+
+```bash
+sig login my-provider          # opens browser, log in
+sig status my-provider         # should show valid: true
+sig get my-provider --no-redaction  # should show actual credentials
+```
+
+If `sig status` shows `valid: false` after login:
+
+- The `validateUrl` is wrong (try a different endpoint)
+- Or add `validateRule` if the endpoint returns 200 regardless
+
+Debug with: `sig login my-provider --mode visible --verbose`
+
+## Provider Config Schema
+
+### Valid top-level fields for a provider
+
+```yaml
+my-provider:
+    name: 'Display Name' # optional
+    domains: [example.com] # required: list of domains
+    entryUrl: https://example.com/ # required for browser/prompt; optional for oauth2
+    strategy: browser # required: browser | prompt | oauth2
+    ttl: 2h # optional: credential lifetime
+    validateUrl: https://... # optional: URL to check auth (must 401/403 when unauthenticated)
+    validateRule: 'res.body.ok' # optional: JS expression when validateUrl returns 200 regardless
+    networkProxy: socks5://... # optional: proxy for this provider
+    loginMode: visible # optional: auto | headless | visible
+    loginUrlPatterns: [/login, /auth] # optional: URL substrings to detect login pages
+    extract: [...] # required for browser/prompt: what to capture
+    apply: [...] # required: how to use captured values
+    oauth2: # only for strategy: oauth2
+        tokenUrl: https://...
+        scopes: ['scope1', 'scope2']
+```
+
+Note: `headlessTimeout` and `visibleTimeout` are browser-level settings (under `browser:` in config root), NOT provider-level.
+
+### Fields that DO NOT EXIST (never use these)
+
+`required`, `cookiePaths`, `requiredCookies`, `cookies`, `headers`, `loginUrl`, `authUrl`, `token`, `credentials`, `session`, `headlessTimeout`, `visibleTimeout`, `waitUntil`
+
+## Troubleshooting
+
+| Symptom                       | Cause                        | Fix                                         |
+| ----------------------------- | ---------------------------- | ------------------------------------------- |
+| `sig get` returns `****`      | Missing `--no-redaction`     | Add `--no-redaction` flag                   |
+| `valid: false` after login    | Wrong/missing validateUrl    | Find an API endpoint that 401s without auth |
+| `configured: false`           | Provider not in config.yaml  | Add provider config first, then login       |
+| Browser opens but login fails | Site needs visible mode      | Use `--mode visible`                        |
+| `sig run` env vars empty      | Provider credentials expired | Run `sig login <provider>` first            |
+| `command not found: sig`      | Not installed globally       | `npm install -g @sigcli/cli`                |
+
+## Self-Test
+
+```bash
+# 1. sig is installed
+sig --help 2>&1 | head -1
+# Expected: "sig — authenticate once, use everywhere"
+
+# 2. Config exists
+cat ~/.sig/config.yaml | head -3
+# Expected: "version: 2" or similar
+
+# 3. Check a provider status
+sig status 2>&1 | head -5
+```

--- a/skills/sigcli/SKILL.md
+++ b/skills/sigcli/SKILL.md
@@ -25,24 +25,24 @@ These are the most common mistakes. Read them FIRST.
 
 ## Command Reference
 
-| Command      | Usage                                  | Key Flags                                                                                                                                       |
-| ------------ | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `init`       | `sig init`                             | `--remote`, `--yes`, `--force`                                                                                                                  |
-| `doctor`     | `sig doctor`                           | —                                                                                                                                               |
-| `login`      | `sig login <provider>`                 | `--strategy oauth2`, `--token-url`, `--client-id`, `--client-secret`, `--scope`, `--force`, `--mode auto\|headless\|visible`, `--network-proxy` |
-| `logout`     | `sig logout [provider]`                | —                                                                                                                                               |
-| `get`        | `sig get <provider>`                   | `--format json\|header\|value`, `--no-redaction`                                                                                                |
-| `request`    | `sig request <url>`                    | `--method`, `--body`, `--header "K: V"`, `--format json\|body\|headers`                                                                         |
-| `status`     | `sig status [provider]`                | `--format json\|yaml\|table\|plain`                                                                                                             |
-| `providers`  | `sig providers`                        | `--format json\|yaml\|table\|plain`                                                                                                             |
-| `rename`     | `sig rename <old> <new>`               | —                                                                                                                                               |
-| `remove`     | `sig remove <provider>`                | `--keep-config`, `--force`                                                                                                                      |
-| `remote`     | `sig remote add\|remove\|list`         | **add:** `<name> <host>` `--user`, `--path`, `--ssh-key`                                                                                        |
-| `sync`       | `sig sync push\|pull [remote]`         | `--provider`, `--force`                                                                                                                         |
-| `watch`      | `sig watch add\|remove\|set-interval`  | **add:** `<provider>` `--auto-sync`                                                                                                             |
-| `proxy`      | `sig proxy start\|stop\|status\|trust` | **start:** `--port`                                                                                                                             |
-| `run`        | `sig run [providers...] -- <cmd>`      | `--expand-cookies`, `--mount <path>`, `--mount-format env\|json`                                                                                |
-| `completion` | `sig completion <shell>`               | bash, zsh, fish                                                                                                                                 |
+| Command      | Usage                                  | Key Flags                                                                                                                                         |
+| ------------ | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `init`       | `sig init`                             | `--remote`, `--yes`, `--force`                                                                                                                    |
+| `doctor`     | `sig doctor`                           | —                                                                                                                                                 |
+| `login`      | `sig login <provider>`                 | `--as <id>`, `--strategy oauth2`, `--token-url`, `--client-id`, `--client-secret`, `--scope`, `--mode auto\|headless\|visible`, `--network-proxy` |
+| `logout`     | `sig logout [provider]`                | —                                                                                                                                                 |
+| `get`        | `sig get <provider>`                   | `--format json\|header\|value`, `--no-redaction`                                                                                                  |
+| `request`    | `sig request <url>`                    | `--method`, `--body`, `--header "K: V"`, `--format json\|body\|headers`                                                                           |
+| `status`     | `sig status [provider]`                | `--format json\|yaml\|table\|plain`                                                                                                               |
+| `providers`  | `sig providers`                        | `--format json\|yaml\|table\|plain`                                                                                                               |
+| `rename`     | `sig rename <old> <new>`               | —                                                                                                                                                 |
+| `remove`     | `sig remove <provider>`                | `--keep-config`, `--force`                                                                                                                        |
+| `remote`     | `sig remote add\|remove\|list`         | **add:** `<name> <host>` `--user`, `--path`, `--ssh-key`                                                                                          |
+| `sync`       | `sig sync push\|pull [remote]`         | `--provider`, `--force`                                                                                                                           |
+| `watch`      | `sig watch add\|remove\|set-interval`  | **add:** `<provider>` `--auto-sync`                                                                                                               |
+| `proxy`      | `sig proxy start\|stop\|status\|trust` | **start:** `--port`                                                                                                                               |
+| `run`        | `sig run [providers...] -- <cmd>`      | `--expand-cookies`, `--mount <path>`, `--mount-format env\|json`                                                                                  |
+| `completion` | `sig completion <shell>`               | bash, zsh, fish                                                                                                                                   |
 
 Global: `--verbose`, `--help`
 
@@ -75,7 +75,7 @@ sig login <provider>                 # auto mode (headless first, then visible)
 sig login <provider> --mode visible  # force open browser — USE THIS for first-time public site login
 ```
 
-Note: Do NOT use `--force` unless you specifically want to discard existing credentials and re-authenticate from scratch. Without `--force`, `sig login` reuses existing valid credentials if available.
+Note: `sig login` reuses existing valid credentials if available — it only re-authenticates when credentials are expired or missing.
 
 ### Make an authenticated request
 

--- a/skills/sigcli/scripts/discover-validate-url.mjs
+++ b/skills/sigcli/scripts/discover-validate-url.mjs
@@ -13,7 +13,6 @@
  *   - Node.js 22+ (native WebSocket)
  *   - sig must be initialized (~/.sig/config.yaml exists with browser config)
  */
-
 import { spawn } from 'child_process';
 import { readFileSync } from 'fs';
 import { homedir } from 'os';
@@ -39,7 +38,9 @@ try {
     if (execMatch) execPath = execMatch[1].trim();
     const dataMatch = config.match(/browserDataDir:\s*['"]?([^'"\n]+)/);
     if (dataMatch) dataDir = dataMatch[1].replace('~', homedir()).trim();
-} catch { /* use defaults */ }
+} catch {
+    /* use defaults */
+}
 
 // --- Helpers ---
 function createCDP(wsUrl) {
@@ -57,27 +58,26 @@ function createCDP(wsUrl) {
 
     const send = (method, params = {}) => {
         const msgId = id++;
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
             pending[msgId] = resolve;
             ws.send(JSON.stringify({ id: msgId, method, params }));
         });
     };
 
-    const ready = new Promise(r => ws.addEventListener('open', r));
+    const ready = new Promise((r) => ws.addEventListener('open', r));
     return { ws, send, ready };
 }
 
 // --- Main ---
 console.log(`[1/5] Launching browser → ${TARGET_URL}`);
-const proc = spawn(execPath, [
-    `--remote-debugging-port=${PORT}`,
-    `--user-data-dir=${dataDir}`,
-    '--no-first-run',
-    TARGET_URL
-], { stdio: 'ignore', detached: true });
+const proc = spawn(
+    execPath,
+    [`--remote-debugging-port=${PORT}`, `--user-data-dir=${dataDir}`, '--no-first-run', TARGET_URL],
+    { stdio: 'ignore', detached: true },
+);
 proc.unref();
 
-await new Promise(r => setTimeout(r, 4000));
+await new Promise((r) => setTimeout(r, 4000));
 
 // Connect CDP
 let pages;
@@ -89,8 +89,11 @@ try {
     process.exit(1);
 }
 
-const page = pages.find(p => p.url.includes(DOMAIN)) || pages[0];
-if (!page) { console.error('No matching page found'); process.exit(1); }
+const page = pages.find((p) => p.url.includes(DOMAIN)) || pages[0];
+if (!page) {
+    console.error('No matching page found');
+    process.exit(1);
+}
 
 const { ws, send, ready } = createCDP(page.webSocketDebuggerUrl);
 await ready;
@@ -104,9 +107,14 @@ ws.addEventListener('message', (event) => {
     const msg = JSON.parse(event.data);
     if (msg.method === 'Network.requestWillBeSent') {
         const r = msg.params.request;
-        if (r.method === 'GET' && r.url.includes(DOMAIN) &&
-            (r.url.includes('/rest/') || r.url.includes('/api/') ||
-             r.url.includes('/graphql') || r.url.includes('/ajax/'))) {
+        if (
+            r.method === 'GET' &&
+            r.url.includes(DOMAIN) &&
+            (r.url.includes('/rest/') ||
+                r.url.includes('/api/') ||
+                r.url.includes('/graphql') ||
+                r.url.includes('/ajax/'))
+        ) {
             const path = new URL(r.url).pathname;
             if (!apiRequests.has(path)) {
                 apiRequests.set(path, { url: r.url.split('?')[0], status: null });
@@ -115,7 +123,13 @@ ws.addEventListener('message', (event) => {
     }
     if (msg.method === 'Network.responseReceived') {
         const url = msg.params.response.url;
-        const path = (() => { try { return new URL(url).pathname; } catch { return null; } })();
+        const path = (() => {
+            try {
+                return new URL(url).pathname;
+            } catch {
+                return null;
+            }
+        })();
         if (path && apiRequests.has(path)) {
             apiRequests.get(path).status = msg.params.response.status;
         }
@@ -124,7 +138,7 @@ ws.addEventListener('message', (event) => {
 
 console.log(`[2/5] Observing API requests (waiting 8s for page load)...`);
 await send('Page.reload');
-await new Promise(r => setTimeout(r, 8000));
+await new Promise((r) => setTimeout(r, 8000));
 
 console.log(`\n--- Discovered GET API endpoints ---`);
 for (const [path, entry] of apiRequests) {
@@ -178,7 +192,10 @@ const testNoCookie = `
     return JSON.stringify(results);
 })()`;
 
-const evalResult2 = await send('Runtime.evaluate', { expression: testNoCookie, awaitPromise: true });
+const evalResult2 = await send('Runtime.evaluate', {
+    expression: testNoCookie,
+    awaitPromise: true,
+});
 const withoutCookie = JSON.parse(evalResult2.result?.result?.value || '{}');
 
 console.log('\n--- Without cookies (simulating logged out) ---');
@@ -197,7 +214,9 @@ for (const path of paths) {
 
     if (before.status !== after.status) {
         console.log(`\n✓ CANDIDATE: ${path}`);
-        console.log(`  Status differs: ${before.status} (no cookie) vs ${after.status} (with cookie)`);
+        console.log(
+            `  Status differs: ${before.status} (no cookie) vs ${after.status} (with cookie)`,
+        );
         if (before.status === 401 || before.status === 403) {
             console.log(`  → Use as validateUrl (returns ${before.status} without auth)`);
         } else if (before.status >= 300 && before.status < 400) {
@@ -221,5 +240,9 @@ if (!found) {
 
 console.log('\n[5/5] Done. Closing browser.');
 ws.close();
-try { process.kill(-proc.pid); } catch { proc.kill(); }
+try {
+    process.kill(-proc.pid);
+} catch {
+    proc.kill();
+}
 process.exit(0);

--- a/skills/sigcli/scripts/discover-validate-url.mjs
+++ b/skills/sigcli/scripts/discover-validate-url.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-/* eslint-env node */
+/* eslint-disable no-undef */
 /**
  * discover-validate-url.mjs
  *
@@ -18,7 +18,6 @@ import { spawn } from 'child_process';
 import { readFileSync } from 'fs';
 import { homedir } from 'os';
 import { resolve } from 'path';
-import { createInterface } from 'readline/promises';
 
 // --- Config ---
 const TARGET_URL = process.argv[2];
@@ -142,7 +141,7 @@ await send('Page.reload');
 await new Promise((r) => setTimeout(r, 8000));
 
 console.log(`\n--- Discovered GET API endpoints ---`);
-for (const [path, entry] of apiRequests) {
+for (const [, entry] of apiRequests) {
     console.log(`  [${entry.status}] ${entry.url}`);
 }
 

--- a/skills/sigcli/scripts/discover-validate-url.mjs
+++ b/skills/sigcli/scripts/discover-validate-url.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-env node */
 /**
  * discover-validate-url.mjs
  *

--- a/skills/sigcli/scripts/discover-validate-url.mjs
+++ b/skills/sigcli/scripts/discover-validate-url.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+/**
+ * discover-validate-url.mjs
+ *
+ * Discover candidate validateUrl endpoints for a sigcli provider.
+ * Launches browser with sig's browser-data profile, observes GET API requests
+ * during page load, then lets the user log in and compares before/after.
+ *
+ * Usage:
+ *   node discover-validate-url.mjs https://www.example.com
+ *
+ * Requirements:
+ *   - Node.js 22+ (native WebSocket)
+ *   - sig must be initialized (~/.sig/config.yaml exists with browser config)
+ */
+
+import { spawn } from 'child_process';
+import { readFileSync } from 'fs';
+import { homedir } from 'os';
+import { resolve } from 'path';
+import { createInterface } from 'readline/promises';
+
+// --- Config ---
+const TARGET_URL = process.argv[2];
+if (!TARGET_URL) {
+    console.error('Usage: node discover-validate-url.mjs <url>');
+    process.exit(1);
+}
+
+const DOMAIN = new URL(TARGET_URL).hostname;
+const PORT = 9334;
+
+// Read sig config for browser path
+let execPath = '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge';
+let dataDir = resolve(homedir(), '.sig/browser-data');
+try {
+    const config = readFileSync(resolve(homedir(), '.sig/config.yaml'), 'utf8');
+    const execMatch = config.match(/execPath:\s*['"]?([^'"\n]+)/);
+    if (execMatch) execPath = execMatch[1].trim();
+    const dataMatch = config.match(/browserDataDir:\s*['"]?([^'"\n]+)/);
+    if (dataMatch) dataDir = dataMatch[1].replace('~', homedir()).trim();
+} catch { /* use defaults */ }
+
+// --- Helpers ---
+function createCDP(wsUrl) {
+    const ws = new WebSocket(wsUrl);
+    let id = 1;
+    const pending = {};
+
+    ws.addEventListener('message', (event) => {
+        const msg = JSON.parse(event.data);
+        if (msg.id && pending[msg.id]) {
+            pending[msg.id](msg);
+            delete pending[msg.id];
+        }
+    });
+
+    const send = (method, params = {}) => {
+        const msgId = id++;
+        return new Promise(resolve => {
+            pending[msgId] = resolve;
+            ws.send(JSON.stringify({ id: msgId, method, params }));
+        });
+    };
+
+    const ready = new Promise(r => ws.addEventListener('open', r));
+    return { ws, send, ready };
+}
+
+// --- Main ---
+console.log(`[1/5] Launching browser → ${TARGET_URL}`);
+const proc = spawn(execPath, [
+    `--remote-debugging-port=${PORT}`,
+    `--user-data-dir=${dataDir}`,
+    '--no-first-run',
+    TARGET_URL
+], { stdio: 'ignore', detached: true });
+proc.unref();
+
+await new Promise(r => setTimeout(r, 4000));
+
+// Connect CDP
+let pages;
+try {
+    const resp = await fetch(`http://127.0.0.1:${PORT}/json`);
+    pages = await resp.json();
+} catch {
+    console.error(`Failed to connect to CDP on port ${PORT}. Browser may not have started.`);
+    process.exit(1);
+}
+
+const page = pages.find(p => p.url.includes(DOMAIN)) || pages[0];
+if (!page) { console.error('No matching page found'); process.exit(1); }
+
+const { ws, send, ready } = createCDP(page.webSocketDebuggerUrl);
+await ready;
+
+// Enable network monitoring
+await send('Network.enable');
+
+// Collect GET API requests during page load
+const apiRequests = new Map();
+ws.addEventListener('message', (event) => {
+    const msg = JSON.parse(event.data);
+    if (msg.method === 'Network.requestWillBeSent') {
+        const r = msg.params.request;
+        if (r.method === 'GET' && r.url.includes(DOMAIN) &&
+            (r.url.includes('/rest/') || r.url.includes('/api/') ||
+             r.url.includes('/graphql') || r.url.includes('/ajax/'))) {
+            const path = new URL(r.url).pathname;
+            if (!apiRequests.has(path)) {
+                apiRequests.set(path, { url: r.url.split('?')[0], status: null });
+            }
+        }
+    }
+    if (msg.method === 'Network.responseReceived') {
+        const url = msg.params.response.url;
+        const path = (() => { try { return new URL(url).pathname; } catch { return null; } })();
+        if (path && apiRequests.has(path)) {
+            apiRequests.get(path).status = msg.params.response.status;
+        }
+    }
+});
+
+console.log(`[2/5] Observing API requests (waiting 8s for page load)...`);
+await send('Page.reload');
+await new Promise(r => setTimeout(r, 8000));
+
+console.log(`\n--- Discovered GET API endpoints ---`);
+for (const [path, entry] of apiRequests) {
+    console.log(`  [${entry.status}] ${entry.url}`);
+}
+
+if (apiRequests.size === 0) {
+    console.log('  (none found — site may use only POST APIs or different URL patterns)');
+}
+
+// Test candidates with cookie-only fetch
+console.log(`\n[3/5] Testing endpoints with cookie-only fetch (no extra headers)...`);
+const paths = [...apiRequests.keys()];
+const testExpr = `
+(async () => {
+    const paths = ${JSON.stringify(paths)};
+    const results = {};
+    for (const p of paths) {
+        try {
+            const r = await fetch(p, { credentials: 'include' });
+            const ct = r.headers.get('content-type') || '';
+            const body = ct.includes('json') ? await r.text() : null;
+            results[p] = { status: r.status, hasJson: ct.includes('json'), body: body?.slice(0, 200) };
+        } catch(e) { results[p] = { status: -1, error: e.message }; }
+    }
+    return JSON.stringify(results);
+})()`;
+
+const evalResult = await send('Runtime.evaluate', { expression: testExpr, awaitPromise: true });
+const withCookie = JSON.parse(evalResult.result?.result?.value || '{}');
+
+console.log('\n--- With cookies (current state) ---');
+for (const [path, data] of Object.entries(withCookie)) {
+    const body = data.body ? ` → ${data.body.slice(0, 80)}` : '';
+    console.log(`  [${data.status}] ${path}${body}`);
+}
+
+// Test without cookies
+const testNoCookie = `
+(async () => {
+    const paths = ${JSON.stringify(paths)};
+    const results = {};
+    for (const p of paths) {
+        try {
+            const r = await fetch(p, { credentials: 'omit' });
+            const ct = r.headers.get('content-type') || '';
+            const body = ct.includes('json') ? await r.text() : null;
+            results[p] = { status: r.status, hasJson: ct.includes('json'), body: body?.slice(0, 200) };
+        } catch(e) { results[p] = { status: -1, error: e.message }; }
+    }
+    return JSON.stringify(results);
+})()`;
+
+const evalResult2 = await send('Runtime.evaluate', { expression: testNoCookie, awaitPromise: true });
+const withoutCookie = JSON.parse(evalResult2.result?.result?.value || '{}');
+
+console.log('\n--- Without cookies (simulating logged out) ---');
+for (const [path, data] of Object.entries(withoutCookie)) {
+    const body = data.body ? ` → ${data.body.slice(0, 80)}` : '';
+    console.log(`  [${data.status}] ${path}${body}`);
+}
+
+// Compare and recommend
+console.log('\n[4/5] === Analysis ===');
+let found = false;
+for (const path of paths) {
+    const before = withoutCookie[path];
+    const after = withCookie[path];
+    if (!before || !after) continue;
+
+    if (before.status !== after.status) {
+        console.log(`\n✓ CANDIDATE: ${path}`);
+        console.log(`  Status differs: ${before.status} (no cookie) vs ${after.status} (with cookie)`);
+        if (before.status === 401 || before.status === 403) {
+            console.log(`  → Use as validateUrl (returns ${before.status} without auth)`);
+        } else if (before.status >= 300 && before.status < 400) {
+            console.log(`  → Use as validateUrl (redirects without auth)`);
+        }
+        found = true;
+    } else if (before.body !== after.body && before.body && after.body) {
+        console.log(`\n~ CANDIDATE (needs validateRule): ${path}`);
+        console.log(`  Both return ${after.status} but body differs:`);
+        console.log(`  Without cookie: ${before.body.slice(0, 100)}`);
+        console.log(`  With cookie:    ${after.body.slice(0, 100)}`);
+        found = true;
+    }
+}
+
+if (!found) {
+    console.log('\n  No cookie-only endpoints found that differentiate auth state.');
+    console.log('  This site may require extra headers (CSRF, signatures) beyond cookies.');
+    console.log('  Try asking the user which API endpoint they use.');
+}
+
+console.log('\n[5/5] Done. Closing browser.');
+ws.close();
+try { process.kill(-proc.pid); } catch { proc.kill(); }
+process.exit(0);

--- a/skills/tiktok/SKILL.md
+++ b/skills/tiktok/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: tiktok
+description: 'Provide authenticated cookies for TikTok (www.tiktok.com). Use this skill whenever the user needs TikTok cookies for scraping tools, downloaders, or needs to authenticate with TikTok services. Trigger when the user mentions TikTok, tiktok cookies, or wants to use tools that require TikTok login cookies.'
+---
+
+# TikTok Skill (Cookie Provider)
+
+This skill provides authenticated cookies for TikTok via sigcli.
+
+| Provider | Domain         | Use case                          |
+| -------- | -------------- | --------------------------------- |
+| `tiktok` | www.tiktok.com | Scraping, downloading, API access |
+
+## Setup
+
+### 1. Configure provider
+
+Add the config from `references/provider-config.yaml` to `~/.sig/config.yaml` under `providers:`.
+
+Adjust `networkProxy` to your proxy URL if needed (TikTok is blocked in China).
+
+### 2. Login
+
+```bash
+sig login tiktok --mode visible
+```
+
+Opens browser with proxy, navigate to TikTok and log in (or sign up).
+
+### 3. Verify
+
+```bash
+sig status tiktok
+# Should show: valid: true
+```
+
+## Get cookies
+
+```bash
+sig get tiktok --no-redaction --format value
+# Output: sessionid=xxx; tt_chain_token=yyy; ...
+```
+
+## Usage with TikTokDownloader
+
+```bash
+# Copy cookie to clipboard for TikTokDownloader's "从剪贴板读取" mode
+sig get tiktok --no-redaction --format value | pbcopy
+
+# Or inject as environment variable
+sig run tiktok -- python main.py
+```
+
+## Validation
+
+- Endpoint: `https://www.tiktok.com/setting`
+- Logged in: returns 200 (settings page)
+- Not logged in: 302 redirect to `/foryou`
+- No validateRule needed (redirect detection is sufficient)
+
+## Notes
+
+- TikTok requires proxy access from China — `networkProxy: socks5://127.0.0.1:3333`
+- First login may take longer (registration + verification)
+- Use `--mode visible` for first login; subsequent logins can use auto mode
+- TTL is set to 2h; use `sig watch add tiktok` for auto-refresh

--- a/skills/tiktok/references/provider-config.yaml
+++ b/skills/tiktok/references/provider-config.yaml
@@ -1,0 +1,30 @@
+# sigcli provider config for TikTok
+# Add to ~/.sig/config.yaml under `providers:`
+#
+# Prerequisites:
+#   npm install -g @sigcli/cli
+#   sig init
+#
+# Login:
+#   sig login tiktok
+#
+# NOTE: TikTok is blocked in China. You need a proxy to access it.
+# Set networkProxy in the config below to your proxy URL.
+
+tiktok:
+    domains:
+        - www.tiktok.com
+    entryUrl: https://www.tiktok.com/
+    validateUrl: https://www.tiktok.com/setting
+    strategy: browser
+    networkProxy: socks5://127.0.0.1:3333
+    loginMode: visible
+    ttl: 2h
+    extract:
+        - from: cookies
+          as: cookie
+          match: '*'
+    apply:
+        - in: header
+          name: Cookie
+          value: ${cookie}


### PR DESCRIPTION
## Summary

- New `skills/sigcli/SKILL.md` — guardrails and reference for Claude when using sigcli commands or editing provider configs
- New `skills/sigcli/scripts/discover-validate-url.mjs` — CDP script to discover validateUrl candidates by observing browser API requests

## What the skill covers

- Command reference with exact flags (prevents inventing non-existent commands/flags)
- Provider config schema (prevents inventing non-existent fields like `required`, `cookiePaths`, `waitUntil`)
- Onboarding workflow: auto-provision → add validateUrl → login → verify
- validateUrl/validateRule discovery methodology (with the full validation algorithm documented)
- Common pitfalls: `sig get` without `--no-redaction`, public site auto-provision problem, etc.

## CDP discovery script

`scripts/discover-validate-url.mjs` automates finding a suitable validateUrl:
1. Launches browser with sig's profile
2. Observes GET API requests during page load
3. Tests each endpoint with/without cookies
4. Recommends candidates based on status code or body differences

## Test plan

- [x] Tested weibo onboarding (public site → add validateUrl → login → valid)
- [x] Tested reddit, v2ex, linkedin configuration
- [x] Tested kuaishou (discovered limitation: sites with API signing can't use cookie-only validateUrl)