### PR TITLE
chore(ci): add Dependabot, CodeQL, and SHA-pin action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+    # npm dependencies across all workspaces
+    - package-ecosystem: npm
+      directory: /
+      schedule:
+          interval: weekly
+          day: monday
+      open-pull-requests-limit: 10
+      groups:
+          dev-dependencies:
+              dependency-type: development
+              update-types:
+                  - minor
+                  - patch
+          production-dependencies:
+              dependency-type: production
+              update-types:
+                  - patch
+
+    # GitHub Actions (keeps SHA-pinned action versions fresh)
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+          interval: weekly
+          day: monday
+      open-pull-requests-limit: 5
+
+    # Python SDK
+    - package-ecosystem: pip
+      directory: /sdk/python
+      schedule:
+          interval: weekly
+          day: monday
+      open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
                   node-version: 22
                   cache: pnpm
@@ -47,13 +47,13 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
 
             - name: Setup Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: pnpm
@@ -79,10 +79,10 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
             - name: Setup Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
               with:
                   python-version: '3.12'
 
@@ -103,7 +103,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
               with:
                   fetch-depth: 0
 
@@ -125,11 +125,11 @@ jobs:
 
             - name: Install pnpm
               if: steps.changes.outputs.changed == 'true'
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
 
             - name: Setup Node.js
               if: steps.changes.outputs.changed == 'true'
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
                   node-version: 22
                   cache: pnpm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: CodeQL
+
+on:
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
+    schedule:
+        # Weekly scan on Monday
+        - cron: '17 6 * * 1'
+
+permissions:
+    contents: read
+
+jobs:
+    analyze:
+        name: Analyze (${{ matrix.language }})
+        runs-on: ubuntu-latest
+
+        permissions:
+            security-events: write
+            packages: read
+            actions: read
+            contents: read
+
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - language: javascript-typescript
+                      build-mode: none
+                    - language: python
+                      build-mode: none
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
+              with:
+                  languages: ${{ matrix.language }}
+                  build-mode: ${{ matrix.build-mode }}
+                  queries: security-and-quality
+
+            - name: Perform CodeQL Analysis
+              uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
+              with:
+                  category: '/language:${{ matrix.language }}'

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -24,10 +24,10 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
             - name: Setup Python 3.12
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
               with:
                   python-version: '3.12'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,13 +32,13 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
 
             - name: Setup Node.js 22
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
                   node-version: 22
                   registry-url: https://registry.npmjs.org

--- a/.github/workflows/unrelease.yml
+++ b/.github/workflows/unrelease.yml
@@ -35,7 +35,7 @@ jobs:
 
         steps:
             - name: Setup Node.js 22
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
                   node-version: 22
                   registry-url: https://registry.npmjs.org


### PR DESCRIPTION
## Summary

Follow-up to #196 and #197. Three Scorecard hygiene improvements in one PR — all pure additions or SHA pins, no change to existing CI behaviour.

| Change | Lifts Scorecard check |
| --- | --- |
| `.github/dependabot.yml` (new) — weekly npm + Actions + pip updates | Dependency-Update-Tool: 0/10 → 10/10 |
| `.github/workflows/codeql.yml` (new) — CodeQL JS/TS + Python | SAST: 0/10 → 10/10 |
| SHA-pin all third-party actions in existing workflows | Pinned-Dependencies: 0/10 → 10/10 |

Combined with the SECURITY.md from #196 (Security-Policy 0/10 → 10/10), this brings four Scorecard checks from red to green.

## Why SHA pins

Tag refs like `@v4` are mutable — a compromised maintainer account can re-point them at malicious code, and your CI would pick it up silently on the next run (this is exactly how the `tj-actions/changed-files` compromise played out in 2025). Commit SHAs are immutable and content-addressed, so they cannot be tampered with.

Dependabot understands SHA-pinned actions natively and opens PRs like "bump actions/checkout from 34e1148... to 0b9a3e3d... (v4.3.1 → v4.3.2)", so the maintenance overhead is the same as version-tag updates.

## Actions pinned (with comment for readability)

| Action | Tag | SHA |
| --- | --- | --- |
| `actions/checkout` | v4.3.1 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/setup-node` | v4.4.0 | `49933ea5288caeca8642d1e84afbd3f7d6820020` |
| `actions/setup-python` | v5.6.0 | `a26af69be951a213d495a4c3e4e4022e16d87065` |
| `pnpm/action-setup` | v4.4.0 | `b906affcce14559ad1aafd4ab0e942779e9f58b1` |
| `github/codeql-action/init` & `/analyze` | v3.36.2 | `dd903d2e4f5405488e5ef1422510ee31c8b32357` |

## Test plan

- [x] All six YAML files parse cleanly (`yaml.safe_load`)
- [x] No remaining `@v<N>` tag refs in any workflow
- [ ] CI green on this PR (validates CodeQL workflow runs and existing jobs still pass)
- [ ] First Dependabot run on next Monday confirms `.github/dependabot.yml` is valid

## Expected Scorecard score lift

Roughly +3.0 from 4 checks moving 0/10 → 10/10 (Security-Policy via #196 + the three in this PR), weighted across ~16 active checks.

Refs HTCE-57091