### PR TITLE
fix(cli): bump undici to 7.28.0 to patch 7 advisories

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,60 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are issued against the latest minor release line of each package.
+
+| Package               | Supported version |
+| --------------------- | ----------------- |
+| `@sigcli/cli`         | Latest 1.x        |
+| `@sigcli/sdk`         | Latest 2.x        |
+| `sigcli-sdk` (Python) | Latest 0.x        |
+
+Older versions do not receive security patches. Please upgrade before reporting.
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security reports.**
+
+Please report vulnerabilities privately via either:
+
+- GitHub Security Advisories: https://github.com/sigcli/sigcli/security/advisories/new (preferred — encrypted, tracked)
+- Email: pylon.peng@gmail.com with the subject `[sigcli security]`
+
+Include in your report:
+
+- Affected package and version (`sig --version` for the CLI)
+- A description of the vulnerability and the impact you observed
+- Reproduction steps or a proof-of-concept, if available
+- Your suggested remediation, if any
+
+You can expect:
+
+- Acknowledgement within **3 business days**
+- An initial assessment and severity rating within **7 business days**
+- A patched release for confirmed High/Critical issues within **14 days** of confirmation, where feasible
+- Public disclosure coordinated with you after a patched release is available
+
+## Scope
+
+In scope:
+
+- Code in this repository (`cli/`, `sdk/typescript/`, `sdk/python/`)
+- Credential handling, encryption-at-rest, proxy, and authentication flows
+- Supply-chain integrity of published packages (`@sigcli/cli`, `@sigcli/sdk`, `sigcli-sdk`)
+
+Out of scope:
+
+- The `website/` workspace (marketing site only, not published as a package)
+- Issues that require physical access to an unlocked user machine
+- Social engineering against package maintainers
+- Vulnerabilities in third-party browser engines, operating systems, or upstream Node.js
+
+## Security Practices
+
+- All credentials are encrypted at rest with AES-256-GCM using a per-machine key at `~/.sig/encryption.key` (mode `0o400`)
+- Released packages have no `preinstall`, `install`, or `postinstall` lifecycle scripts
+- Releases are gated on a manually-triggered GitHub Actions workflow on `main`, with `--frozen-lockfile` installs
+- All direct and transitive licences are permissive (MIT / ISC / 0BSD)
+
+For a current snapshot of dependency advisories, run `pnpm audit --prod` from the relevant workspace.

--- a/cli/package.json
+++ b/cli/package.json
@@ -24,7 +24,7 @@
         "croner": "^10.0.1",
         "dlv": "^1.1.3",
         "proper-lockfile": "^4.1.2",
-        "undici": "^7.25.0",
+        "undici": "^7.28.0",
         "yaml": "^2.7.0"
     },
     "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2
       undici:
-        specifier: ^7.25.0
-        version: 7.25.0
+        specifier: ^7.28.0
+        version: 7.28.0
       yaml:
         specifier: ^2.7.0
         version: 2.8.3
@@ -3978,8 +3978,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -6346,7 +6346,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.25.0
+      undici: 7.28.0
       whatwg-mimetype: 4.0.0
 
   chokidar@3.6.0:
@@ -7174,7 +7174,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -8170,7 +8170,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:


### PR DESCRIPTION
## Summary

- Bumps `undici` in `cli/` from `^7.25.0` to `^7.28.0` — patches **all 7 outstanding advisories** in sigcli's runtime dependency tree, including 3 High-severity issues that hit sigcli's SOCKS5 proxy code path directly.
- Adds `SECURITY.md` documenting responsible vulnerability disclosure (lifts the OpenSSF Scorecard Security-Policy check from 0/10 to 10/10).
- After this change, **`pnpm audit --prod` for `@sigcli/cli` reports zero advisories.**

## Why this is the right scope

A recent OpenSSF Scorecard scan flagged 39 CVEs across 17 packages. After auditing each path, only the `undici` cluster actually ships to end users via `npm install -g @sigcli/cli`. The remaining advisories live in:

- `website/` — `"private": true`, never published to npm
- `vitest` / `vite` / `esbuild` — devDependencies, stripped by `npm install -g`

A follow-up PR will widen the sweep (bump `vitest` 3.2.6+, add Dependabot, pin GitHub Actions by SHA) so the audit report itself comes back clean.

## Advisories closed (all in `cli > undici`)

| Severity | Title |
| --- | --- |
| HIGH | TLS certificate validation bypass via dropped requestTls in SOCKS5 ProxyAgent |
| HIGH | Cross-origin request routing via SOCKS5 proxy pool reuse |
| HIGH | WebSocket client DoS via fragment count bypass |
| MOD | Cross-user information disclosure via shared cache whitespace bypass |
| MOD | HTTP header injection via Set-Cookie percent-decoding |
| LOW | HTTP response queue poisoning via keep-alive socket reuse |
| LOW | Set-Cookie SameSite attribute downgrade |

The two SOCKS5 advisories are directly relevant — sigcli uses `Socks5ProxyAgent` in `cli/src/utils/http.ts`.

## Regression risk

- Same major version (`7.x` → `7.x`), no breaking changes
- API surface used by sigcli (`fetch`, `ProxyAgent`, `Socks5ProxyAgent`, `Dispatcher`) is stable
- Lockfile diff is 7 lines, undici only

## Test plan

- [x] `pnpm -r build` — clean across `cli`, `sdk`, `website`
- [x] `cli`: **496/496 tests pass**
- [x] `sdk`: **42/42 tests pass**
- [x] `pnpm audit --prod` in `cli/` — zero advisories
- [ ] CI green

Refs HTCE-57091