### PR TITLE
website: stack demo gifs vertically

### DIFF
--- a/website/src/content/skills.tsx
+++ b/website/src/content/skills.tsx
@@ -153,7 +153,7 @@ export function SkillsPage() {
 
                 {/* Demo GIFs */}
                 <section className="max-w-4xl mx-auto px-6 pb-12">
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div className="grid grid-cols-1 gap-8">
                         <div>
                             <div
                                 className="rounded-lg overflow-hidden"


### PR DESCRIPTION
## Summary
- Switch the demo gifs section from `md:grid-cols-2` to a single column. The 2-column layout made each gif too small to read terminal text.

## Test plan
- [ ] `pnpm --filter website dev` and verify both demo gifs stack vertically at full width.