### PR TITLE
xiaohongshu skill: detect captcha-not-solved soft-reject

### DIFF
--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sigcli/skills",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "AI agent skills for authenticated web access via sigcli",
     "type": "module",
     "bin": {

--- a/skills/xiaohongshu/SKILL.md
+++ b/skills/xiaohongshu/SKILL.md
@@ -22,15 +22,27 @@ sig status xiaohongshu 2>&1
 Check the JSON output fields `configured` and `valid`:
 
 - **`configured: false`** → run Provider Setup below.
-- **`valid: false` (but configured: true)** → run `sig login xiaohongshu`, then re-check.
+- **`valid: false` (but configured: true)** → run `sig login xiaohongshu --mode visible`, **complete the captcha**, then re-check.
 - **`valid: true`** → run Vendor Setup (one-time per machine), then execute the user's request.
 
 ### Provider Setup
 
 1. Read `<SKILL_DIR>/references/provider-config.yaml`
 2. Append the provider block to `~/.sig/config.yaml` under `providers:`
-3. Run `sig login xiaohongshu` — a browser opens; scan the QR code with the Xiaohongshu app
-4. Verify: `sig status xiaohongshu` should show `valid: true`. The provider config uses `validateRule` to probe `/api/sns/web/unread_count` — if the captcha was not solved, validation will fail here instead of silently passing.
+3. Run `sig login xiaohongshu --mode visible` — a browser opens; scan the QR code with the Xiaohongshu app **and complete the slider/image captcha if prompted**
+4. Verify: `sig status xiaohongshu` should show `valid: true`
+
+### Why captcha matters — three response shapes
+
+XHS hides a "captcha not solved" state behind what looks like a successful response. The provider's `validateRule` is built specifically to reject it:
+
+| State                  | `/api/sns/web/unread_count` returns                           | Detected as                                   |
+| ---------------------- | ------------------------------------------------------------- | --------------------------------------------- |
+| Fully authenticated    | `{code:0, success:true, data:{unread_count:N, likes:N, ...}}` | ✅ valid                                      |
+| **Captcha not solved** | `{code:0, success:true, data:{}}`                             | ❌ rejected by `Object.keys(data).length > 0` |
+| Logged out / expired   | `{code:-101, success:false, msg:"无登录信息"}`                | ❌ rejected by `code === 0`                   |
+
+If `sig login` exits without prompting you, but later API calls fail with empty data — the captcha was bypassed by a stale rule. Re-pull `references/provider-config.yaml` and refresh the rule in `~/.sig/config.yaml`, then re-login.
 
 ### Vendor Setup (one-time per machine)
 
@@ -136,13 +148,15 @@ All scripts are in this skill's `scripts/` directory. Output is JSON to stdout.
 
 ## Error Handling
 
-| Error                  | Meaning                                                                                                                                                                                        | Fix                                                                                                                                                                                                          |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `AUTH_REQUIRED`        | No cookie available                                                                                                                                                                            | `sig login xiaohongshu --mode visible`                                                                                                                                                                       |
-| `VENDOR_MISSING`       | `<SKILL_DIR>/vendor/` not populated                                                                                                                                                            | Run `<SKILL_DIR>/scripts/sync-vendor.sh`                                                                                                                                                                     |
-| `NODE_MODULES_MISSING` | `vendor/node_modules/` missing                                                                                                                                                                 | `cd <SKILL_DIR>/vendor && npm install`                                                                                                                                                                       |
-| `API_ERROR`            | Any other failure from Xiaohongshu (expired session, signing rejected, account flagged, network blip, etc.). The error message includes the raw `code`/`msg` from the response when available. | `sig logout xiaohongshu && sig login xiaohongshu --mode visible`. If it persists after re-login, capture the full error and consider running `<SKILL_DIR>/scripts/sync-vendor.sh` to refresh the signing JS. |
-| `HTTP_<code>`          | Network / transport failure                                                                                                                                                                    | Check connectivity                                                                                                                                                                                           |
+| Error                          | Meaning                                                                                                                                                                     | Fix                                                                                                                                                                                                                                                                                                                                                                      |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `AUTH_REQUIRED`                | No cookie available                                                                                                                                                         | `sig login xiaohongshu --mode visible`                                                                                                                                                                                                                                                                                                                                   |
+| `VENDOR_MISSING`               | `<SKILL_DIR>/vendor/` not populated                                                                                                                                         | Run `<SKILL_DIR>/scripts/sync-vendor.sh`                                                                                                                                                                                                                                                                                                                                 |
+| `NODE_MODULES_MISSING`         | `vendor/node_modules/` missing                                                                                                                                              | `cd <SKILL_DIR>/vendor && npm install`                                                                                                                                                                                                                                                                                                                                   |
+| `API_ERROR` with `msg="'msg'"` | Vendor parser hit `KeyError: 'msg'` because the API returned `{code:0, success:true, data:{}}`. This is the **captcha-not-solved soft-reject** — the cookie is half-cooked. | `sig logout xiaohongshu && sig login xiaohongshu --mode visible`, **then complete the captcha in the browser**. Verify with `sig status xiaohongshu` showing `valid: true` _after_ the captcha. The validateRule in `references/provider-config.yaml` should detect this state — if `sig status` already showed valid:true, your local config drifted; refresh the rule. |
+| `API_ERROR` with `code=-101`   | `无登录信息` — session is gone                                                                                                                                              | `sig login xiaohongshu --mode visible`                                                                                                                                                                                                                                                                                                                                   |
+| `API_ERROR` (other)            | Account flagged, vendor schema drift, etc.                                                                                                                                  | `sig logout xiaohongshu && sig login xiaohongshu --mode visible`. If it persists after re-login, run `<SKILL_DIR>/scripts/sync-vendor.sh` to refresh the signing JS.                                                                                                                                                                                                     |
+| `HTTP_<code>`                  | Network / transport failure                                                                                                                                                 | Check connectivity                                                                                                                                                                                                                                                                                                                                                       |
 
 ## Workflow Examples
 
@@ -169,7 +183,65 @@ sig run xiaohongshu -- bash -c \
   "python3 <SKILL_DIR>/scripts/xiaohongshu_get_note_comments.py --note-id '$NOTE_ID' --xsec-token '$XSEC'"
 ```
 
-## Vendoring
+## Self-Test
+
+Two-tier verification. Run tier 1 unconditionally; tier 2 only after tier 1 passes.
+
+### Tier 1: prerequisite checks (read-only, safe)
+
+```bash
+# 1. Provider authenticated and validated against the strict rule
+sig status xiaohongshu
+# Expect: configured: true, valid: true
+```
+
+```bash
+# 2. Probe the validateUrl directly — must return non-empty data object
+sig run xiaohongshu -- bash -c 'curl -sL --max-time 10 \
+  -H "Cookie: $SIG_XIAOHONGSHU_COOKIE" \
+  -H "User-Agent: Mozilla/5.0" \
+  https://edith.xiaohongshu.com/api/sns/web/unread_count'
+# Expect: {"code":0,"success":true,"msg":"成功","data":{"unread_count":N,...}}
+# If `data` is `{}` → captcha not solved. Re-login with --mode visible and complete the captcha.
+# If code is -101 → session gone. Re-login.
+```
+
+```bash
+# 3. Vendor signing JS deps installed
+test -d <SKILL_DIR>/vendor/node_modules && echo "OK: node_modules present" || echo "FAIL: cd vendor && npm install"
+```
+
+```bash
+# 4. Smoke-test signature generation (no network, no cookie)
+cd <SKILL_DIR>/vendor && python3 -c "
+import sys; sys.path.insert(0, '.')
+from xhs_utils.xhs_util import generate_x_rap_param, generate_xs_xs_common
+xs, xt, xsc = generate_xs_xs_common('a1=test', '/api/sns/web/v1/feed', '', 'POST')
+rap = generate_x_rap_param('/api/sns/web/v1/user_posted', '')
+print('OK' if xs and rap else 'FAIL')
+"
+# Expect: OK
+```
+
+### Tier 2: live execution test
+
+Run a tiny search and assert that `items` is a non-empty list. This is the canary for "everything actually works":
+
+```bash
+sig run xiaohongshu -- bash -c \
+  'python3 <SKILL_DIR>/scripts/xiaohongshu_search_note.py --keyword "AI"' \
+  | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+items = d.get('items', [])
+assert isinstance(items, list) and len(items) > 0, f'expected items list, got: {d}'
+print(f'OK: {len(items)} items')
+"
+# Expect: OK: N items
+# If you see {'error': 'API_ERROR', 'message': \"code=0, msg=\\\"'msg'\\\"\"} → captcha-not-solved
+# soft-reject. The cookie is half-cooked even though sig status shows valid:true.
+# Refresh references/provider-config.yaml into ~/.sig/config.yaml, then re-login with captcha.
+```
 
 This skill bundles a minimal slice of [cv-cat/Spider_XHS](https://github.com/cv-cat/Spider_XHS) (MIT) at `<SKILL_DIR>/vendor/`. To bump the vendored version:
 

--- a/skills/xiaohongshu/references/provider-config.yaml
+++ b/skills/xiaohongshu/references/provider-config.yaml
@@ -5,8 +5,20 @@
 #   npm install -g @sigcli/cli
 #   sig init
 #
-# Login:
-#   sig login xiaohongshu
+# Login (visible mode is required — Xiaohongshu shows a slider/image captcha
+# that must be solved by a human before the session is fully authenticated):
+#   sig login xiaohongshu --mode visible
+#
+# Why the elaborate validateRule below:
+#   /unread_count returns three different shapes:
+#     1. Fully authenticated:  {code:0, success:true, data:{unread_count:N, likes:N, ...}}
+#     2. Captcha not solved:   {code:0, success:true, data:{}}      ← looks valid, isn't!
+#     3. Logged out / expired: {code:-101, success:false, msg:"无登录信息"}
+#   Naive rule `code===0 && success===true` accepts state #2 — sigcli writes a
+#   half-cooked cookie and exits before the human finishes the captcha. Later
+#   API calls then return empty data and the vendor parser crashes.
+#   The rule below requires `data` to be a non-empty object, which is only true
+#   in state #1.
 
 xiaohongshu:
     domains:
@@ -14,7 +26,7 @@ xiaohongshu:
         - edith.xiaohongshu.com
     entryUrl: https://www.xiaohongshu.com/explore
     validateUrl: https://edith.xiaohongshu.com/api/sns/web/unread_count
-    validateRule: 'res.body.code === 0 && res.body.success === true'
+    validateRule: 'res.status === 200 && res.body.code === 0 && res.body.success === true && res.body.data && typeof res.body.data === "object" && Object.keys(res.body.data).length > 0'
     strategy: browser
     ttl: 2h
     extract:


### PR DESCRIPTION
## Summary

XHS hides a "captcha not solved" state behind a `code:0, success:true, data:{}` response. The previous `validateRule` accepted this state, so sigcli wrote a half-cooked cookie and exited before the human finished the captcha. Later API calls returned empty data, the vendor parser hit `KeyError: 'msg'`, and the skill surfaced a "re-login" prompt that didn't mention the captcha — sending users in circles.

This PR tightens the rule and teaches Claude/users to recognise the three response shapes.

### Three response shapes from `/api/sns/web/unread_count`

| State | Body | Detected as |
| --- | --- | --- |
| Fully authenticated | `{code:0, success:true, data:{unread_count, likes, ...}}` | ✅ valid |
| Captcha not solved | `{code:0, success:true, data:{}}` | ❌ rejected (was ✅ before) |
| Logged out | `{code:-101, success:false, msg:"无登录信息"}` | ❌ rejected |

### Changes

- **`provider-config.yaml`** — `validateRule` now requires `data` to be a non-empty object. Header comment documents the three states.
- **`SKILL.md` Setup** — `--mode visible` is explicit, captcha completion is an explicit step, three-state table is inline.
- **`SKILL.md` Error Handling** — split the generic `API_ERROR` row into three: `msg="'msg'"` → captcha, `code=-101` → expired, other → vendor drift.
- **`SKILL.md` Self-Test** — new section with two tiers:
  - Tier 1 (read-only): `sig status`, `unread_count` probe, `node_modules`, signing smoke test
  - Tier 2 (live): real search asserting `items` is non-empty

## Test plan

- [x] Tier 1 prereq checks pass on a freshly logged-in account
- [x] Tier 2 live search returns 22 items for keyword "AI"
- [x] Re-running login when the cookie is still in captcha state now keeps the browser open until the captcha is solved (rule rejects the empty-data state)
- [x] Misleading "re-login" loop reproduced before the fix; resolved after