### PR TITLE
chore(ci): tighten Dependabot to suppress version-bump noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,30 +1,53 @@
 version: 2
+
+# Goal: keep security fixes flowing, but suppress non-security version-bump noise.
+#
+# Strategy:
+#   - group everything aggressively so weekly runs produce 1–3 PRs, not 13
+#   - ignore major version bumps (handle them by hand when there's a reason)
+#   - keep open-pull-requests-limit low; security PRs bypass the limit anyway
+
 updates:
-    # npm dependencies across all workspaces
+    # npm — root workspace (all sigcli packages share one lockfile)
     - package-ecosystem: npm
       directory: /
       schedule:
           interval: weekly
           day: monday
-      open-pull-requests-limit: 10
+      open-pull-requests-limit: 3
       groups:
-          dev-dependencies:
-              dependency-type: development
+          # One PR for every non-major dependency update
+          all-deps:
+              patterns:
+                  - '*'
               update-types:
                   - minor
                   - patch
-          production-dependencies:
-              dependency-type: production
-              update-types:
-                  - patch
+      ignore:
+          # Don't touch major versions automatically — they routinely have
+          # breaking changes that need manual review.
+          - dependency-name: '*'
+            update-types:
+                - version-update:semver-major
 
-    # GitHub Actions (keeps SHA-pinned action versions fresh)
+    # GitHub Actions — keeps SHA-pinned action versions fresh
     - package-ecosystem: github-actions
       directory: /
       schedule:
           interval: weekly
           day: monday
-      open-pull-requests-limit: 5
+      open-pull-requests-limit: 2
+      groups:
+          actions:
+              patterns:
+                  - '*'
+              update-types:
+                  - minor
+                  - patch
+      ignore:
+          - dependency-name: '*'
+            update-types:
+                - version-update:semver-major
 
     # Python SDK
     - package-ecosystem: pip
@@ -32,4 +55,15 @@ updates:
       schedule:
           interval: weekly
           day: monday
-      open-pull-requests-limit: 5
+      open-pull-requests-limit: 2
+      groups:
+          python-deps:
+              patterns:
+                  - '*'
+              update-types:
+                  - minor
+                  - patch
+      ignore:
+          - dependency-name: '*'
+            update-types:
+                - version-update:semver-major


### PR DESCRIPTION
## Summary

The initial Dependabot run from #198 produced a flood of 17+ PRs (#199–#216), most of them non-security version bumps that nobody asked for. All have been bulk-closed. This PR tightens `dependabot.yml` so future runs stay quiet.

## Changes

- **Group all updates per ecosystem into a single PR/week** — instead of one PR per dependency
- **Ignore all major version bumps** — they routinely break things and need manual review (e.g. the closed #213 wanted `actions/checkout v4 → v7`, #215 wanted `@types/node v20 → v26`)
- **Drop `open-pull-requests-limit`** from 10/5/5 to 3/2/2

## What this does NOT block

Security PRs from Dependabot bypass both the per-week limit and the `ignore` rules. So CVE fixes still arrive promptly — only routine version bumps are throttled.

## Expected weekly volume

| Ecosystem | Before | After |
| --- | --- | --- |
| npm | 13 PRs on first run | 1 grouped PR/week max |
| github-actions | 4 PRs on first run | 1 grouped PR/week max |
| pip | 0 (no pip deps changed yet) | 1 grouped PR/week max |

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` parses clean
- [ ] Next Monday's Dependabot run produces ≤3 PRs total (validates in production)

Refs HTCE-57091