### PR TITLE
fix(xiaohongshu): improve auth detection and surface raw error details

### DIFF
--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sigcli/skills",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "AI agent skills for authenticated web access via sigcli",
     "type": "module",
     "bin": {

--- a/skills/xiaohongshu/SKILL.md
+++ b/skills/xiaohongshu/SKILL.md
@@ -30,7 +30,7 @@ Check the JSON output fields `configured` and `valid`:
 1. Read `<SKILL_DIR>/references/provider-config.yaml`
 2. Append the provider block to `~/.sig/config.yaml` under `providers:`
 3. Run `sig login xiaohongshu` — a browser opens; scan the QR code with the Xiaohongshu app
-4. Verify: `sig status xiaohongshu` should show `valid: true`
+4. Verify: `sig status xiaohongshu` should show `valid: true`. The provider config uses `validateRule` to probe `/api/sns/web/unread_count` — if the captcha was not solved, validation will fail here instead of silently passing.
 
 ### Vendor Setup (one-time per machine)
 
@@ -136,15 +136,13 @@ All scripts are in this skill's `scripts/` directory. Output is JSON to stdout.
 
 ## Error Handling
 
-| Error                  | Meaning                                  | Fix                                               |
-| ---------------------- | ---------------------------------------- | ------------------------------------------------- |
-| `AUTH_REQUIRED`        | No cookie available                      | `sig login xiaohongshu`                           |
-| `VENDOR_MISSING`       | `<SKILL_DIR>/vendor/` not populated      | Run `<SKILL_DIR>/scripts/sync-vendor.sh`          |
-| `NODE_MODULES_MISSING` | `vendor/node_modules/` missing           | `cd <SKILL_DIR>/vendor && npm install`            |
-| `API_ERROR` + `461`    | CAPTCHA / risk control triggered         | Wait several minutes; reduce request frequency    |
-| `API_ERROR` + `300011` | Account marked abnormal                  | Wait 24h; switch network; use a different account |
-| `API_ERROR` + `406`    | Signing rejected (algorithm out of date) | `<SKILL_DIR>/scripts/sync-vendor.sh` to refresh   |
-| `HTTP_<code>`          | Network / transport failure              | Check connectivity                                |
+| Error                  | Meaning                                                                                                                                                                                        | Fix                                                                                                                                                                                                          |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `AUTH_REQUIRED`        | No cookie available                                                                                                                                                                            | `sig login xiaohongshu --mode visible`                                                                                                                                                                       |
+| `VENDOR_MISSING`       | `<SKILL_DIR>/vendor/` not populated                                                                                                                                                            | Run `<SKILL_DIR>/scripts/sync-vendor.sh`                                                                                                                                                                     |
+| `NODE_MODULES_MISSING` | `vendor/node_modules/` missing                                                                                                                                                                 | `cd <SKILL_DIR>/vendor && npm install`                                                                                                                                                                       |
+| `API_ERROR`            | Any other failure from Xiaohongshu (expired session, signing rejected, account flagged, network blip, etc.). The error message includes the raw `code`/`msg` from the response when available. | `sig logout xiaohongshu && sig login xiaohongshu --mode visible`. If it persists after re-login, capture the full error and consider running `<SKILL_DIR>/scripts/sync-vendor.sh` to refresh the signing JS. |
+| `HTTP_<code>`          | Network / transport failure                                                                                                                                                                    | Check connectivity                                                                                                                                                                                           |
 
 ## Workflow Examples
 

--- a/skills/xiaohongshu/references/provider-config.yaml
+++ b/skills/xiaohongshu/references/provider-config.yaml
@@ -13,7 +13,8 @@ xiaohongshu:
         - www.xiaohongshu.com
         - edith.xiaohongshu.com
     entryUrl: https://www.xiaohongshu.com/explore
-    validateUrl: https://www.xiaohongshu.com/notifications
+    validateUrl: https://edith.xiaohongshu.com/api/sns/web/unread_count
+    validateRule: 'res.body.code === 0 && res.body.success === true'
     strategy: browser
     ttl: 2h
     extract:

--- a/skills/xiaohongshu/scripts/xiaohongshu_client.py
+++ b/skills/xiaohongshu/scripts/xiaohongshu_client.py
@@ -108,10 +108,23 @@ class XiaohongshuClient:
 
     @staticmethod
     def _unwrap(success: bool, msg: str, res_json: dict | None) -> dict:
-        if not success:
-            raise XiaohongshuApiError("API_ERROR", msg or "request failed")
-        if res_json is None:
-            raise XiaohongshuApiError("API_ERROR", "empty response")
+        # On any failure, surface what we know (HTTP code from response if any)
+        # and tell the user the only reliable next step: re-login. We do NOT
+        # try to guess the root cause (captcha, expired session, account
+        # flagged, vendor schema drift, network blip, etc.) — too many things
+        # can land here, and a misleading guess is worse than none.
+        if not success or res_json is None:
+            code = res_json.get("code") if isinstance(res_json, dict) else None
+            parts = []
+            if code is not None:
+                parts.append(f"code={code}")
+            if msg:
+                parts.append(f"msg={msg!r}")
+            detail = ", ".join(parts) if parts else "request failed"
+            raise XiaohongshuApiError(
+                "API_ERROR",
+                f"{detail}. Try: sig logout xiaohongshu && sig login xiaohongshu --mode visible",
+            )
         # Spider_XHS returns the full envelope {success, msg, code, data}.
         # Return just the `data` payload to match other skills' shape.
         return res_json.get("data", res_json)


### PR DESCRIPTION
## Summary

- Switch validateUrl to `/api/sns/web/unread_count` and add a `validateRule` so sigcli reads the response body instead of relying on HTTP status alone. Cookies that have not actually passed Xiaohongshu's auth flow are now correctly marked invalid.
- In `xiaohongshu_client._unwrap`, surface the raw `code` and `msg` from the response on any failure, and suggest re-login as the next step. The wrapper no longer attempts to attribute the error to a specific cause.

## Background

The previous `validateUrl` (`https://www.xiaohongshu.com/notifications`) returns `302 → /login` when not authenticated. sigcli's default validation did not flag that as invalid, so a cookie that had not passed Xiaohongshu's image captcha was marked `valid: true`. Every downstream API call then returned `HTTP 461` with an empty body (`{\"code\":0,\"success\":true,\"data\":{}}`), which the vendor's `res_json[\"msg\"]` lookup turned into a `KeyError`, surfaced to users as the opaque `API_ERROR: 'msg'`.

After the change:
- `sig status xiaohongshu` reflects whether the cookie actually works (true negative when captcha unsolved).
- Failures from scripts now look like `code=-3, msg='...'` instead of `'msg'`, and tell the user to re-login.

## Files

- `skills/xiaohongshu/references/provider-config.yaml` — new `validateUrl` + `validateRule` + comments.
- `skills/xiaohongshu/SKILL.md` — Error Handling table simplified; setup verification note added.
- `skills/xiaohongshu/scripts/xiaohongshu_client.py` — `_unwrap` returns richer error detail; no root-cause guessing.

Vendor (`skills/xiaohongshu/vendor/`) is untouched.

## Test plan

- [x] `sig status xiaohongshu` reports `valid: false` for a cookie that has not passed captcha (was previously `valid: true`).
- [x] `sig login xiaohongshu --mode visible` followed by solving the captcha → `sig status` shows `valid: true`.
- [x] `xiaohongshu_search_note.py --keyword \"MBA\"` returns 22 real results on a valid cookie.
- [x] Forced bad cookie returns `API_ERROR: code=-3, msg='...'. Try: sig logout && sig login...` instead of `'msg'`.