### PR TITLE
feat(idp): auto-fill TOTP on 2FA pages during browser login

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -23,6 +23,7 @@
         "@peculiar/x509": "^2.0.0",
         "croner": "^10.0.1",
         "dlv": "^1.1.3",
+        "otpauth": "^9.5.1",
         "proper-lockfile": "^4.1.2",
         "reflect-metadata": "^0.2.2",
         "undici": "^7.28.0",

--- a/cli/src/auth-manager.ts
+++ b/cli/src/auth-manager.ts
@@ -1,3 +1,6 @@
+import os from 'node:os';
+import path from 'node:path';
+
 import {
     err,
     isOk,
@@ -6,6 +9,7 @@ import {
     type ApplyRule,
     type AuthError,
     type ExtractedCredentials,
+    type IIdpRegistry,
     type ILogger,
     type IProviderRegistry,
     type IStorage,
@@ -28,6 +32,9 @@ import { ApplyEngine, type ApplyResult } from './apply/apply-engine.js';
 import { parseDuration } from './utils/duration.js';
 import { createNoopLogger, createOperationalLogger } from './utils/logger.js';
 import { expandHome } from './utils/path.js';
+import { IdpRegistry } from './idps/idp-registry.js';
+import { IdpStore } from './idps/idp-store.js';
+import type { IdpEntry } from './idps/types.js';
 
 /**
  * Central orchestrator for authentication lifecycle.
@@ -39,6 +46,7 @@ export class AuthManager {
     readonly config: SigConfig;
     readonly browserAvailable: boolean;
     readonly logger: ILogger;
+    readonly idps: IIdpRegistry;
 
     private readonly providers: IProviderRegistry;
     private readonly browserConfig: BrowserConfig;
@@ -50,6 +58,7 @@ export class AuthManager {
         browserConfig: BrowserConfig,
         config: SigConfig,
         logger: ILogger,
+        idps: IIdpRegistry,
     ) {
         this.storage = storage;
         this.providers = providers;
@@ -57,6 +66,7 @@ export class AuthManager {
         this.config = config;
         this.browserAvailable = config.mode !== 'browserless';
         this.logger = logger;
+        this.idps = idps;
     }
 
     static async create(config: SigConfig, logger?: ILogger): Promise<AuthManager> {
@@ -91,10 +101,34 @@ export class AuthManager {
             ttlMs: 5000,
         });
 
-        const manager = new AuthManager(storage, providerRegistry, config.browser, config, log);
+        // IdP registry — metadata from config.yaml, secrets from ~/.sig/idps/.
+        const sigDir = path.join(os.homedir(), '.sig');
+        const idpStore = new IdpStore(path.join(sigDir, 'idps'), encryptionKey);
+        const idpMeta = config.idps ?? {};
+        const idpEntries: IdpEntry[] = await Promise.all(
+            Object.entries(idpMeta).map(async ([hostname, meta]) => {
+                const secret = await idpStore.getSecret(hostname).catch(() => null);
+                const entry: IdpEntry = { hostname };
+                if (meta.label) entry.label = meta.label;
+                if (secret) {
+                    entry.totp = { secret };
+                }
+                return entry;
+            }),
+        );
+        const idps = new IdpRegistry(idpEntries);
+
+        const manager = new AuthManager(
+            storage,
+            providerRegistry,
+            config.browser,
+            config,
+            log,
+            idps,
+        );
 
         if (manager.browserAvailable) {
-            manager.registerStrategy(new BrowserStrategy(config.browser, undefined, log));
+            manager.registerStrategy(new BrowserStrategy(config.browser, undefined, log, idps));
         }
         manager.registerStrategy(new PromptStrategy());
         manager.registerStrategy(new OAuth2Strategy());

--- a/cli/src/cli-router.ts
+++ b/cli/src/cli-router.ts
@@ -8,6 +8,7 @@ import { AuthManager } from './auth-manager.js';
 import { runCompletion } from './commands/completion.js';
 import { runDoctor } from './commands/doctor.js';
 import { runGet } from './commands/get.js';
+import { runIdp } from './commands/idp.js';
 import { runInit } from './commands/init.js';
 import { runLogin } from './commands/login.js';
 import { runLogout } from './commands/logout.js';
@@ -138,6 +139,15 @@ Watch:
   watch remove <provider>      Remove provider from watch list
   watch set-interval <dur>     Set default check interval
 
+Identity providers (2FA/MFA auto-fill during login):
+  idp add <hostname>           Configure per-hostname TOTP secret
+    --totp-secret <secret>       Base32 TOTP secret (prompted if omitted)
+    --label <name>               Friendly name
+  idp list                     List configured IdPs (secrets redacted)
+    --format json|table          Output format
+  idp show <hostname>          Show a single IdP entry (secret redacted)
+  idp remove <hostname>        Remove an IdP entry (metadata + secret)
+
 Setup:
   init                         Create ~/.sig/config.yaml
     --remote                     Headless machine setup (mode: browserless)
@@ -245,6 +255,9 @@ export async function run(args: string[]): Promise<void> {
             break;
         case Command.REMOTE:
             await runRemote(positionals, flags);
+            break;
+        case Command.IDP:
+            await runIdp(positionals, flags);
             break;
         case Command.SYNC:
             await runSync(positionals, flags, auth as AuthManager);

--- a/cli/src/commands/idp.ts
+++ b/cli/src/commands/idp.ts
@@ -1,0 +1,192 @@
+/**
+ * `sig idp` — manage per-hostname Identity Provider secrets (currently TOTP).
+ *
+ * Metadata (hostname, label, totp presence) lives in ~/.sig/config.yaml.
+ * The TOTP secret lives encrypted at ~/.sig/idps/<hostname>.json.
+ * Secrets are NEVER printed by list/show — only their presence is reported.
+ */
+
+import os from 'node:os';
+import path from 'node:path';
+
+import { IdpSubcommand } from '../types/index.js';
+import { loadEncryptionKey } from '../crypto/encryption.js';
+import { ExitCode } from '../utils/exit-codes.js';
+import { formatJson, formatTable } from '../utils/formatters.js';
+import { promptSecret } from '../utils/prompt.js';
+import { computeTotp } from '../utils/totp.js';
+import { getIdpMetaEntries, removeIdpMetaEntry, setIdpMetaEntry } from '../idps/idp-config.js';
+import { IdpStore } from '../idps/idp-store.js';
+import type { IdpMetaEntry } from '../idps/types.js';
+
+const USAGE = `Usage: sig idp <subcommand> [options]
+
+Subcommands:
+  add <hostname>                   Add or replace an IdP entry
+    --totp-secret <secret>           Base32 TOTP secret (prompted if omitted)
+    --label <name>                   Optional friendly name
+  list [--format json|table]       List configured IdPs (secrets redacted)
+  show <hostname>                  Show a single IdP entry (secret redacted)
+  remove <hostname>                Remove an IdP entry (metadata + secret)
+`;
+
+function idpDir(): string {
+    return path.join(os.homedir(), '.sig', 'idps');
+}
+
+async function asyncIdpStore(): Promise<IdpStore> {
+    const key = await loadEncryptionKey();
+    return new IdpStore(idpDir(), key);
+}
+
+function totpStatus(_meta: IdpMetaEntry, hasSecret: boolean): string {
+    return hasSecret ? 'configured' : 'none';
+}
+
+export async function runIdp(
+    positionals: string[],
+    flags: Record<string, string | boolean | string[]>,
+): Promise<void> {
+    const subcommand = positionals[0];
+
+    switch (subcommand) {
+        case IdpSubcommand.ADD:
+            return runAdd(positionals, flags);
+        case IdpSubcommand.LIST:
+            return runList(flags);
+        case IdpSubcommand.SHOW:
+            return runShow(positionals);
+        case IdpSubcommand.REMOVE:
+            return runRemove(positionals);
+        default:
+            process.stderr.write(USAGE);
+            process.exitCode = ExitCode.GENERAL_ERROR;
+    }
+}
+
+async function runAdd(
+    positionals: string[],
+    flags: Record<string, string | boolean | string[]>,
+): Promise<void> {
+    const hostname = positionals[1];
+    if (!hostname) {
+        process.stderr.write('Usage: sig idp add <hostname> [--totp-secret <secret>] ...\n');
+        process.exitCode = ExitCode.GENERAL_ERROR;
+        return;
+    }
+
+    let secret: string | undefined;
+    if (typeof flags['totp-secret'] === 'string') {
+        secret = flags['totp-secret'];
+    } else {
+        secret = (await promptSecret('TOTP secret (base32): ')).trim();
+    }
+    if (!secret) {
+        process.stderr.write('Error: TOTP secret is required\n');
+        process.exitCode = ExitCode.GENERAL_ERROR;
+        return;
+    }
+    // Normalize: strip spaces (authenticator apps often show them in groups).
+    secret = secret.replace(/\s+/g, '');
+
+    try {
+        computeTotp(secret);
+    } catch (e) {
+        process.stderr.write(`Error: invalid TOTP secret — ${(e as Error).message}\n`);
+        process.exitCode = ExitCode.GENERAL_ERROR;
+        return;
+    }
+
+    const label = typeof flags.label === 'string' ? flags.label : undefined;
+
+    const meta: IdpMetaEntry = {
+        ...(label ? { label } : {}),
+        totp: {},
+    };
+
+    await setIdpMetaEntry(hostname, meta);
+    const store = await asyncIdpStore();
+    await store.setSecret(hostname, secret);
+
+    process.stderr.write(`IdP "${hostname}" added (totp configured)\n`);
+}
+
+async function runList(flags: Record<string, string | boolean | string[]>): Promise<void> {
+    const meta = await getIdpMetaEntries();
+    const store = await asyncIdpStore();
+
+    const rows = await Promise.all(
+        Object.entries(meta).map(async ([hostname, m]) => {
+            const hasSecret = (await store.getSecret(hostname).catch(() => null)) !== null;
+            return {
+                hostname,
+                label: m.label ?? '',
+                totp: totpStatus(m, hasSecret),
+            };
+        }),
+    );
+
+    if (rows.length === 0) {
+        process.stderr.write(
+            'No IdPs configured. Use "sig idp add <hostname> --totp-secret <secret>" to add one.\n',
+        );
+        return;
+    }
+
+    const format = typeof flags.format === 'string' ? flags.format : 'table';
+    if (format === 'json') {
+        process.stdout.write(formatJson(rows) + '\n');
+    } else {
+        process.stdout.write(formatTable(rows) + '\n');
+    }
+}
+
+async function runShow(positionals: string[]): Promise<void> {
+    const hostname = positionals[1];
+    if (!hostname) {
+        process.stderr.write('Usage: sig idp show <hostname>\n');
+        process.exitCode = ExitCode.GENERAL_ERROR;
+        return;
+    }
+
+    const meta = await getIdpMetaEntries();
+    const entry = meta[hostname];
+    if (!entry) {
+        process.stderr.write(`IdP "${hostname}" not found\n`);
+        process.exitCode = ExitCode.GENERAL_ERROR;
+        return;
+    }
+
+    const store = await asyncIdpStore();
+    const hasSecret = (await store.getSecret(hostname).catch(() => null)) !== null;
+
+    process.stdout.write(
+        formatJson({
+            hostname,
+            label: entry.label ?? null,
+            totp: hasSecret
+                ? {
+                      configured: true,
+                      secret: '<redacted>',
+                  }
+                : { configured: false },
+        }) + '\n',
+    );
+}
+
+async function runRemove(positionals: string[]): Promise<void> {
+    const hostname = positionals[1];
+    if (!hostname) {
+        process.stderr.write('Usage: sig idp remove <hostname>\n');
+        process.exitCode = ExitCode.GENERAL_ERROR;
+        return;
+    }
+    const removed = await removeIdpMetaEntry(hostname);
+    const store = await asyncIdpStore();
+    await store.deleteSecret(hostname);
+    if (removed) {
+        process.stderr.write(`IdP "${hostname}" removed\n`);
+    } else {
+        process.stderr.write(`IdP "${hostname}" not found in config\n`);
+    }
+}

--- a/cli/src/config/schema.ts
+++ b/cli/src/config/schema.ts
@@ -3,6 +3,8 @@
  * All config lives in ~/.sig/config.yaml — no cascade, no env vars.
  */
 
+import type { IdpMetaEntry } from '../idps/types.js';
+
 // ============================================================================
 // Top-level Config Sections
 // ============================================================================
@@ -52,6 +54,7 @@ export interface SigConfig {
     remotes?: Record<string, RemoteEntry>;
     providers: Record<string, ProviderEntry>;
     watch?: WatchEntry;
+    idps?: Record<string, IdpMetaEntry>;
 }
 
 // ============================================================================

--- a/cli/src/config/validator.ts
+++ b/cli/src/config/validator.ts
@@ -7,6 +7,7 @@
  */
 
 import { ConfigError, err, ok, type AuthError, type Result } from '../types/index.js';
+import type { IdpMetaEntry } from '../idps/types.js';
 import type {
     BrowserConfig,
     ProviderEntry,
@@ -138,6 +139,43 @@ export function validateConfig(raw: Record<string, unknown>): Result<SigConfig, 
         }
     }
 
+    // --- idps section (optional) ---
+    if (raw.idps !== undefined && raw.idps !== null) {
+        if (typeof raw.idps !== 'object') {
+            errors.push('"idps" must be an object');
+        } else {
+            const idps = raw.idps as Record<string, unknown>;
+            for (const [hostname, entry] of Object.entries(idps)) {
+                if (entry === null || entry === undefined) continue;
+                if (typeof entry !== 'object') {
+                    errors.push(`IdP "${hostname}": must be an object`);
+                    continue;
+                }
+                const e = entry as Record<string, unknown>;
+                if (e.label !== undefined && typeof e.label !== 'string') {
+                    errors.push(`IdP "${hostname}": label must be a string`);
+                }
+                if (Object.keys(e).some((k) => /^(secret|totpSecret)$/i.test(k))) {
+                    errors.push(
+                        `IdP "${hostname}": secrets must not be stored in config.yaml — use "sig idp add"`,
+                    );
+                }
+                if (e.totp !== undefined && e.totp !== null) {
+                    if (typeof e.totp !== 'object') {
+                        errors.push(`IdP "${hostname}": totp must be an object`);
+                    } else {
+                        const t = e.totp as Record<string, unknown>;
+                        if (Object.keys(t).some((k) => /^secret$/i.test(k))) {
+                            errors.push(
+                                `IdP "${hostname}": totp.secret must not be stored in config.yaml — use "sig idp add"`,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     if (errors.length > 0) {
         return err(new ConfigError(`Config validation failed:\n  - ${errors.join('\n  - ')}`));
     }
@@ -204,6 +242,21 @@ export function validateConfig(raw: Record<string, unknown>): Result<SigConfig, 
         };
     }
 
+    let idps: Record<string, IdpMetaEntry> | undefined;
+    if (raw.idps && typeof raw.idps === 'object') {
+        idps = {};
+        for (const [hostname, entry] of Object.entries(raw.idps as Record<string, unknown>)) {
+            if (entry === null || entry === undefined || typeof entry !== 'object') continue;
+            const e = entry as Record<string, unknown>;
+            const meta: IdpMetaEntry = {};
+            if (typeof e.label === 'string') meta.label = e.label;
+            if (e.totp && typeof e.totp === 'object') {
+                meta.totp = {};
+            }
+            idps[hostname] = meta;
+        }
+    }
+
     const config: SigConfig = {
         mode,
         browser,
@@ -211,6 +264,7 @@ export function validateConfig(raw: Record<string, unknown>): Result<SigConfig, 
         providers,
         ...(remotes ? { remotes } : {}),
         ...(watch ? { watch } : {}),
+        ...(idps ? { idps } : {}),
     };
 
     return ok(config);

--- a/cli/src/idps/hostname-match.ts
+++ b/cli/src/idps/hostname-match.ts
@@ -1,0 +1,12 @@
+/**
+ * Strict suffix-match for hostnames used in IdP resolution.
+ *
+ * `hostnameMatches("idp.example.com", "example.com")` → true
+ * `hostnameMatches("evilexample.com", "example.com")`     → false (not a suffix on a label boundary)
+ * `hostnameMatches("example.com", "example.com")`         → true
+ */
+export function hostnameMatches(candidate: string, key: string): boolean {
+    const c = candidate.toLowerCase().replace(/\.$/, '');
+    const k = key.toLowerCase().replace(/\.$/, '');
+    return c === k || c.endsWith('.' + k);
+}

--- a/cli/src/idps/idp-config.ts
+++ b/cli/src/idps/idp-config.ts
@@ -1,0 +1,47 @@
+/**
+ * Read/write the `idps:` section of ~/.sig/config.yaml, preserving comments.
+ * Only metadata lives here — secrets are handled by IdpStore.
+ */
+
+import YAML from 'yaml';
+
+import { loadDocument, saveDocument } from '../config/document.js';
+import type { IdpMetaEntry } from './types.js';
+
+/**
+ * Get all IdP metadata entries, keyed by hostname.
+ */
+export async function getIdpMetaEntries(): Promise<Record<string, IdpMetaEntry>> {
+    const doc = await loadDocument();
+    const node = doc.getIn(['idps']);
+    if (!node) return {};
+    const raw = (YAML.isMap(node) ? node.toJSON() : node) as Record<string, IdpMetaEntry> | null;
+    if (!raw || typeof raw !== 'object') return {};
+    return raw;
+}
+
+/**
+ * Add or update the metadata for a single hostname. Comment-preserving.
+ */
+export async function setIdpMetaEntry(hostname: string, entry: IdpMetaEntry): Promise<void> {
+    const doc = await loadDocument();
+    if (!doc.getIn(['idps'])) {
+        doc.setIn(['idps'], doc.createNode({}));
+    }
+    const idpsNode = doc.getIn(['idps'], true);
+    if (YAML.isMap(idpsNode)) {
+        idpsNode.set(hostname, doc.createNode(entry));
+    }
+    await saveDocument(doc);
+}
+
+/**
+ * Remove a single hostname's metadata. Returns true if present.
+ */
+export async function removeIdpMetaEntry(hostname: string): Promise<boolean> {
+    const doc = await loadDocument();
+    if (!doc.getIn(['idps', hostname])) return false;
+    doc.deleteIn(['idps', hostname]);
+    await saveDocument(doc);
+    return true;
+}

--- a/cli/src/idps/idp-registry.ts
+++ b/cli/src/idps/idp-registry.ts
@@ -1,0 +1,36 @@
+import type { IIdpRegistry } from '../types/interfaces/idp.js';
+import { hostnameMatches } from './hostname-match.js';
+import type { IdpEntry } from './types.js';
+
+/**
+ * Registry of configured Identity Providers, keyed by hostname.
+ *
+ * `resolve(candidate)` returns the entry whose configured hostname is the
+ * longest suffix match of `candidate`. This lets `idp.example.com` win over
+ * `example.com` when both are configured.
+ */
+export class IdpRegistry implements IIdpRegistry {
+    private readonly entries: IdpEntry[];
+
+    constructor(entries: IdpEntry[]) {
+        this.entries = entries;
+    }
+
+    resolve(candidate: string): IdpEntry | null {
+        if (!candidate) return null;
+        let best: IdpEntry | null = null;
+        let bestLen = -1;
+        for (const entry of this.entries) {
+            if (!hostnameMatches(candidate, entry.hostname)) continue;
+            if (entry.hostname.length > bestLen) {
+                best = entry;
+                bestLen = entry.hostname.length;
+            }
+        }
+        return best;
+    }
+
+    list(): IdpEntry[] {
+        return [...this.entries];
+    }
+}

--- a/cli/src/idps/idp-store.ts
+++ b/cli/src/idps/idp-store.ts
@@ -1,0 +1,135 @@
+/**
+ * Encrypted per-hostname TOTP secret store at `~/.sig/idps/`.
+ *
+ * Deliberately separate from `DirectoryStorage` (which is for provider
+ * credentials): mixing them would pollute `sig providers` / `sig status`
+ * listings and blur the security boundary between "credentials I fetch"
+ * and "secrets I use to fetch credentials".
+ *
+ * Uses the same atomic-write + file-lock pattern as `DirectoryStorage`.
+ */
+
+import { randomBytes } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import lockfile from 'proper-lockfile';
+
+import { StorageError } from '../types/index.js';
+import { decrypt, encrypt, isEncryptedEnvelope } from '../crypto/encryption.js';
+import { restrictFileWindows } from '../utils/restrict-windows.js';
+import { sanitizeId } from '../utils/sanitize.js';
+
+interface IdpSecretFile {
+    version: 1;
+    hostname: string;
+    totpSecret: string;
+    updatedAt: string;
+}
+
+export class IdpStore {
+    constructor(
+        private readonly dirPath: string,
+        private readonly encryptionKey: Buffer,
+    ) {}
+
+    async getSecret(hostname: string): Promise<string | null> {
+        const filePath = this.filePathFor(hostname);
+        try {
+            const content = await fs.readFile(filePath, 'utf-8');
+            const parsed: unknown = JSON.parse(content);
+            let raw: Record<string, unknown>;
+            if (isEncryptedEnvelope(parsed)) {
+                raw = JSON.parse(decrypt(parsed, this.encryptionKey)) as Record<string, unknown>;
+            } else {
+                // Legacy / unencrypted — read but do not warn (secret store is new)
+                raw = parsed as Record<string, unknown>;
+            }
+            const totpSecret = raw.totpSecret;
+            if (typeof totpSecret !== 'string' || totpSecret.length === 0) return null;
+            return totpSecret;
+        } catch (e: unknown) {
+            if ((e as NodeJS.ErrnoException).code === 'ENOENT') return null;
+            throw new StorageError('read', (e as Error).message);
+        }
+    }
+
+    async setSecret(hostname: string, totpSecret: string): Promise<void> {
+        const filePath = this.filePathFor(hostname);
+        await this.ensureDir();
+
+        const data: IdpSecretFile = {
+            version: 1,
+            hostname,
+            totpSecret,
+            updatedAt: new Date().toISOString(),
+        };
+
+        await this.withLock(filePath, async () => {
+            await this.atomicWrite(filePath, data);
+        });
+    }
+
+    async deleteSecret(hostname: string): Promise<void> {
+        const filePath = this.filePathFor(hostname);
+        try {
+            await fs.unlink(filePath);
+        } catch (e: unknown) {
+            if ((e as NodeJS.ErrnoException).code === 'ENOENT') return;
+            throw new StorageError('delete', (e as Error).message);
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Private helpers — mirrors DirectoryStorage
+    // ---------------------------------------------------------------------------
+
+    private filePathFor(hostname: string): string {
+        return path.join(this.dirPath, `${sanitizeId(hostname)}.json`);
+    }
+
+    private async ensureDir(): Promise<void> {
+        await fs.mkdir(this.dirPath, { recursive: true, mode: 0o700 });
+    }
+
+    private async atomicWrite(filePath: string, data: IdpSecretFile): Promise<void> {
+        const tmpPath = `${filePath}.tmp.${randomBytes(8).toString('hex')}`;
+        try {
+            const plaintext = JSON.stringify(data, null, 2);
+            const envelope = encrypt(plaintext, this.encryptionKey);
+            const content = JSON.stringify(envelope, null, 2);
+            await fs.writeFile(tmpPath, content, { encoding: 'utf-8', mode: 0o600 });
+            await fs.rename(tmpPath, filePath);
+            await restrictFileWindows(filePath);
+        } catch (e: unknown) {
+            await fs.unlink(tmpPath).catch(() => {});
+            throw new StorageError('write', (e as Error).message);
+        }
+    }
+
+    private async withLock<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
+        await this.ensureDir();
+        const lockPath = `${filePath}.lock`;
+        await fs.writeFile(lockPath, '', { flag: 'a', mode: 0o600 });
+
+        let release: (() => Promise<void>) | undefined;
+        try {
+            release = await lockfile.lock(lockPath, {
+                retries: { retries: 5, minTimeout: 100, maxTimeout: 1000 },
+                stale: 10000,
+            });
+            return await fn();
+        } catch (e: unknown) {
+            if ((e as Error).message?.includes('ELOCKED')) {
+                throw new StorageError(
+                    'lock',
+                    'Could not acquire file lock. Another process may be writing.',
+                );
+            }
+            throw e;
+        } finally {
+            if (release) {
+                await release().catch(() => {});
+            }
+        }
+    }
+}

--- a/cli/src/idps/types.ts
+++ b/cli/src/idps/types.ts
@@ -1,0 +1,29 @@
+/**
+ * IdP (Identity Provider) types.
+ *
+ * IdP entries wire per-hostname secrets (e.g. TOTP) that the browser strategy
+ * uses to auto-fill 2FA / MFA prompts during a login flow.
+ *
+ * Storage split:
+ * - Metadata (hostname, label, totp presence) lives in ~/.sig/config.yaml
+ *   under a top-level `idps:` map keyed by hostname.
+ * - Secrets (totp.secret) live in per-hostname encrypted JSON at ~/.sig/idps/.
+ */
+
+export interface IdpTotpConfig {
+    secret: string;
+}
+
+export interface IdpEntry {
+    hostname: string;
+    label?: string;
+    totp?: IdpTotpConfig;
+}
+
+/**
+ * The YAML-side shape of an IdP entry — no secrets.
+ */
+export interface IdpMetaEntry {
+    label?: string;
+    totp?: Record<string, never>;
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -50,6 +50,13 @@ export type { IStorage } from './types/index.js';
 export type { IProviderRegistry } from './types/index.js';
 export type { IStrategy, ExtractedCredentials } from './types/index.js';
 export type { IBrowserExtractor } from './types/index.js';
+export type { IIdpRegistry } from './types/index.js';
+
+// IdP registry
+export { IdpRegistry } from './idps/idp-registry.js';
+export { IdpStore } from './idps/idp-store.js';
+export { hostnameMatches } from './idps/hostname-match.js';
+export type { IdpEntry, IdpMetaEntry, IdpTotpConfig } from './idps/types.js';
 
 // Apply engine
 export { ApplyEngine } from './apply/apply-engine.js';
@@ -106,6 +113,7 @@ export {
     RemoteSubcommand,
     SyncSubcommand,
     WatchSubcommand,
+    IdpSubcommand,
     CredentialTypeName,
     LOGIN_URL_PATTERNS,
     HttpHeader,
@@ -125,6 +133,7 @@ export { parseDuration, formatDuration } from './utils/duration.js';
 export { buildUserAgent } from './utils/http.js';
 export { sanitizeId } from './utils/sanitize.js';
 export { expandHome } from './utils/path.js';
+export { computeTotp } from './utils/totp.js';
 
 // Crypto
 export {

--- a/cli/src/strategies/browser/browser-strategy.ts
+++ b/cli/src/strategies/browser/browser-strategy.ts
@@ -10,6 +10,7 @@ import {
     type AuthError,
     type ExtractedCredentials,
     type IBrowserExtractor,
+    type IIdpRegistry,
     type ILogger,
     type IStrategy,
     type ProviderConfig,
@@ -21,16 +22,27 @@ import { parseDuration } from '../../utils/duration.js';
 import { createNoopLogger } from '../../utils/logger.js';
 import { expandHome } from '../../utils/path.js';
 import { killProcess } from '../../utils/process-kill.js';
+import { computeTotp } from '../../utils/totp.js';
 import { findFreePort, waitForBrowserReady } from './browser-lifecycle.js';
 import { acquireBrowser, releaseBrowser } from './cdp-state.js';
 import { attachToPageTarget, connectCdpWs, type CdpWsClient } from './cdp-ws.js';
 import { CdpCookieExtractor } from './extractors/cdp-cookie.js';
 import { CdpStorageExtractor } from './extractors/cdp-storage.js';
+import { injectTotpFill } from './totp-injector.js';
 
 const TRACKING_COOKIE_TTL_MS = 60_000;
 const EXISTING_STATE_TIMEOUT = 5000;
 const LOGIN_PAGE_SETTLE_MS = 5000;
 const POLL_INTERVAL_MS = 3000;
+
+function safeHostname(url: string): string | null {
+    if (!url) return null;
+    try {
+        return new URL(url).hostname;
+    } catch {
+        return null;
+    }
+}
 
 interface CookieExpiry {
     name: string;
@@ -50,10 +62,12 @@ export class BrowserStrategy implements IStrategy {
     private readonly extractors: Map<string, IBrowserExtractor>;
     private readonly config: BrowserConfig;
     private readonly logger: ILogger;
+    private readonly idps?: IIdpRegistry;
 
-    constructor(browserConfig: BrowserConfig, _?: unknown, logger?: ILogger) {
+    constructor(browserConfig: BrowserConfig, _?: unknown, logger?: ILogger, idps?: IIdpRegistry) {
         this.config = browserConfig;
         this.logger = logger ?? createNoopLogger();
+        this.idps = idps;
         this.extractors = new Map<string, IBrowserExtractor>();
         this.extractors.set('cookies', new CdpCookieExtractor());
         this.extractors.set('localStorage', new CdpStorageExtractor());
@@ -217,6 +231,18 @@ export class BrowserStrategy implements IStrategy {
             const sessionId = await attachToPageTarget(cdp).catch(() => null);
             const url = await this.getPageUrl(cdp, sessionId);
 
+            // IdP TOTP auto-fill: if the current page's hostname matches a
+            // configured IdP with a TOTP secret, try to fill the OTP input
+            // BEFORE the off-domain check. IdP pages are legitimately on a
+            // different hostname than the entry URL and would otherwise be
+            // skipped by the off-domain branch. After filling, the form
+            // submits and navigates; the next poll iteration will detect the
+            // redirect back to the entry domain and proceed with validation.
+            if (sessionId) {
+                const { filled } = await this.tryFillTotp(cdp, sessionId, url, provider.id);
+                if (filled) loginPageSince = null;
+            }
+
             if (this.isOffDomain(url, entryHostname)) {
                 this.logger.info(`${provider.id}: waiting for redirect back to ${entryHostname}`);
                 if (sessionId)
@@ -268,6 +294,46 @@ export class BrowserStrategy implements IStrategy {
         }
 
         return null;
+    }
+
+    // =========================================================================
+    // TOTP auto-fill — resolve current-host IdP, compute code, inject into page
+    // =========================================================================
+
+    private async tryFillTotp(
+        cdp: CdpWsClient,
+        sessionId: string,
+        url: string,
+        providerId: string,
+    ): Promise<{ filled: boolean }> {
+        if (!this.idps) return { filled: false };
+        const currentHost = safeHostname(url);
+        if (!currentHost) return { filled: false };
+        const idp = this.idps.resolve(currentHost);
+        if (!idp?.totp) return { filled: false };
+
+        let code: string;
+        try {
+            code = computeTotp(idp.totp.secret);
+        } catch (e) {
+            this.logger.warn(
+                `${providerId}: invalid TOTP secret for ${idp.hostname}: ${(e as Error).message}`,
+            );
+            return { filled: false };
+        }
+
+        const outcome = await injectTotpFill(cdp, sessionId, { code }).catch(() => ({
+            filled: false,
+            submitted: false,
+            reason: 'error' as const,
+        }));
+
+        if (outcome.filled) {
+            this.logger.info(
+                `${providerId}: TOTP filled on ${currentHost} (submit=${outcome.submitted})`,
+            );
+        }
+        return { filled: outcome.filled };
     }
 
     // =========================================================================

--- a/cli/src/strategies/browser/totp-injector.ts
+++ b/cli/src/strategies/browser/totp-injector.ts
@@ -1,0 +1,103 @@
+/**
+ * Inject a TOTP code into the current page during a browser login flow.
+ *
+ * Called from `BrowserStrategy.pollUntilValid` when the currently attached
+ * page's hostname matches a configured IdP with a TOTP secret. The heuristic
+ * looks for common OTP input selectors; if none is visible the call is a no-op
+ * and the poll loop continues. After filling, the form is always submitted.
+ *
+ * There is NO injection surface — the only user input in the script is the
+ * 6-digit numeric code, substituted via JSON.stringify.
+ */
+
+import type { CdpWsClient } from './cdp-ws.js';
+
+export interface TotpFillArgs {
+    code: string;
+}
+
+export interface TotpFillResult {
+    filled: boolean;
+    submitted: boolean;
+    reason?: string;
+}
+
+/**
+ * Build the page-side IIFE that fills the OTP input and submits the form.
+ * Pure function — exported so it can be unit-tested without a real browser.
+ */
+export function buildFillScript(args: TotpFillArgs): string {
+    // JSON.stringify is safe for a 6-digit numeric string.
+    const codeLiteral = JSON.stringify(args.code);
+
+    return `(() => {
+  const trySelectors = [
+    '#j_otpcode',
+    'input[name="j_otpcode"]',
+    '#otp',
+    'input[name="otp"]',
+    'input[autocomplete="one-time-code"]',
+    'input[name="code"]',
+    'input[name="passcode"]',
+    'input[type="tel"][maxlength="6"]',
+    'input[inputmode="numeric"]',
+  ];
+  let input = null;
+  for (const sel of trySelectors) {
+    const el = document.querySelector(sel);
+    if (el && el.offsetParent !== null) { input = el; break; }
+  }
+  if (!input) return { filled: false, submitted: false, reason: 'no-input' };
+  const nativeSetter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype, 'value'
+  ).set;
+  nativeSetter.call(input, ${codeLiteral});
+  input.dispatchEvent(new Event('input',  { bubbles: true }));
+  input.dispatchEvent(new Event('change', { bubbles: true }));
+  const form = input.form || input.closest('form');
+  if (!form) return { filled: true, submitted: false, reason: 'no-form' };
+  if (typeof form.requestSubmit === 'function') form.requestSubmit();
+  else form.submit();
+  return { filled: true, submitted: true };
+})()`;
+}
+
+/**
+ * Evaluate `buildFillScript` in the given CDP session. Never throws — returns
+ * a structured result even when the evaluation fails.
+ */
+export async function injectTotpFill(
+    cdp: CdpWsClient,
+    sessionId: string,
+    args: TotpFillArgs,
+): Promise<TotpFillResult> {
+    const expression = buildFillScript(args);
+    try {
+        const res = (await cdp.send(
+            'Runtime.evaluate',
+            { expression, returnByValue: true },
+            sessionId,
+        )) as {
+            result?: { value?: unknown };
+            exceptionDetails?: unknown;
+        };
+
+        if (res?.exceptionDetails) {
+            return { filled: false, submitted: false, reason: 'exception' };
+        }
+
+        const value = res?.result?.value;
+        if (!value || typeof value !== 'object') {
+            return { filled: false, submitted: false, reason: 'bad-shape' };
+        }
+        const v = value as Record<string, unknown>;
+        const result: TotpFillResult = {
+            filled: v.filled === true,
+            submitted: v.submitted === true,
+        };
+        if (typeof v.reason === 'string') result.reason = v.reason;
+        return result;
+    } catch {
+        return { filled: false, submitted: false, reason: 'error' };
+    }
+}

--- a/cli/src/types/constants.ts
+++ b/cli/src/types/constants.ts
@@ -28,6 +28,7 @@ export const Command = {
     COMPLETION: 'completion',
     RUN: 'run',
     PROXY: 'proxy',
+    IDP: 'idp',
     HELP: 'help',
 } as const;
 
@@ -65,6 +66,16 @@ export const ProxySubcommand = {
     STOP: 'stop',
     STATUS: 'status',
     TRUST: 'trust',
+} as const;
+
+/**
+ * Subcommands for the 'idp' command.
+ */
+export const IdpSubcommand = {
+    ADD: 'add',
+    LIST: 'list',
+    SHOW: 'show',
+    REMOVE: 'remove',
 } as const;
 
 /**

--- a/cli/src/types/index.ts
+++ b/cli/src/types/index.ts
@@ -44,6 +44,7 @@ export {
     SyncSubcommand,
     WatchSubcommand,
     ProxySubcommand,
+    IdpSubcommand,
     CredentialTypeName,
     LOGIN_URL_PATTERNS,
     HttpHeader,
@@ -60,3 +61,5 @@ export type { IStrategy, ExtractedCredentials } from './interfaces/strategy.js';
 export type { IBrowserExtractor } from './interfaces/browser-extractor.js';
 export type { IStorage } from './interfaces/storage.js';
 export type { IProviderRegistry } from './interfaces/provider.js';
+export type { IIdpRegistry } from './interfaces/idp.js';
+export type { IdpEntry, IdpMetaEntry, IdpTotpConfig } from '../idps/types.js';

--- a/cli/src/types/interfaces/idp.ts
+++ b/cli/src/types/interfaces/idp.ts
@@ -1,0 +1,18 @@
+import type { IdpEntry } from '../../idps/types.js';
+
+/**
+ * Registry of configured Identity Providers. Resolves the best entry for
+ * a hostname during browser auth flows (e.g. TOTP fill on a 2FA page).
+ */
+export interface IIdpRegistry {
+    /**
+     * Return the entry whose hostname is the longest suffix match of
+     * `candidate`, or `null` if none is configured.
+     */
+    resolve(candidate: string): IdpEntry | null;
+
+    /**
+     * List all configured entries.
+     */
+    list(): IdpEntry[];
+}

--- a/cli/src/utils/totp.ts
+++ b/cli/src/utils/totp.ts
@@ -1,0 +1,21 @@
+import { TOTP } from 'otpauth';
+
+/**
+ * Compute a TOTP code from a base32-encoded shared secret.
+ * Uses SHA-1, 6 digits, 30s period — matching every mainstream authenticator.
+ *
+ * Throws if `secret` is not valid base32 (letters A-Z, digits 2-7, optional
+ * padding). Callers that need graceful handling should try/catch.
+ */
+export function computeTotp(
+    secret: string,
+    options?: { digits?: number; period?: number },
+): string {
+    const totp = new TOTP({
+        algorithm: 'SHA1',
+        digits: options?.digits ?? 6,
+        period: options?.period ?? 30,
+        secret,
+    });
+    return totp.generate();
+}

--- a/cli/tests/unit/auth-manager.test.ts
+++ b/cli/tests/unit/auth-manager.test.ts
@@ -1,0 +1,77 @@
+/**
+ * AuthManager wiring tests.
+ *
+ * Focuses on the paths where AuthManager.create composes optional pieces of
+ * config — currently: the idps section may be omitted entirely.
+ */
+
+import { randomBytes } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AuthManager } from '../../src/auth-manager.js';
+import type { SigConfig } from '../../src/config/schema.js';
+import { createNoopLogger } from '../../src/utils/logger.js';
+
+// Deterministic encryption key so AuthManager.create doesn't touch the real
+// ~/.sig/encryption.key.
+const TEST_KEY = randomBytes(32);
+vi.mock('../../src/crypto/encryption.js', async () => {
+    const actual = await vi.importActual<typeof import('../../src/crypto/encryption.js')>(
+        '../../src/crypto/encryption.js',
+    );
+    return {
+        ...actual,
+        loadEncryptionKey: vi.fn(async () => TEST_KEY),
+    };
+});
+
+// Redirect ~/.sig under a per-test tmp dir.
+let tmpHome: string;
+vi.mock('node:os', async () => {
+    const actual = await vi.importActual<typeof import('node:os')>('node:os');
+    return {
+        ...actual,
+        default: { ...actual, homedir: () => tmpHome },
+        homedir: () => tmpHome,
+    };
+});
+
+function baseConfig(): SigConfig {
+    return <SigConfig>{
+        mode: 'browser',
+        browser: {
+            browserDataDir: '/tmp/test-browser-data',
+            execPath: '',
+            headlessTimeout: 20_000,
+            visibleTimeout: 120_000,
+        },
+        storage: {
+            credentialsDir: path.join(tmpHome, 'creds'),
+        },
+        providers: {},
+    };
+}
+
+describe('AuthManager.create — idps wiring', () => {
+    beforeEach(async () => {
+        tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'sig-auth-mgr-'));
+    });
+
+    afterEach(async () => {
+        await fs.rm(tmpHome, { recursive: true, force: true });
+    });
+
+    it('exposes an empty IdP registry when config has no idps section', async () => {
+        const config = baseConfig();
+        // Sanity — the omitted section is the case under test.
+        expect(config.idps).toBeUndefined();
+
+        const manager = await AuthManager.create(config, createNoopLogger());
+
+        expect(manager.idps.list()).toEqual([]);
+        expect(manager.idps.resolve('anything.com')).toBeNull();
+    });
+});

--- a/cli/tests/unit/commands/idp.test.ts
+++ b/cli/tests/unit/commands/idp.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Tests for `sig idp add|list|show|remove`.
+ *
+ * We isolate the command from the real filesystem by mocking:
+ *   - `../config/document.js`   → in-memory YAML string
+ *   - `../crypto/encryption.js` → deterministic 32-byte key, real encrypt/decrypt
+ *   - `../utils/prompt.js`      → controlled promptSecret responses (unused here
+ *                                 since we always pass --totp-secret in tests)
+ *
+ * `IdpStore` writes real encrypted files under a temp dir. To force it there we
+ * mock `node:os`.homedir so `~/.sig/idps` resolves under tmpdir.
+ */
+
+import { randomBytes } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import YAML from 'yaml';
+
+import { runIdp } from '../../../src/commands/idp.js';
+
+// ---------------------------------------------------------------------------
+// Module mocks (must be declared before importing runIdp)
+// ---------------------------------------------------------------------------
+
+let currentYaml = '';
+
+vi.mock('../../../src/config/document.js', () => ({
+    loadDocument: vi.fn(async () => {
+        if (!currentYaml) return new YAML.Document({});
+        return YAML.parseDocument(currentYaml);
+    }),
+    saveDocument: vi.fn(async (doc: YAML.Document) => {
+        currentYaml = doc.toString();
+    }),
+    loadRawContent: vi.fn(async () => currentYaml),
+}));
+
+const TEST_KEY = randomBytes(32);
+vi.mock('../../../src/crypto/encryption.js', async () => {
+    const actual = await vi.importActual<typeof import('../../../src/crypto/encryption.js')>(
+        '../../../src/crypto/encryption.js',
+    );
+    return {
+        ...actual,
+        loadEncryptionKey: vi.fn(async () => TEST_KEY),
+    };
+});
+
+// Redirect ~/.sig/idps under a per-test tmp dir by mocking os.homedir.
+let tmpHome: string;
+vi.mock('node:os', async () => {
+    const actual = await vi.importActual<typeof import('node:os')>('node:os');
+    return {
+        ...actual,
+        default: { ...actual, homedir: () => tmpHome },
+        homedir: () => tmpHome,
+    };
+});
+
+// ---------------------------------------------------------------------------
+
+const VALID_SECRET = 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ';
+const INVALID_SECRET = '!!!not-base32!!!';
+
+describe('sig idp', () => {
+    let stderrChunks: string[];
+    let stdoutChunks: string[];
+    let originalExitCode: number | undefined;
+
+    beforeEach(async () => {
+        tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'sig-idp-cmd-'));
+        currentYaml = '';
+        vi.clearAllMocks();
+
+        stderrChunks = [];
+        stdoutChunks = [];
+        originalExitCode = process.exitCode;
+        process.exitCode = undefined;
+
+        vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+            stderrChunks.push(String(chunk));
+            return true;
+        });
+        vi.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+            stdoutChunks.push(String(chunk));
+            return true;
+        });
+    });
+
+    afterEach(async () => {
+        process.exitCode = originalExitCode;
+        vi.restoreAllMocks();
+        await fs.rm(tmpHome, { recursive: true, force: true });
+    });
+
+    // -----------------------------------------------------------------------
+    // add
+    // -----------------------------------------------------------------------
+
+    describe('add', () => {
+        it('writes YAML metadata (no plaintext secret) and encrypted secret file', async () => {
+            await runIdp(['add', 'idp.example.com'], { 'totp-secret': VALID_SECRET });
+
+            // YAML metadata is present with no secret.
+            expect(currentYaml).toContain('idps:');
+            expect(currentYaml).toContain('idp.example.com');
+            expect(currentYaml.includes(VALID_SECRET)).toBe(false);
+            expect(currentYaml).not.toMatch(/secret:/);
+
+            // Encrypted file exists under tmpHome/.sig/idps/.
+            const idpFile = path.join(tmpHome, '.sig', 'idps', 'idp.example.com.json');
+            const content = await fs.readFile(idpFile, 'utf-8');
+            const parsed = JSON.parse(content);
+            expect(parsed.encrypted).toBe(true);
+            expect(parsed.algorithm).toBe('aes-256-gcm');
+            expect(content.includes(VALID_SECRET)).toBe(false);
+        });
+
+        it('rejects an invalid base32 secret with a clean error and no writes', async () => {
+            await runIdp(['add', 'idp.example.com'], { 'totp-secret': INVALID_SECRET });
+
+            expect(process.exitCode).not.toBe(undefined);
+            expect(process.exitCode).not.toBe(0);
+            const stderr = stderrChunks.join('');
+            expect(stderr.toLowerCase()).toContain('invalid totp secret');
+
+            // No YAML entry
+            expect(currentYaml).toBe('');
+            // No encrypted file
+            const idpDir = path.join(tmpHome, '.sig', 'idps');
+            await expect(fs.readdir(idpDir)).rejects.toThrow();
+        });
+
+        it('normalizes whitespace in the provided secret before validation', async () => {
+            // The RFC/valid secret split into groups of 4 with spaces (as most
+            // authenticator apps display it).
+            const withSpaces = 'GEZD GNBV GY3T QOJQ GEZD GNBV GY3T QOJQ';
+            await runIdp(['add', 'idp.example.com'], { 'totp-secret': withSpaces });
+
+            // Success path: metadata written, no exit code set.
+            expect(process.exitCode).toBeFalsy();
+            expect(currentYaml).toContain('idp.example.com');
+        });
+
+        it('fails when hostname is missing', async () => {
+            await runIdp(['add'], { 'totp-secret': VALID_SECRET });
+            expect(process.exitCode).not.toBe(undefined);
+            expect(process.exitCode).not.toBe(0);
+            const stderr = stderrChunks.join('');
+            expect(stderr).toContain('sig idp add');
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // list
+    // -----------------------------------------------------------------------
+
+    describe('list', () => {
+        it('lists entries, redacts secrets, reports totp status', async () => {
+            await runIdp(['add', 'idp.example.com'], { 'totp-secret': VALID_SECRET });
+            stderrChunks.length = 0;
+            stdoutChunks.length = 0;
+
+            await runIdp(['list'], { format: 'json' });
+            const output = stdoutChunks.join('') + stderrChunks.join('');
+            expect(output.includes(VALID_SECRET)).toBe(false);
+            expect(output).toContain('idp.example.com');
+            expect(output).toContain('configured');
+        });
+
+        it('reports "No IdPs configured" when the registry is empty', async () => {
+            await runIdp(['list'], {});
+            const stderr = stderrChunks.join('');
+            expect(stderr).toContain('No IdPs configured');
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // show
+    // -----------------------------------------------------------------------
+
+    describe('show', () => {
+        it('shows metadata for a known hostname, redacting the secret', async () => {
+            await runIdp(['add', 'idp.example.com'], { 'totp-secret': VALID_SECRET });
+            stderrChunks.length = 0;
+            stdoutChunks.length = 0;
+
+            await runIdp(['show', 'idp.example.com'], {});
+            const output = stdoutChunks.join('');
+            expect(output.includes(VALID_SECRET)).toBe(false);
+            expect(output).toContain('idp.example.com');
+            expect(output).toContain('<redacted>');
+        });
+
+        it('errors when hostname is not configured', async () => {
+            await runIdp(['show', 'nonexistent.example.com'], {});
+            expect(process.exitCode).not.toBe(undefined);
+            expect(process.exitCode).not.toBe(0);
+            const stderr = stderrChunks.join('');
+            expect(stderr).toContain('nonexistent.example.com');
+            expect(stderr).toContain('not found');
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // remove
+    // -----------------------------------------------------------------------
+
+    describe('remove', () => {
+        it('removes both the YAML entry and the encrypted secret file', async () => {
+            await runIdp(['add', 'idp.example.com'], { 'totp-secret': VALID_SECRET });
+            const idpFile = path.join(tmpHome, '.sig', 'idps', 'idp.example.com.json');
+            await expect(fs.access(idpFile)).resolves.toBeUndefined();
+
+            stderrChunks.length = 0;
+            await runIdp(['remove', 'idp.example.com'], {});
+
+            expect(currentYaml).not.toContain('idp.example.com');
+            await expect(fs.access(idpFile)).rejects.toThrow();
+        });
+
+        it('reports "not found" when hostname is not in config but does not throw', async () => {
+            await runIdp(['remove', 'nonexistent.example.com'], {});
+            const stderr = stderrChunks.join('');
+            expect(stderr).toContain('not found in config');
+        });
+    });
+});

--- a/cli/tests/unit/core/constants.test.ts
+++ b/cli/tests/unit/core/constants.test.ts
@@ -35,11 +35,12 @@ describe('constants', () => {
             expect(Command.COMPLETION).toBe('completion');
             expect(Command.RUN).toBe('run');
             expect(Command.PROXY).toBe('proxy');
+            expect(Command.IDP).toBe('idp');
             expect(Command.HELP).toBe('help');
         });
 
         it('has exactly the expected number of commands', () => {
-            expect(Object.keys(Command)).toHaveLength(17);
+            expect(Object.keys(Command)).toHaveLength(18);
         });
 
         it('values are all lowercase strings', () => {

--- a/cli/tests/unit/idps/hostname-match.test.ts
+++ b/cli/tests/unit/idps/hostname-match.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { hostnameMatches } from '../../../src/idps/hostname-match.js';
+
+describe('hostnameMatches', () => {
+    it('matches exact hostname', () => {
+        expect(hostnameMatches('idp.example.com', 'idp.example.com')).toBe(true);
+        expect(hostnameMatches('github.com', 'github.com')).toBe(true);
+    });
+
+    it('matches on label boundary (subdomain)', () => {
+        expect(hostnameMatches('sub.idp.example.com', 'idp.example.com')).toBe(true);
+        expect(hostnameMatches('foo.bar.baz.example.com', 'example.com')).toBe(true);
+    });
+
+    it('SECURITY: does NOT match a non-label-boundary suffix', () => {
+        // The critical case — evil-github.com should not match github.com.
+        expect(hostnameMatches('evil-github.com', 'github.com')).toBe(false);
+        expect(hostnameMatches('evilexample.com', 'example.com')).toBe(false);
+        expect(hostnameMatches('notidp.example.com'.replace('.', ''), 'idp.example.com')).toBe(
+            false,
+        );
+    });
+
+    it('does NOT match when the separator is missing', () => {
+        // The concatenation of two labels without a dot is never a match.
+        expect(hostnameMatches('githubXcom', 'github.com')).toBe(false);
+        expect(hostnameMatches('subgithub.com', 'github.com')).toBe(false);
+    });
+
+    it('is case-insensitive on both sides', () => {
+        expect(hostnameMatches('IDP.EXAMPLE.COM', 'idp.example.com')).toBe(true);
+        expect(hostnameMatches('idp.example.com', 'IDP.EXAMPLE.COM')).toBe(true);
+        expect(hostnameMatches('Idp.Example.com', 'idp.EXAMPLE.COM')).toBe(true);
+    });
+
+    it('returns false for unrelated hosts', () => {
+        expect(hostnameMatches('example.com', 'github.com')).toBe(false);
+        expect(hostnameMatches('idp.example.com', 'idp.other.com')).toBe(false);
+    });
+
+    it('returns false when the candidate is a strict parent of the key', () => {
+        // example.com is not a subdomain of idp.example.com — it's the other way round.
+        expect(hostnameMatches('example.com', 'idp.example.com')).toBe(false);
+    });
+
+    it('strips trailing DNS dot from candidate and key', () => {
+        expect(hostnameMatches('github.com.', 'github.com')).toBe(true);
+        expect(hostnameMatches('github.com', 'github.com.')).toBe(true);
+        expect(hostnameMatches('idp.example.com.', 'example.com')).toBe(true);
+    });
+});

--- a/cli/tests/unit/idps/idp-config.test.ts
+++ b/cli/tests/unit/idps/idp-config.test.ts
@@ -1,0 +1,235 @@
+/**
+ * idp-config tests — verify get/set/remove round-trip and comment preservation.
+ *
+ * We mock the shared `../config/document.js` module so we can drive load/save
+ * against an in-memory YAML string without touching the real ~/.sig/config.yaml.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import YAML from 'yaml';
+
+import { validateConfig } from '../../../src/config/validator.js';
+import {
+    getIdpMetaEntries,
+    removeIdpMetaEntry,
+    setIdpMetaEntry,
+} from '../../../src/idps/idp-config.js';
+import { isErr } from '../../../src/types/index.js';
+
+// Mock the document helpers before importing the module under test.
+let currentYaml = '';
+vi.mock('../../../src/config/document.js', () => ({
+    loadDocument: vi.fn(async () => {
+        if (!currentYaml) return new YAML.Document({});
+        return YAML.parseDocument(currentYaml);
+    }),
+    saveDocument: vi.fn(async (doc: YAML.Document) => {
+        currentYaml = doc.toString();
+    }),
+    loadRawContent: vi.fn(async () => currentYaml),
+}));
+
+describe('idp-config', () => {
+    beforeEach(() => {
+        currentYaml = '';
+        vi.clearAllMocks();
+    });
+
+    describe('getIdpMetaEntries', () => {
+        it('returns empty object when no idps section is present', async () => {
+            currentYaml = 'browser:\n  browserDataDir: /tmp\n';
+            const entries = await getIdpMetaEntries();
+            expect(entries).toEqual({});
+        });
+
+        it('reads existing idps entries from YAML', async () => {
+            currentYaml = [
+                'idps:',
+                '  idp.example.com:',
+                '    label: IDP1',
+                '    totp: {}',
+                '  github.com:',
+                '    label: GitHub',
+                '',
+            ].join('\n');
+            const entries = await getIdpMetaEntries();
+            expect(Object.keys(entries).sort()).toEqual(['github.com', 'idp.example.com']);
+            expect(entries['idp.example.com'].label).toBe('IDP1');
+            expect(entries['idp.example.com'].totp).toBeDefined();
+        });
+    });
+
+    describe('setIdpMetaEntry', () => {
+        it('adds an entry when idps section does not exist', async () => {
+            currentYaml = 'browser:\n  browserDataDir: /tmp\n';
+            await setIdpMetaEntry('idp.example.com', {
+                label: 'IDP1',
+                totp: {},
+            });
+            expect(currentYaml).toContain('idps:');
+            expect(currentYaml).toContain('idp.example.com');
+            expect(currentYaml).toContain('label: IDP1');
+        });
+
+        it('round-trips: set then get returns same entry', async () => {
+            await setIdpMetaEntry('idp.example.com', {
+                label: 'IDP1',
+                totp: {},
+            });
+            const entries = await getIdpMetaEntries();
+            expect(entries['idp.example.com'].label).toBe('IDP1');
+            expect(entries['idp.example.com'].totp).toBeDefined();
+        });
+
+        it('updates an existing entry in place', async () => {
+            currentYaml = [
+                'idps:',
+                '  idp.example.com:',
+                '    label: OLD',
+                '    totp: {}',
+                '',
+            ].join('\n');
+            await setIdpMetaEntry('idp.example.com', {
+                label: 'NEW',
+                totp: {},
+            });
+            const entries = await getIdpMetaEntries();
+            expect(entries['idp.example.com'].label).toBe('NEW');
+            expect(entries['idp.example.com'].totp).toBeDefined();
+        });
+    });
+
+    describe('removeIdpMetaEntry', () => {
+        it('returns true and removes the entry when present', async () => {
+            currentYaml = [
+                'idps:',
+                '  idp.example.com:',
+                '    label: IDP1',
+                '  github.com:',
+                '    label: GitHub',
+                '',
+            ].join('\n');
+            const removed = await removeIdpMetaEntry('idp.example.com');
+            expect(removed).toBe(true);
+            const entries = await getIdpMetaEntries();
+            expect(entries['idp.example.com']).toBeUndefined();
+            expect(entries['github.com']).toBeDefined();
+        });
+
+        it('returns false when the entry does not exist', async () => {
+            currentYaml = 'idps:\n  github.com:\n    label: GitHub\n';
+            const removed = await removeIdpMetaEntry('idp.example.com');
+            expect(removed).toBe(false);
+        });
+    });
+
+    describe('comment preservation', () => {
+        it('preserves comments inside the idps: block across set/save', async () => {
+            currentYaml = [
+                '# top-of-file comment',
+                'idps:',
+                '  # inline comment before idp.example.com',
+                '  idp.example.com:',
+                '    label: IDP1',
+                '  github.com:',
+                '    label: GitHub',
+                '',
+            ].join('\n');
+            await setIdpMetaEntry('github.com', { label: 'GitHub-updated' });
+
+            expect(currentYaml).toContain('# top-of-file comment');
+            expect(currentYaml).toContain('# inline comment before idp.example.com');
+            expect(currentYaml).toContain('GitHub-updated');
+        });
+    });
+
+    describe('validator: rejects secrets in the idps: section', () => {
+        const BASE = {
+            browser: { browserDataDir: '/tmp/browser' },
+            storage: { credentialsDir: '/tmp/creds' },
+        };
+
+        it('rejects a top-level idp.secret field', () => {
+            const raw = {
+                ...BASE,
+                idps: {
+                    'idp.example.com': { secret: 'SHOULDBEREJECTED' },
+                },
+            };
+            const result = validateConfig(raw);
+            expect(isErr(result)).toBe(true);
+            if (isErr(result)) {
+                expect(result.error.message.toLowerCase()).toContain('secret');
+            }
+        });
+
+        it('rejects an idp.totpSecret field', () => {
+            const raw = {
+                ...BASE,
+                idps: {
+                    'idp.example.com': { totpSecret: 'SHOULDBEREJECTED' },
+                },
+            };
+            const result = validateConfig(raw);
+            expect(isErr(result)).toBe(true);
+        });
+
+        it('rejects an idp.totp.secret field', () => {
+            const raw = {
+                ...BASE,
+                idps: {
+                    'idp.example.com': {
+                        totp: { secret: 'SHOULDBEREJECTED' },
+                    },
+                },
+            };
+            const result = validateConfig(raw);
+            expect(isErr(result)).toBe(true);
+            if (isErr(result)) {
+                expect(result.error.message.toLowerCase()).toContain('totp.secret');
+            }
+        });
+
+        it('rejects a capitalized top-level Secret field (case-insensitive)', () => {
+            const raw = {
+                ...BASE,
+                idps: {
+                    'idp.example.com': { Secret: 'X' },
+                },
+            };
+            const result = validateConfig(raw);
+            expect(isErr(result)).toBe(true);
+            if (isErr(result)) {
+                expect(result.error.message.toLowerCase()).toContain('secret');
+            }
+        });
+
+        it('rejects an all-caps TOTPSECRET field (case-insensitive)', () => {
+            const raw = {
+                ...BASE,
+                idps: {
+                    'idp.example.com': { TOTPSECRET: 'X' },
+                },
+            };
+            const result = validateConfig(raw);
+            expect(isErr(result)).toBe(true);
+            if (isErr(result)) {
+                expect(result.error.message.toLowerCase()).toContain('secret');
+            }
+        });
+
+        it('rejects a capitalized nested totp.Secret field (case-insensitive)', () => {
+            const raw = {
+                ...BASE,
+                idps: {
+                    'idp.example.com': { totp: { Secret: 'X' } },
+                },
+            };
+            const result = validateConfig(raw);
+            expect(isErr(result)).toBe(true);
+            if (isErr(result)) {
+                expect(result.error.message.toLowerCase()).toContain('totp.secret');
+            }
+        });
+    });
+});

--- a/cli/tests/unit/idps/idp-registry.test.ts
+++ b/cli/tests/unit/idps/idp-registry.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { IdpRegistry } from '../../../src/idps/idp-registry.js';
+import type { IdpEntry } from '../../../src/idps/types.js';
+
+function makeEntry(hostname: string, label?: string): IdpEntry {
+    return { hostname, ...(label ? { label } : {}) };
+}
+
+describe('IdpRegistry', () => {
+    describe('resolve', () => {
+        it('returns the entry for an exact match', () => {
+            const reg = new IdpRegistry([
+                makeEntry('idp.example.com', 'IDP1'),
+                makeEntry('idp.other.com', 'Google'),
+                makeEntry('github.com', 'GitHub'),
+            ]);
+            expect(reg.resolve('idp.example.com')?.label).toBe('IDP1');
+            expect(reg.resolve('github.com')?.label).toBe('GitHub');
+        });
+
+        it('returns the entry for a matching subdomain', () => {
+            const reg = new IdpRegistry([
+                makeEntry('idp.example.com', 'IDP2'),
+                makeEntry('login.other.com', 'IDP1'),
+            ]);
+            expect(reg.resolve('sub.idp.example.com')?.label).toBe('IDP2');
+        });
+
+        it('longest-suffix wins when multiple entries match', () => {
+            const reg = new IdpRegistry([
+                makeEntry('example.com', 'idp1'),
+                makeEntry('idp.example.com', 'idp1-sub'),
+            ]);
+            expect(reg.resolve('foo.idp.example.com')?.label).toBe('idp1-sub');
+            expect(reg.resolve('idp.example.com')?.label).toBe('idp1-sub');
+            // A subdomain of example.com that isn't under idp.example.com falls back
+            expect(reg.resolve('other.example.com')?.label).toBe('idp1');
+        });
+
+        it('returns null when there is no match', () => {
+            const reg = new IdpRegistry([makeEntry('idp.example.com')]);
+            expect(reg.resolve('example.com')).toBeNull();
+            expect(reg.resolve('evil-example.com')).toBeNull();
+        });
+
+        it('returns null for an empty candidate', () => {
+            const reg = new IdpRegistry([makeEntry('idp.example.com')]);
+            expect(reg.resolve('')).toBeNull();
+        });
+
+        it('does not match a non-label-boundary suffix', () => {
+            const reg = new IdpRegistry([makeEntry('github.com')]);
+            expect(reg.resolve('evil-github.com')).toBeNull();
+        });
+    });
+
+    describe('list', () => {
+        it('returns all entries', () => {
+            const entries = [makeEntry('a.com'), makeEntry('b.com'), makeEntry('c.com')];
+            const reg = new IdpRegistry(entries);
+            expect(reg.list()).toHaveLength(3);
+        });
+
+        it('returns a copy — mutating the result does not affect the registry', () => {
+            const reg = new IdpRegistry([makeEntry('a.com'), makeEntry('b.com')]);
+            const first = reg.list();
+            first.push(makeEntry('c.com'));
+            expect(reg.list()).toHaveLength(2);
+        });
+    });
+});

--- a/cli/tests/unit/idps/idp-store.test.ts
+++ b/cli/tests/unit/idps/idp-store.test.ts
@@ -1,0 +1,86 @@
+import { randomBytes } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { isEncryptedEnvelope } from '../../../src/crypto/encryption.js';
+import { IdpStore } from '../../../src/idps/idp-store.js';
+
+describe('IdpStore', () => {
+    let tmpDir: string;
+    let key: Buffer;
+    let store: IdpStore;
+
+    beforeEach(async () => {
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sig-idp-store-'));
+        key = randomBytes(32);
+        store = new IdpStore(tmpDir, key);
+    });
+
+    afterEach(async () => {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('round-trips a secret via setSecret / getSecret', async () => {
+        await store.setSecret('idp.example.com', 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ');
+        const got = await store.getSecret('idp.example.com');
+        expect(got).toBe('GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ');
+    });
+
+    it('returns null when there is no stored secret for a hostname', async () => {
+        expect(await store.getSecret('nonexistent.example.com')).toBeNull();
+    });
+
+    it('writes an EncryptedEnvelope to disk — no plaintext secret is visible', async () => {
+        const secret = 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ';
+        await store.setSecret('idp.example.com', secret);
+
+        const filePath = path.join(tmpDir, 'idp.example.com.json');
+        const content = await fs.readFile(filePath, 'utf-8');
+        const parsed = JSON.parse(content);
+        expect(isEncryptedEnvelope(parsed)).toBe(true);
+        // Sanity: the ciphertext should not include the plaintext secret
+        expect(content.includes(secret)).toBe(false);
+    });
+
+    it('deleteSecret removes the on-disk file and subsequent getSecret returns null', async () => {
+        await store.setSecret('idp.example.com', 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ');
+        await store.deleteSecret('idp.example.com');
+        expect(await store.getSecret('idp.example.com')).toBeNull();
+    });
+
+    it('deleteSecret is a no-op when no file exists (does not throw)', async () => {
+        await expect(store.deleteSecret('never-created.example.com')).resolves.toBeUndefined();
+    });
+
+    it('setSecret then setSecret overwrites the previous secret', async () => {
+        await store.setSecret('idp.example.com', 'OLDSECRETOLDSECRETOLDSECRETOLDSE');
+        await store.setSecret('idp.example.com', 'NEWSECRETNEWSECRETNEWSECRETNEWSE');
+        expect(await store.getSecret('idp.example.com')).toBe('NEWSECRETNEWSECRETNEWSECRETNEWSE');
+    });
+
+    it('sanitizes hostnames — path-traversal characters cannot escape the store dir', async () => {
+        // sanitizeId replaces "/" and other unsafe chars with "_". Storing under
+        // a hostname like "../etc/passwd" must NOT create a file at ../etc/passwd
+        // relative to tmpDir; the file must live inside tmpDir with a mangled name.
+        await store.setSecret('../etc/passwd', 'ANYSECRETANYSECRETANYSECRETANYSE');
+
+        // The parent directory must not contain a leaked file.
+        const parentDir = path.dirname(tmpDir);
+        const escapedPath = path.join(parentDir, 'etc', 'passwd.json');
+        await expect(fs.access(escapedPath)).rejects.toThrow();
+
+        // Round-trip must still work through the sanitized filename.
+        expect(await store.getSecret('../etc/passwd')).toBe('ANYSECRETANYSECRETANYSECRETANYSE');
+
+        // All actual files must live within tmpDir (no path separators leaked
+        // into the filename — sanitizeId replaces "/" with "_", so no on-disk
+        // entry can be a subdirectory or an escape).
+        const entries = await fs.readdir(tmpDir);
+        for (const entry of entries) {
+            expect(entry.includes('/')).toBe(false);
+            expect(entry.includes(path.sep)).toBe(false);
+        }
+    });
+});

--- a/cli/tests/unit/strategies/browser-idp-totp-order.test.ts
+++ b/cli/tests/unit/strategies/browser-idp-totp-order.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Regression test: TOTP auto-fill must run BEFORE the off-domain check.
+ *
+ * When a login flow redirects to an IdP on a different hostname than the
+ * entry URL (e.g. grafana-rel → sub.idp.example.com), `isOffDomain`
+ * returns true and the previous ordering caused `continue` to run before
+ * the TOTP hook was reached — so the OTP was never filled.
+ *
+ * This test verifies:
+ *   - When current page URL is on an IdP domain (sub.idp.example.com)
+ *   - AND the provider's entry hostname is different (grafana.example.com)
+ *   - AND an IdP is configured for that IdP hostname with a TOTP secret
+ *   - THEN `injectTotpFill` IS called (even though isOffDomain would be true).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { BrowserConfig } from '../../../src/config/schema.js';
+import type { IdpEntry } from '../../../src/idps/types.js';
+import { BrowserStrategy } from '../../../src/strategies/browser/browser-strategy.js';
+import * as cdpWsMod from '../../../src/strategies/browser/cdp-ws.js';
+import * as totpInjectorMod from '../../../src/strategies/browser/totp-injector.js';
+import type { IIdpRegistry, ProviderConfig } from '../../../src/types/index.js';
+import { validate } from '../../../src/utils/credential-validator.js';
+
+// ============================================================================
+// Module mocks
+// ============================================================================
+
+vi.mock('../../../src/strategies/browser/cdp-state.js', () => ({
+    acquireBrowser: vi.fn().mockResolvedValue({ port: 9222, wsUrl: 'ws://127.0.0.1:9222/mock' }),
+    releaseBrowser: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../src/strategies/browser/cdp-ws.js', () => ({
+    connectCdpWs: vi.fn(),
+    attachToPageTarget: vi.fn(),
+}));
+
+vi.mock('../../../src/strategies/browser/browser-lifecycle.js', () => ({
+    findFreePort: vi.fn().mockResolvedValue(9222),
+    waitForBrowserReady: vi.fn().mockResolvedValue('ws://127.0.0.1:9222/mock'),
+    isCdpResponding: vi.fn().mockResolvedValue(true),
+    fetchJson: vi.fn().mockResolvedValue({ webSocketDebuggerUrl: 'ws://127.0.0.1:9222/mock' }),
+}));
+
+vi.mock('node:child_process', () => ({
+    spawn: vi.fn().mockReturnValue({
+        pid: 12345,
+        killed: false,
+        on: vi.fn(),
+        kill: vi.fn(),
+    }),
+}));
+
+vi.mock('../../../src/utils/credential-validator.js', () => ({
+    validate: vi.fn(),
+}));
+
+vi.mock('../../../src/strategies/browser/totp-injector.js', () => ({
+    injectTotpFill: vi.fn(),
+}));
+
+const mockedConnectCdpWs = vi.mocked(cdpWsMod.connectCdpWs);
+const mockedAttachToPageTarget = vi.mocked(cdpWsMod.attachToPageTarget);
+const mockedValidate = vi.mocked(validate);
+const mockedInjectTotpFill = vi.mocked(totpInjectorMod.injectTotpFill);
+
+// ============================================================================
+// Constants mirrored from browser-strategy.ts
+// ============================================================================
+
+const POLL_INTERVAL_MS = 3000;
+const SESSION_ID = 'sess-1';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeBrowserConfig(overrides: Partial<BrowserConfig> = {}): BrowserConfig {
+    return {
+        browserDataDir: '/tmp/test-browser-data',
+        execPath: '/usr/bin/google-chrome',
+        headlessTimeout: 60_000,
+        visibleTimeout: 60_000,
+        ...overrides,
+    };
+}
+
+function makeProvider(overrides: Partial<ProviderConfig> = {}): ProviderConfig {
+    return {
+        id: 'grafana-rel',
+        name: 'Grafana Rel',
+        domains: ['grafana.example.com'],
+        entryUrl: 'https://grafana.example.com/',
+        strategy: 'browser',
+        extract: [],
+        apply: [],
+        loginMode: 'visible',
+        ...overrides,
+    };
+}
+
+function makeCdpStub(urlSequence: string[]) {
+    let urlCallCount = 0;
+    return {
+        send: vi.fn(
+            async (method: string, params?: Record<string, unknown>, _sessionId?: string) => {
+                if (method === 'Target.getTargets') {
+                    return {
+                        targetInfos: [{ targetId: 'target-1', type: 'page', url: 'mock-page' }],
+                    };
+                }
+                if (method === 'Target.attachToTarget') return { sessionId: SESSION_ID };
+                if (method === 'Runtime.evaluate') {
+                    const expr = (params as { expression?: string })?.expression ?? '';
+                    if (expr.includes('document.readyState')) {
+                        return { result: { value: 'complete' } };
+                    }
+                    if (expr.includes('window.location.href')) {
+                        const url =
+                            urlSequence[urlCallCount] ?? urlSequence[urlSequence.length - 1];
+                        urlCallCount++;
+                        return { result: { value: url } };
+                    }
+                }
+                return undefined;
+            },
+        ),
+        close: vi.fn(),
+    };
+}
+
+function makeIdpRegistry(entry: IdpEntry): IIdpRegistry {
+    return {
+        resolve: vi.fn((candidate: string) =>
+            candidate === entry.hostname || candidate.endsWith('.' + entry.hostname) ? entry : null,
+        ),
+        list: vi.fn(() => [entry]),
+    };
+}
+
+// ============================================================================
+// Test suite
+// ============================================================================
+
+describe('BrowserStrategy.pollUntilValid — TOTP hook runs before off-domain check', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.clearAllMocks();
+        mockedAttachToPageTarget.mockResolvedValue(SESSION_ID);
+        mockedInjectTotpFill.mockResolvedValue({ filled: true, submitted: true });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('calls injectTotpFill on IdP hostname even when off-domain from entry URL', async () => {
+        // Current URL is on the IdP hostname, which is DIFFERENT from the
+        // provider's entry hostname (grafana.example.com). Under the buggy
+        // ordering isOffDomain() would return true and `continue` would run
+        // before the TOTP block. With the fix, TOTP fill runs first.
+        const cdp = makeCdpStub(['https://sub.idp.example.com/saml2/idp/sso']);
+        mockedConnectCdpWs.mockResolvedValue(cdp as unknown as cdpWsMod.CdpWsClient);
+        mockedValidate.mockResolvedValue(false);
+
+        // Valid base32 TOTP secret (RFC 6238 test vector-ish)
+        const idpEntry: IdpEntry = {
+            hostname: 'sub.idp.example.com',
+            totp: { secret: 'JBSWY3DPEHPK3PXP' },
+        };
+        const idps = makeIdpRegistry(idpEntry);
+
+        const strategy = new BrowserStrategy(
+            makeBrowserConfig({ visibleTimeout: 5000 }),
+            undefined,
+            undefined,
+            idps,
+        );
+        const provider = makeProvider();
+
+        const extractPromise = strategy.extract(provider);
+
+        // Advance fake time enough for at least one iteration + timeout.
+        for (let i = 0; i < 5; i++) {
+            await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS + 100);
+        }
+        await extractPromise;
+
+        // The core assertion: injectTotpFill was invoked despite the URL being
+        // off-domain from the entry hostname.
+        expect(mockedInjectTotpFill).toHaveBeenCalled();
+        const call = mockedInjectTotpFill.mock.calls[0];
+        // Third arg is { code }
+        expect(typeof call[2].code).toBe('string');
+        // Registry was consulted with the off-domain hostname
+        expect(idps.resolve).toHaveBeenCalledWith('sub.idp.example.com');
+    });
+});

--- a/cli/tests/unit/strategies/totp-injector.test.ts
+++ b/cli/tests/unit/strategies/totp-injector.test.ts
@@ -1,0 +1,270 @@
+/* eslint-disable @typescript-eslint/no-this-alias, @typescript-eslint/no-implied-eval */
+/**
+ * Tests for buildFillScript. We evaluate the produced script in a minimal
+ * hand-rolled DOM shim (no jsdom dependency) — just enough surface to run:
+ *   - document.querySelector
+ *   - offsetParent access on the returned element
+ *   - Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set
+ *   - element.dispatchEvent + event listeners for 'input' / 'change'
+ *   - form.requestSubmit / submit + a 'submit' listener
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { buildFillScript } from '../../../src/strategies/browser/totp-injector.js';
+
+// -----------------------------------------------------------------------------
+// Minimal DOM shim
+// -----------------------------------------------------------------------------
+
+interface ShimEvent {
+    type: string;
+    bubbles: boolean;
+}
+
+interface ShimListeners {
+    [type: string]: Array<(e: ShimEvent) => void>;
+}
+
+class ShimElement {
+    tagName: string;
+    attrs: Record<string, string> = {};
+    value: string = '';
+    offsetParent: object | null = { tag: 'body' };
+    form: ShimForm | null = null;
+    listeners: ShimListeners = {};
+    _parent: ShimElement | null = null;
+
+    constructor(tagName: string) {
+        this.tagName = tagName.toUpperCase();
+    }
+
+    addEventListener(type: string, cb: (e: ShimEvent) => void) {
+        (this.listeners[type] ||= []).push(cb);
+    }
+
+    dispatchEvent(e: ShimEvent) {
+        (this.listeners[e.type] || []).forEach((cb) => cb(e));
+    }
+
+    closest(sel: string): ShimElement | null {
+        if (sel === 'form') {
+            let node: ShimElement | null = this;
+            while (node) {
+                if (node.tagName === 'FORM') return node;
+                node = node._parent;
+            }
+            return null;
+        }
+        return null;
+    }
+}
+
+class ShimForm extends ShimElement {
+    constructor() {
+        super('FORM');
+    }
+    requestSubmit() {
+        this.dispatchEvent({ type: 'submit', bubbles: true });
+    }
+    submit() {
+        this.dispatchEvent({ type: 'submit', bubbles: true });
+    }
+}
+
+/**
+ * Very small selector engine — supports id, tag, and attribute-value selectors
+ * of the form `input[name="x"]`, `input[type="tel"][maxlength="6"]`,
+ * `input[autocomplete="one-time-code"]`, `input[inputmode="numeric"]`.
+ * That's enough for the totp-injector's fallback list.
+ */
+function matchesSelector(el: ShimElement, selector: string): boolean {
+    // #id
+    if (selector.startsWith('#')) return el.attrs.id === selector.slice(1);
+    // input[attr="val"]... — split into tag + bracketed conditions
+    const bracketRegex = /\[([a-zA-Z-]+)="([^"]+)"\]/g;
+    const tagMatch = selector.match(/^([a-zA-Z]+)/);
+    const tag = tagMatch ? tagMatch[1].toUpperCase() : null;
+    if (tag && el.tagName !== tag) return false;
+    let m: RegExpExecArray | null;
+    while ((m = bracketRegex.exec(selector)) !== null) {
+        const [, name, val] = m;
+        if (el.attrs[name] !== val) return false;
+    }
+    return true;
+}
+
+function makeDocument(elements: ShimElement[]) {
+    return {
+        querySelector(selector: string): ShimElement | null {
+            for (const el of elements) {
+                if (matchesSelector(el, selector)) return el;
+            }
+            return null;
+        },
+    };
+}
+
+function makeSandbox(elements: ShimElement[]) {
+    // Emulate the native value setter used by the script.
+    const nativeSetter = function (this: ShimElement, v: string) {
+        this.value = v;
+    };
+    const HTMLInputElement = {
+        prototype: {} as Record<string, unknown>,
+    };
+    Object.defineProperty(HTMLInputElement.prototype, 'value', {
+        set: nativeSetter,
+        get() {
+            return (this as ShimElement).value;
+        },
+        configurable: true,
+    });
+    return {
+        document: makeDocument(elements),
+        window: { HTMLInputElement },
+        Event: class {
+            type: string;
+            bubbles: boolean;
+            constructor(type: string, init?: { bubbles?: boolean }) {
+                this.type = type;
+                this.bubbles = init?.bubbles ?? false;
+            }
+        },
+    };
+}
+
+/**
+ * Evaluate the built script in a sandbox constructed from the shim globals.
+ * Uses `new Function` (no eval on the outer scope) with the sandbox globals
+ * as named parameters so the script sees `document`, `window`, `Event`.
+ */
+function runScript(script: string, sandbox: ReturnType<typeof makeSandbox>): unknown {
+    // The script is an IIFE — wrap in `return (...)` so we can capture the value.
+    const fn = new Function('document', 'window', 'Event', 'Object', `return ${script};`);
+    return fn(sandbox.document, sandbox.window, sandbox.Event, Object);
+}
+
+function makeInput(attrs: Record<string, string>): ShimElement {
+    const el = new ShimElement('INPUT');
+    el.attrs = { ...attrs };
+    return el;
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+describe('buildFillScript', () => {
+    it('fills input[name="otp"] and dispatches input + change events', () => {
+        const input = makeInput({ name: 'otp' });
+        let inputFired = false;
+        let changeFired = false;
+        input.addEventListener('input', () => {
+            inputFired = true;
+        });
+        input.addEventListener('change', () => {
+            changeFired = true;
+        });
+
+        const sandbox = makeSandbox([input]);
+        const script = buildFillScript({ code: '123456' });
+        const result = runScript(script, sandbox) as { filled: boolean; submitted: boolean };
+
+        expect(input.value).toBe('123456');
+        expect(inputFired).toBe(true);
+        expect(changeFired).toBe(true);
+        expect(result.filled).toBe(true);
+        // No ancestor form → not submitted, but filled.
+        expect(result.submitted).toBe(false);
+    });
+
+    it('uses the fallback selector input[name="passcode"] when otp is absent', () => {
+        const input = makeInput({ name: 'passcode' });
+        const sandbox = makeSandbox([input]);
+        const script = buildFillScript({ code: '999999' });
+        const result = runScript(script, sandbox) as { filled: boolean };
+        expect(input.value).toBe('999999');
+        expect(result.filled).toBe(true);
+    });
+
+    it('triggers a submit event on the ancestor form', () => {
+        const form = new ShimForm();
+        const input = makeInput({ name: 'otp' });
+        input.form = form;
+        input._parent = form;
+        let submitFired = false;
+        form.addEventListener('submit', () => {
+            submitFired = true;
+        });
+
+        const sandbox = makeSandbox([input]);
+        const script = buildFillScript({ code: '111111' });
+        const result = runScript(script, sandbox) as { filled: boolean; submitted: boolean };
+
+        expect(input.value).toBe('111111');
+        expect(submitFired).toBe(true);
+        expect(result.filled).toBe(true);
+        expect(result.submitted).toBe(true);
+    });
+
+    it('returns { filled: false, reason: "no-input" } when no OTP input is visible', () => {
+        const sandbox = makeSandbox([]);
+        const script = buildFillScript({ code: '123456' });
+        const result = runScript(script, sandbox) as {
+            filled: boolean;
+            submitted: boolean;
+            reason?: string;
+        };
+        expect(result.filled).toBe(false);
+        expect(result.submitted).toBe(false);
+        expect(result.reason).toBe('no-input');
+    });
+
+    it('skips hidden inputs (offsetParent === null)', () => {
+        const hidden = makeInput({ name: 'otp' });
+        hidden.offsetParent = null;
+        const sandbox = makeSandbox([hidden]);
+        const script = buildFillScript({ code: '123456' });
+        const result = runScript(script, sandbox) as {
+            filled: boolean;
+            reason?: string;
+        };
+        expect(result.filled).toBe(false);
+        expect(result.reason).toBe('no-input');
+    });
+
+    it('returns { filled: true, reason: "no-form" } when input has no ancestor form', () => {
+        const input = makeInput({ name: 'otp' });
+        // no .form, no ancestor form
+        const sandbox = makeSandbox([input]);
+        const script = buildFillScript({ code: '123456' });
+        const result = runScript(script, sandbox) as {
+            filled: boolean;
+            submitted: boolean;
+            reason?: string;
+        };
+        expect(result.filled).toBe(true);
+        expect(result.submitted).toBe(false);
+        expect(result.reason).toBe('no-form');
+    });
+
+    it('safely escapes the code — malicious quotes in the code cannot break out of the string literal', () => {
+        // JSON.stringify() escapes quotes and backslashes. buildFillScript should
+        // produce a valid JS expression regardless of the input code. We drive
+        // an extreme code containing quotes/backslashes and confirm:
+        //   1. The script parses/runs (no syntax error).
+        //   2. The input receives the code verbatim (proof of proper escaping).
+        const evil = `6"); alert(1); //`;
+        const input = makeInput({ name: 'otp' });
+        const sandbox = makeSandbox([input]);
+        const script = buildFillScript({ code: evil });
+
+        // The script should be a syntactically valid expression.
+        expect(() => new Function(`return ${script};`)).not.toThrow();
+
+        const result = runScript(script, sandbox) as { filled: boolean };
+        expect(result.filled).toBe(true);
+        expect(input.value).toBe(evil);
+    });
+});

--- a/cli/tests/unit/utils/totp.test.ts
+++ b/cli/tests/unit/utils/totp.test.ts
@@ -1,0 +1,71 @@
+/**
+ * TOTP known-answer tests based on RFC 6238 Appendix B (SHA-1 vector).
+ *
+ * The RFC vector uses the ASCII secret "12345678901234567890", base32-encoded
+ * as "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ".
+ *
+ * The RFC prints 8-digit codes; the underlying HOTP truncation is the same, so
+ * we compute 8-digit codes here for direct comparison with the RFC table.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { computeTotp } from '../../../src/utils/totp.js';
+
+const SECRET_BASE32 = 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ';
+
+describe('computeTotp — RFC 6238 Appendix B known answers (SHA-1, 8 digits)', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    // RFC 6238 Appendix B table — SHA-1 column
+    const cases: Array<{ ts: number; code: string }> = [
+        { ts: 59, code: '94287082' },
+        { ts: 1111111109, code: '07081804' },
+        { ts: 1111111111, code: '14050471' },
+        { ts: 1234567890, code: '89005924' },
+        { ts: 2000000000, code: '69279037' },
+    ];
+
+    for (const { ts, code } of cases) {
+        it(`ts=${ts} → ${code}`, () => {
+            vi.setSystemTime(new Date(ts * 1000));
+            expect(computeTotp(SECRET_BASE32, { digits: 8, period: 30 })).toBe(code);
+        });
+    }
+});
+
+describe('computeTotp — defaults', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(59_000)); // matches ts=59 in the RFC table
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('returns a 6-digit numeric string with default options', () => {
+        const code = computeTotp(SECRET_BASE32);
+        expect(code).toMatch(/^\d{6}$/);
+    });
+
+    it('the 6-digit code equals the last 6 digits of the 8-digit RFC code', () => {
+        // The 8-digit code at ts=59 is 94287082 → 6-digit truncation is 287082.
+        const code6 = computeTotp(SECRET_BASE32);
+        const code8 = computeTotp(SECRET_BASE32, { digits: 8 });
+        expect(code6).toBe(code8.slice(-6));
+    });
+});
+
+describe('computeTotp — invalid input', () => {
+    it('throws on invalid base32 secret', () => {
+        // '1' and '0' are not valid base32 alphabet characters (base32 is A-Z, 2-7).
+        expect(() => computeTotp('!!!not-base32!!!')).toThrow();
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,9 @@ importers:
       dlv:
         specifier: ^1.1.3
         version: 1.1.3
+      otpauth:
+        specifier: ^9.5.1
+        version: 9.5.1
       proper-lockfile:
         specifier: ^4.1.2
         version: 4.1.2
@@ -75,7 +78,7 @@ importers:
         version: 0.2.2
       undici:
         specifier: ^7.28.0
-        version: 7.28.0
+        version: 7.29.0
       yaml:
         specifier: ^2.7.0
         version: 2.8.3
@@ -97,7 +100,7 @@ importers:
         version: 3.8.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.39)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.7(@types/node@20.19.39)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.33.0)(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   packages/skills: {}
 
@@ -111,7 +114,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.39)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.7(@types/node@20.19.39)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.33.0)(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   website:
     dependencies:
@@ -126,7 +129,7 @@ importers:
         version: 3.1.18
       '@tailwindcss/vite':
         specifier: ^4.1.18
-        version: 4.2.2(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.2.2(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/react-devtools':
         specifier: latest
         version: 0.10.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(csstype@3.2.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@1.9.12)
@@ -135,16 +138,16 @@ importers:
         version: 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-router-devtools':
         specifier: latest
-        version: 1.166.13(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/router-core@1.171.13)(csstype@3.2.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.166.13(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/router-core@1.171.24)(csstype@3.2.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-router-ssr-query':
         specifier: latest
-        version: 1.166.11(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/router-core@1.171.13)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.166.11(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/router-core@1.171.24)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-start':
         specifier: ^1.168.0
-        version: 1.168.26(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.168.46(crossws@0.4.5(srvx@0.11.15))(esbuild@0.28.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rolldown@1.2.4)(rollup@4.60.2)(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/router-plugin':
         specifier: ^1.132.0
-        version: 1.167.22(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.167.22(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -156,7 +159,7 @@ importers:
         version: 0.545.0(react@19.2.5)
       nitro:
         specifier: 3.0.260415-beta
-        version: 3.0.260415-beta(chokidar@5.0.0)(dotenv@17.4.2)(jiti@2.7.0)(lru-cache@11.3.5)(rollup@4.60.2)(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 3.0.260415-beta(chokidar@5.0.0)(dotenv@17.4.2)(jiti@2.7.0)(lru-cache@11.3.5)(rollup@4.60.2)(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       prismjs:
         specifier: ^1.30.0
         version: 1.30.0
@@ -184,7 +187,7 @@ importers:
         version: 0.5.19(tailwindcss@4.2.2)
       '@tanstack/devtools-vite':
         specifier: latest
-        version: 0.6.0(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.6.0(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -208,19 +211,19 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 6.0.1(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       jsdom:
         specifier: ^28.1.0
-        version: 28.1.0(@noble/hashes@1.8.0)
+        version: 28.1.0(@noble/hashes@2.2.0)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
       vite:
         specifier: ^8.0.16
-        version: 8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@22.19.17)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.7(@types/node@22.19.17)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.33.0)(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
 packages:
 
@@ -265,8 +268,8 @@ packages:
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.29.7':
-    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+  '@babel/generator@7.29.8':
+    resolution: {integrity: sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.27.3':
@@ -366,8 +369,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/parser@7.29.7':
-    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -417,16 +420,16 @@ packages:
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.29.7':
-    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+  '@babel/traverse@7.29.8':
+    resolution: {integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.29.7':
-    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
   '@base-ui/react@1.4.0':
@@ -520,158 +523,158 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@esbuild/aix-ppc64@0.28.1':
-    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.28.1':
-    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.28.1':
-    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.28.1':
-    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.28.1':
-    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.28.1':
-    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.28.1':
-    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.28.1':
-    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.28.1':
-    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.28.1':
-    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.28.1':
-    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.28.1':
-    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.28.1':
-    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.28.1':
-    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.28.1':
-    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.28.1':
-    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.28.1':
-    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.28.1':
-    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.28.1':
-    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.28.1':
-    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.28.1':
-    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.28.1':
-    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.28.1':
-    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.28.1':
-    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.28.1':
-    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.28.1':
-    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -872,6 +875,10 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -919,8 +926,8 @@ packages:
   '@oxc-project/types@0.126.0':
     resolution: {integrity: sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==}
 
-  '@oxc-project/types@0.133.0':
-    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+  '@oxc-project/types@0.144.0':
+    resolution: {integrity: sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==}
 
   '@package-json/types@0.0.12':
     resolution: {integrity: sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==}
@@ -965,8 +972,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-android-arm64@1.0.3':
-    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
+  '@rolldown/binding-android-arm64@1.2.4':
+    resolution: {integrity: sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -977,8 +984,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-arm64@1.0.3':
-    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
+  '@rolldown/binding-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -989,8 +996,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.3':
-    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
+  '@rolldown/binding-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -1001,8 +1008,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-freebsd-x64@1.0.3':
-    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
+  '@rolldown/binding-freebsd-x64@1.2.4':
+    resolution: {integrity: sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -1013,8 +1020,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
-    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.4':
+    resolution: {integrity: sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -1026,8 +1033,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.3':
-    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
+  '@rolldown/binding-linux-arm64-gnu@1.2.4':
+    resolution: {integrity: sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -1040,8 +1047,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.3':
-    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
+  '@rolldown/binding-linux-arm64-musl@1.2.4':
+    resolution: {integrity: sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -1054,8 +1061,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
-    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.2.4':
+    resolution: {integrity: sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -1068,8 +1075,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.3':
-    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
+  '@rolldown/binding-linux-s390x-gnu@1.2.4':
+    resolution: {integrity: sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
@@ -1082,8 +1089,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.3':
-    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
+  '@rolldown/binding-linux-x64-gnu@1.2.4':
+    resolution: {integrity: sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -1096,8 +1103,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-x64-musl@1.0.3':
-    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
+  '@rolldown/binding-linux-x64-musl@1.2.4':
+    resolution: {integrity: sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -1109,8 +1116,8 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-openharmony-arm64@1.0.3':
-    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
+  '@rolldown/binding-openharmony-arm64@1.2.4':
+    resolution: {integrity: sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -1120,19 +1127,14 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-wasm32-wasi@1.0.3':
-    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
-
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.16':
     resolution: {integrity: sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.3':
-    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
+  '@rolldown/binding-win32-arm64-msvc@1.2.4':
+    resolution: {integrity: sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -1143,8 +1145,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.3':
-    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
+  '@rolldown/binding-win32-x64-msvc@1.2.4':
+    resolution: {integrity: sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1469,8 +1471,8 @@ packages:
     resolution: {integrity: sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==}
     engines: {node: '>=20.19'}
 
-  '@tanstack/history@1.162.0':
-    resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
+  '@tanstack/history@1.162.1':
+    resolution: {integrity: sha512-DR9t6lfLVdrjgCwpglrR9DR7Ok8/HlXjcOE+goWXF3zyuLUO/ug7vMbSFxTqrQTtbRghJfyhmIZ0S6LhPIy44w==}
     engines: {node: '>=20.19'}
 
   '@tanstack/query-core@5.99.0':
@@ -1519,26 +1521,26 @@ packages:
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
 
-  '@tanstack/react-router@1.170.16':
-    resolution: {integrity: sha512-w6eq1IJklujs1tESazaK/FxH0+H2l8vm/QPuu1cD3oRW/ubgKneQpd7b64ti/8gUyEimzimJQZDmJr6YHfP5+g==}
+  '@tanstack/react-router@1.170.29':
+    resolution: {integrity: sha512-xQwakR0ReaUGu3xeXEl2CqzlIXk4i9vxaf/zqdzoELMY0mDZgMOr+xobiA5cQdn8cnovqZgqqUxcwXhsruC+NA==}
     engines: {node: '>=20.19'}
     peerDependencies:
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
 
-  '@tanstack/react-start-client@1.168.14':
-    resolution: {integrity: sha512-oaz43fdOhBWfOPsdLkp3IejwYEXRyeaZ4CYexOPZx3eVXzm4LLozvNkkkBE9aje1sM5MVC2Yo6+cyv2HdVzkHQ==}
+  '@tanstack/react-start-client@1.168.27':
+    resolution: {integrity: sha512-N18avSX3aAobLkpyYQiRkXrtcc5E+0A97HEWSfzUxT6+1mwMdSg8CBZL1m59zGp9pXWFfO2aFUlBEryGy9beTA==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
 
-  '@tanstack/react-start-rsc@0.1.25':
-    resolution: {integrity: sha512-Rwm6cjcS148y2XAebr8jyrwU0SqsRSkW4/CuXesoHg+G3IOnVRHV0HOylJfnznUTVuH1nVhfQRPI5uWPJaw2TA==}
+  '@tanstack/react-start-rsc@0.1.45':
+    resolution: {integrity: sha512-n962onqz6wZkra9cHygPQumKaShqZAfO2BRvrRzbtYa8M5ytbOG3Wvg6TUbZJ7gPKmjDvFsyrAPgZZ8ZhkrbwA==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@rspack/core': '>=2.0.0-0'
-      '@vitejs/plugin-rsc': '>=0.5.20'
+      '@vitejs/plugin-rsc': '>=0.5.30'
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
       react-server-dom-rspack: '>=0.0.2'
@@ -1550,15 +1552,15 @@ packages:
       react-server-dom-rspack:
         optional: true
 
-  '@tanstack/react-start-server@1.167.20':
-    resolution: {integrity: sha512-hg9xVI6yNDu+6NCalKz1h3Ea18HZEUu35i/ZMJz1WadwqcArLMp41nM1GNhOAtGIdpycrp9tT7ccqc9zuRMRpQ==}
+  '@tanstack/react-start-server@1.167.34':
+    resolution: {integrity: sha512-9C1r6mUyDJPF2GRZBJfp8Zf/IH6YpXKwq09gKcCIt6CX/2z4Ir0SAtdzjgVYsAxX8a5qNQNLbwCkp4xa3kjyqw==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
 
-  '@tanstack/react-start@1.168.26':
-    resolution: {integrity: sha512-ZzNecqKWC0p2643/kIcFUdsMrXZ8A4dXm4Yfe9zV/Y0u14MtSkh/Sk76RQYIU5S84VyDyKhHo0Ffh8HQbLdvFw==}
+  '@tanstack/react-start@1.168.46':
+    resolution: {integrity: sha512-GvjKkZQ4bzuqyDIFvY7Puh7nCDc5Uh7r3puO8EDr1ZSqbZu8LGUaeNRrAHepxEIepr2iYbSDtKVaB7A9fWUMeA==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@rsbuild/core': ^2.0.0
@@ -1585,8 +1587,8 @@ packages:
     engines: {node: '>=20.19'}
     hasBin: true
 
-  '@tanstack/router-core@1.171.13':
-    resolution: {integrity: sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA==}
+  '@tanstack/router-core@1.171.24':
+    resolution: {integrity: sha512-+j+8NmV4QOS+ILNLdXFlLTdKPPbBQIy6mXDZ0QWEKYZ0xQOdlnOCXVHPflyGanD2SWSxjqGkw8CsW0CXXP7fLg==}
     engines: {node: '>=20.19'}
 
   '@tanstack/router-devtools-core@1.167.3':
@@ -1603,8 +1605,8 @@ packages:
     resolution: {integrity: sha512-VuusKwEXcgKq+myq1JQfZogY8scTXIIeFls50dJ/UXgCXWp5n14iFreYNlg41wURcak2oA3M+t2TVfD0xUUD6g==}
     engines: {node: '>=20.19'}
 
-  '@tanstack/router-generator@1.167.17':
-    resolution: {integrity: sha512-xtB9tB2Ws0tWR6Pi7nc3Qk9IYgoh1mQCKWjHqIl9tf6BNUpKoqniJoPAQ4+LGrK8FeZYU0o0p/qlZEyj9FAulA==}
+  '@tanstack/router-generator@1.167.30':
+    resolution: {integrity: sha512-Tf9TJfdpP0yL3k1D1ke6hR1dvPCgKShTik3HcBRDeTK5eNrp9/X0Q0YApN8thE6pVcXL6a78O3ZE7XN7s7KwNw==}
     engines: {node: '>=20.19'}
 
   '@tanstack/router-plugin@1.167.22':
@@ -1629,12 +1631,12 @@ packages:
       webpack:
         optional: true
 
-  '@tanstack/router-plugin@1.168.18':
-    resolution: {integrity: sha512-MofS28/axfnfnhOD2RSgJEaU882aX5RsAzhGz5Vc4XhAmvCjy919u9JrNs4QsTWFbTD1P7IJ8WFlFVsrg0pStg==}
+  '@tanstack/router-plugin@1.168.32':
+    resolution: {integrity: sha512-P+qYIY9b/K+ZGUPNiyLqsd20vN/1abgmSNG0Ch9KTKldag3icR7TlrJgnM2km86yuRdXa4nJ5YT7+JLV5rJRZg==}
     engines: {node: '>=20.19'}
     peerDependencies:
       '@rsbuild/core': '>=1.0.2 || ^2.0.0'
-      '@tanstack/react-router': ^1.170.15
+      '@tanstack/react-router': ^1.170.29
       vite: ^7.3.5
       vite-plugin-solid: ^2.11.10 || ^3.0.0-0
       webpack: '>=5.92.0'
@@ -1665,16 +1667,16 @@ packages:
     resolution: {integrity: sha512-hTWqJtqIFFdvuCl8WXNyrodp2L9zo2G37xKRrcVmVRWpAB2h+U1LuRAfS4tsFTiWOIoE/B+WDVFB8JpoEdw6jQ==}
     engines: {node: '>=20.19'}
 
-  '@tanstack/start-client-core@1.170.12':
-    resolution: {integrity: sha512-gwtZRMPUIAxmDV2AIQUhC0kSW262SV7BkHXEgy5B1woHQdrdsELuGOdJwdweLxrjyefORxk+9MYGqDY0Cxn0bw==}
+  '@tanstack/start-client-core@1.170.24':
+    resolution: {integrity: sha512-BRdV6TZSLVZ43fEVdIdkpkZCwwaEm57JUPpNiNszZeutBZLU0bxR/cbs0cC7sE98oVsgBTNvaBjyk2CDea+4sw==}
     engines: {node: '>=22.12.0'}
 
   '@tanstack/start-fn-stubs@1.162.0':
     resolution: {integrity: sha512-QWfUZ3Yo923tdQn38LyKMU8rcTw69zc+T4dAvgTWV4O56SqFRsGfS0lSWIMhJRwXIx/bvdi7nTUBDdZtTHtpTQ==}
     engines: {node: '>=22.12.0'}
 
-  '@tanstack/start-plugin-core@1.171.18':
-    resolution: {integrity: sha512-weuOOjRD03BiKcF9NYKL5QADEQOp3yGHb0qIsOX42ENz5XUE4in2fXcVYHjSwwpzs+XGhWIFLp5J385pOVPuZQ==}
+  '@tanstack/start-plugin-core@1.171.36':
+    resolution: {integrity: sha512-wWFd0sSpoW3k5cJJ1EpJuQ1REzMcv4LcOmPKotyhH2PNQPqBIRv9ZCxRtH7QWxXcwAaE0G1YE8PTYh9ZARPYOg==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@rsbuild/core': ^2.0.0
@@ -1685,12 +1687,12 @@ packages:
       vite:
         optional: true
 
-  '@tanstack/start-server-core@1.169.15':
-    resolution: {integrity: sha512-V8ie2G2Ecb3Nklk8/QuKzulxb+tDUqgz6rjJe8Isdp4iKVXZu/TscItkUP/4Q5Bu7W4gUy3P25O6soC1oW1SXQ==}
+  '@tanstack/start-server-core@1.169.28':
+    resolution: {integrity: sha512-iGytKBUIzEWxVZ20x2UYyTNGOviYSxUXR4SqAz8NRh0ElcbMHPK0twkE7ZeKLDigyQh9rG1DHGyiGVs6plQTvQ==}
     engines: {node: '>=22.12.0'}
 
-  '@tanstack/start-storage-context@1.167.15':
-    resolution: {integrity: sha512-Jy0q4vdG6pv76N92+X+ag3fuOV2zINQagYyMN1/es7tPI1vzpKECIU8AqHqzI6ahkwaph7XDvmfUkiLJ3i4LOA==}
+  '@tanstack/start-storage-context@1.167.26':
+    resolution: {integrity: sha512-uWUX1zk4rY0vrSzW7JyIGYRLX0jx75Mc+CeaJL8TPTE4UHq2DxZ+4rwrx8/KBRyDFXTzgIzJAXIvp8Tm6hQaNQ==}
     engines: {node: '>=22.12.0'}
 
   '@tanstack/store@0.9.3':
@@ -1964,11 +1966,11 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
-  '@vitest/expect@3.2.6':
-    resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
 
-  '@vitest/mocker@3.2.6':
-    resolution: {integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==}
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^7.3.5
@@ -1978,20 +1980,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.2.6':
-    resolution: {integrity: sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==}
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
 
-  '@vitest/runner@3.2.6':
-    resolution: {integrity: sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==}
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
 
-  '@vitest/snapshot@3.2.6':
-    resolution: {integrity: sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==}
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
 
-  '@vitest/spy@3.2.6':
-    resolution: {integrity: sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==}
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
 
-  '@vitest/utils@3.2.6':
-    resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -2098,9 +2100,9 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2461,8 +2463,8 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.28.1:
-    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2614,8 +2616,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -2773,8 +2775,8 @@ packages:
   headers-polyfill@5.0.1:
     resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
-  hono@4.12.26:
-    resolution: {integrity: sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==}
+  hono@4.13.2:
+    resolution: {integrity: sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==}
     engines: {node: '>=16.9.0'}
 
   hookable@6.1.1:
@@ -2835,8 +2837,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.5.0:
+    resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -2957,8 +2959,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@28.1.0:
@@ -3025,8 +3027,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.32.0:
     resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -3037,8 +3051,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.32.0:
     resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -3049,8 +3075,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -3063,8 +3102,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -3077,8 +3130,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -3089,8 +3155,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
   lines-and-columns@1.2.4:
@@ -3210,8 +3286,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3333,6 +3409,9 @@ packages:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
 
+  otpauth@9.5.1:
+    resolution: {integrity: sha512-fJmDAHc8wImfqqqOXIlBvT1dEKrZK0Cmb2VEgScpNTolCz0PHh6ExUZGv4sLtOsWNaHCQlD+rRqaPgnoxFoZjQ==}
+
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
@@ -3402,6 +3481,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
@@ -3418,8 +3501,8 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   powershell-utils@0.1.0:
@@ -3469,8 +3552,8 @@ packages:
     resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
     engines: {node: '>=16.0.0'}
 
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -3500,8 +3583,8 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
-  readdirp@5.0.0:
-    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+  readdirp@5.1.1:
+    resolution: {integrity: sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==}
     engines: {node: '>= 20.19.0'}
 
   recast@0.23.11:
@@ -3552,8 +3635,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rolldown@1.0.3:
-    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
+  rolldown@1.2.4:
+    resolution: {integrity: sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -3605,8 +3688,8 @@ packages:
     peerDependencies:
       seroval: ^1.0
 
-  seroval-plugins@1.5.4:
-    resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
+  seroval-plugins@1.6.2:
+    resolution: {integrity: sha512-TfxuUjlbBESzUOWdTkTKqvSmav0ABym+itetDXLK6mDz8SmrpdI30aF8RTXE8Bvq+tH/1yIDkvy3W0lfQb1ipQ==}
     engines: {node: '>=10'}
     peerDependencies:
       seroval: ^1.0
@@ -3615,8 +3698,8 @@ packages:
     resolution: {integrity: sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==}
     engines: {node: '>=10'}
 
-  seroval@1.5.4:
-    resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
+  seroval@1.6.2:
+    resolution: {integrity: sha512-mPT+SD2TrlB6wvte1KkYOYUkubaTbd6pZ/6Kk3C9nxzrHmCZyhxOO7XGAeL7f+yLKZglzGtM9odUVvg/EhO+vQ==}
     engines: {node: '>=10'}
 
   serve-static@2.2.1:
@@ -3641,8 +3724,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.1:
@@ -3657,8 +3740,8 @@ packages:
     resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
     engines: {node: '>= 0.4'}
 
-  side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -3900,8 +3983,12 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -3923,9 +4010,38 @@ packages:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
     engines: {node: '>=18.12.0'}
 
-  unplugin@3.0.0:
-    resolution: {integrity: sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==}
+  unplugin@3.3.0:
+    resolution: {integrity: sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@farmfe/core': '*'
+      '@rspack/core': '*'
+      bun-types-no-globals: '*'
+      esbuild: ^0.28.1
+      rolldown: '*'
+      rollup: '*'
+      unloader: '*'
+      vite: ^7.3.5
+      webpack: '*'
+    peerDependenciesMeta:
+      '@farmfe/core':
+        optional: true
+      '@rspack/core':
+        optional: true
+      bun-types-no-globals:
+        optional: true
+      esbuild:
+        optional: true
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+      unloader:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -4037,8 +4153,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@7.3.5:
-    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -4077,13 +4193,13 @@ packages:
       yaml:
         optional: true
 
-  vite@8.0.16:
-    resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
+  vite@8.2.1:
+    resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.1.18
+      '@vitejs/devtools': ^0.4.0
       esbuild: ^0.28.1
       jiti: '>=1.21.0'
       less: ^4.0.0
@@ -4128,16 +4244,16 @@ packages:
       vite:
         optional: true
 
-  vitest@3.2.6:
-    resolution: {integrity: sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==}
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.6
-      '@vitest/ui': 3.2.6
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -4209,8 +4325,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.21.0:
-    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -4305,7 +4421,7 @@ snapshots:
 
   '@babel/code-frame@7.27.1':
     dependencies:
-      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/helper-validator-identifier': 7.28.5
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -4326,14 +4442,14 @@ snapshots:
   '@babel/core@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.7
+      '@babel/generator': 7.29.8
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helpers': 7.29.7
-      '@babel/parser': 7.29.7
+      '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -4351,10 +4467,10 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
-  '@babel/generator@7.29.7':
+  '@babel/generator@7.29.8':
     dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -4404,8 +4520,8 @@ snapshots:
 
   '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -4423,7 +4539,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -4464,15 +4580,15 @@ snapshots:
   '@babel/helpers@7.29.7':
     dependencies:
       '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
 
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/parser@7.29.7':
+  '@babel/parser@7.29.8':
     dependencies:
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
 
   '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.7)':
     dependencies:
@@ -4525,8 +4641,8 @@ snapshots:
   '@babel/template@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
 
   '@babel/traverse@7.29.0':
     dependencies:
@@ -4540,14 +4656,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/traverse@7.29.7':
+  '@babel/traverse@7.29.8':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.7
+      '@babel/generator': 7.29.8
       '@babel/helper-globals': 7.29.7
-      '@babel/parser': 7.29.7
+      '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -4557,7 +4673,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@babel/types@7.29.7':
+  '@babel/types@7.29.8':
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
@@ -4661,82 +4777,82 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.28.1':
+  '@esbuild/aix-ppc64@0.28.2':
     optional: true
 
-  '@esbuild/android-arm64@0.28.1':
+  '@esbuild/android-arm64@0.28.2':
     optional: true
 
-  '@esbuild/android-arm@0.28.1':
+  '@esbuild/android-arm@0.28.2':
     optional: true
 
-  '@esbuild/android-x64@0.28.1':
+  '@esbuild/android-x64@0.28.2':
     optional: true
 
-  '@esbuild/darwin-arm64@0.28.1':
+  '@esbuild/darwin-arm64@0.28.2':
     optional: true
 
-  '@esbuild/darwin-x64@0.28.1':
+  '@esbuild/darwin-x64@0.28.2':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.28.1':
+  '@esbuild/freebsd-arm64@0.28.2':
     optional: true
 
-  '@esbuild/freebsd-x64@0.28.1':
+  '@esbuild/freebsd-x64@0.28.2':
     optional: true
 
-  '@esbuild/linux-arm64@0.28.1':
+  '@esbuild/linux-arm64@0.28.2':
     optional: true
 
-  '@esbuild/linux-arm@0.28.1':
+  '@esbuild/linux-arm@0.28.2':
     optional: true
 
-  '@esbuild/linux-ia32@0.28.1':
+  '@esbuild/linux-ia32@0.28.2':
     optional: true
 
-  '@esbuild/linux-loong64@0.28.1':
+  '@esbuild/linux-loong64@0.28.2':
     optional: true
 
-  '@esbuild/linux-mips64el@0.28.1':
+  '@esbuild/linux-mips64el@0.28.2':
     optional: true
 
-  '@esbuild/linux-ppc64@0.28.1':
+  '@esbuild/linux-ppc64@0.28.2':
     optional: true
 
-  '@esbuild/linux-riscv64@0.28.1':
+  '@esbuild/linux-riscv64@0.28.2':
     optional: true
 
-  '@esbuild/linux-s390x@0.28.1':
+  '@esbuild/linux-s390x@0.28.2':
     optional: true
 
-  '@esbuild/linux-x64@0.28.1':
+  '@esbuild/linux-x64@0.28.2':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.28.1':
+  '@esbuild/netbsd-arm64@0.28.2':
     optional: true
 
-  '@esbuild/netbsd-x64@0.28.1':
+  '@esbuild/netbsd-x64@0.28.2':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.28.1':
+  '@esbuild/openbsd-arm64@0.28.2':
     optional: true
 
-  '@esbuild/openbsd-x64@0.28.1':
+  '@esbuild/openbsd-x64@0.28.2':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.28.1':
+  '@esbuild/openharmony-arm64@0.28.2':
     optional: true
 
-  '@esbuild/sunos-x64@0.28.1':
+  '@esbuild/sunos-x64@0.28.2':
     optional: true
 
-  '@esbuild/win32-arm64@0.28.1':
+  '@esbuild/win32-arm64@0.28.2':
     optional: true
 
-  '@esbuild/win32-ia32@0.28.1':
+  '@esbuild/win32-ia32@0.28.2':
     optional: true
 
-  '@esbuild/win32-x64@0.28.1':
+  '@esbuild/win32-x64@0.28.2':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.2.1(jiti@2.7.0))':
@@ -4773,9 +4889,9 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@exodus/bytes@1.15.0(@noble/hashes@1.8.0)':
+  '@exodus/bytes@1.15.0(@noble/hashes@2.2.0)':
     optionalDependencies:
-      '@noble/hashes': 1.8.0
+      '@noble/hashes': 2.2.0
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -4796,9 +4912,9 @@ snapshots:
 
   '@fontsource-variable/geist@5.2.8': {}
 
-  '@hono/node-server@1.19.14(hono@4.12.26)':
+  '@hono/node-server@1.19.14(hono@4.13.2)':
     dependencies:
-      hono: 4.12.26
+      hono: 4.13.2
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -4901,7 +5017,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.26)
+      '@hono/node-server': 1.19.14(hono@4.13.2)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -4911,7 +5027,7 @@ snapshots:
       eventsource-parser: 3.0.7
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.26
+      hono: 4.13.2
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -4937,13 +5053,6 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
-    optional: true
-
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
       '@emnapi/core': 1.9.2
@@ -4958,6 +5067,8 @@ snapshots:
       '@noble/hashes': 1.8.0
 
   '@noble/hashes@1.8.0': {}
+
+  '@noble/hashes@2.2.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -5003,7 +5114,7 @@ snapshots:
 
   '@oxc-project/types@0.126.0': {}
 
-  '@oxc-project/types@0.133.0': {}
+  '@oxc-project/types@0.144.0': {}
 
   '@package-json/types@0.0.12': {}
 
@@ -5099,73 +5210,73 @@ snapshots:
   '@rolldown/binding-android-arm64@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-android-arm64@1.0.3':
+  '@rolldown/binding-android-arm64@1.2.4':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.3':
+  '@rolldown/binding-darwin-arm64@1.2.4':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.3':
+  '@rolldown/binding-darwin-x64@1.2.4':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.3':
+  '@rolldown/binding-freebsd-x64@1.2.4':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.4':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+  '@rolldown/binding-linux-arm64-gnu@1.2.4':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.3':
+  '@rolldown/binding-linux-arm64-musl@1.2.4':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+  '@rolldown/binding-linux-ppc64-gnu@1.2.4':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+  '@rolldown/binding-linux-s390x-gnu@1.2.4':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.3':
+  '@rolldown/binding-linux-x64-gnu@1.2.4':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.3':
+  '@rolldown/binding-linux-x64-musl@1.2.4':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.3':
+  '@rolldown/binding-openharmony-arm64@1.2.4':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.16':
@@ -5175,23 +5286,16 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.3':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    optional: true
-
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+  '@rolldown/binding-win32-arm64-msvc@1.2.4':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.3':
+  '@rolldown/binding-win32-x64-msvc@1.2.4':
     optional: true
 
   '@rolldown/pluginutils@1.0.0-rc.16': {}
@@ -5379,12 +5483,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.2
 
-  '@tailwindcss/vite@4.2.2(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tailwindcss/vite@4.2.2(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@tanstack/devtools-client@0.0.6':
     dependencies:
@@ -5392,7 +5496,7 @@ snapshots:
 
   '@tanstack/devtools-event-bus@0.4.1':
     dependencies:
-      ws: 8.21.0
+      ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -5408,7 +5512,7 @@ snapshots:
     transitivePeerDependencies:
       - csstype
 
-  '@tanstack/devtools-vite@0.6.0(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tanstack/devtools-vite@0.6.0(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/generator': 7.29.1
@@ -5420,7 +5524,7 @@ snapshots:
       chalk: 5.6.2
       launch-editor: 2.14.1
       picomatch: 4.0.4
-      vite: 8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -5444,7 +5548,7 @@ snapshots:
 
   '@tanstack/history@1.161.6': {}
 
-  '@tanstack/history@1.162.0': {}
+  '@tanstack/history@1.162.1': {}
 
   '@tanstack/query-core@5.99.0': {}
 
@@ -5466,23 +5570,23 @@ snapshots:
       '@tanstack/query-core': 5.99.0
       react: 19.2.5
 
-  '@tanstack/react-router-devtools@1.166.13(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/router-core@1.171.13)(csstype@3.2.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@tanstack/react-router-devtools@1.166.13(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/router-core@1.171.24)(csstype@3.2.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@tanstack/react-router': 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/router-devtools-core': 1.167.3(@tanstack/router-core@1.171.13)(csstype@3.2.3)
+      '@tanstack/router-devtools-core': 1.167.3(@tanstack/router-core@1.171.24)(csstype@3.2.3)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
-      '@tanstack/router-core': 1.171.13
+      '@tanstack/router-core': 1.171.24
     transitivePeerDependencies:
       - csstype
 
-  '@tanstack/react-router-ssr-query@1.166.11(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/router-core@1.171.13)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@tanstack/react-router-ssr-query@1.166.11(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/router-core@1.171.24)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@tanstack/query-core': 5.99.0
       '@tanstack/react-query': 5.99.0(react@19.2.5)
       '@tanstack/react-router': 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/router-ssr-query-core': 1.167.1(@tanstack/query-core@5.99.0)(@tanstack/router-core@1.171.13)
+      '@tanstack/router-ssr-query-core': 1.167.1(@tanstack/query-core@5.99.0)(@tanstack/router-core@1.171.24)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     transitivePeerDependencies:
@@ -5497,74 +5601,85 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@tanstack/react-router@1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@tanstack/react-router@1.170.29(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@tanstack/history': 1.162.0
+      '@tanstack/history': 1.162.1
       '@tanstack/react-store': 0.9.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/router-core': 1.171.13
+      '@tanstack/router-core': 1.171.24
       isbot: 5.1.39
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@tanstack/react-start-client@1.168.14(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@tanstack/react-start-client@1.168.27(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@tanstack/react-router': 1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/router-core': 1.171.13
-      '@tanstack/start-client-core': 1.170.12
+      '@tanstack/react-router': 1.170.29(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/router-core': 1.171.24
+      '@tanstack/start-client-core': 1.170.24
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@tanstack/react-start-rsc@0.1.25(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tanstack/react-start-rsc@0.1.45(crossws@0.4.5(srvx@0.11.15))(esbuild@0.28.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rolldown@1.2.4)(rollup@4.60.2)(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@tanstack/react-router': 1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/router-core': 1.171.13
+      '@tanstack/react-router': 1.170.29(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/router-core': 1.171.24
       '@tanstack/router-utils': 1.162.2
-      '@tanstack/start-client-core': 1.170.12
+      '@tanstack/start-client-core': 1.170.24
       '@tanstack/start-fn-stubs': 1.162.0
-      '@tanstack/start-plugin-core': 1.171.18(@tanstack/react-router@1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.15))(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
-      '@tanstack/start-server-core': 1.169.15(crossws@0.4.5(srvx@0.11.15))
-      '@tanstack/start-storage-context': 1.167.15
+      '@tanstack/start-plugin-core': 1.171.36(@tanstack/react-router@1.170.29(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.15))(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.60.2)(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@tanstack/start-storage-context': 1.167.26
       pathe: 2.0.3
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     transitivePeerDependencies:
+      - '@farmfe/core'
       - '@rsbuild/core'
+      - bun-types-no-globals
       - crossws
+      - esbuild
+      - rolldown
+      - rollup
       - supports-color
+      - unloader
       - vite
       - vite-plugin-solid
       - webpack
 
-  '@tanstack/react-start-server@1.167.20(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@tanstack/react-start-server@1.167.34(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@tanstack/react-router': 1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/router-core': 1.171.13
-      '@tanstack/start-server-core': 1.169.15(crossws@0.4.5(srvx@0.11.15))
+      '@tanstack/react-router': 1.170.29(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/router-core': 1.171.24
+      '@tanstack/start-server-core': 1.169.28(crossws@0.4.5(srvx@0.11.15))
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.168.26(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tanstack/react-start@1.168.46(crossws@0.4.5(srvx@0.11.15))(esbuild@0.28.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rolldown@1.2.4)(rollup@4.60.2)(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@tanstack/react-router': 1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/react-start-client': 1.168.14(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/react-start-rsc': 0.1.25(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
-      '@tanstack/react-start-server': 1.167.20(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-router': 1.170.29(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-start-client': 1.168.27(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-start-rsc': 0.1.45(crossws@0.4.5(srvx@0.11.15))(esbuild@0.28.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rolldown@1.2.4)(rollup@4.60.2)(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@tanstack/react-start-server': 1.167.34(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/router-utils': 1.162.2
-      '@tanstack/start-client-core': 1.170.12
-      '@tanstack/start-plugin-core': 1.171.18(@tanstack/react-router@1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.15))(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
-      '@tanstack/start-server-core': 1.169.15(crossws@0.4.5(srvx@0.11.15))
+      '@tanstack/start-client-core': 1.170.24
+      '@tanstack/start-plugin-core': 1.171.36(@tanstack/react-router@1.170.29(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.15))(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.60.2)(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@tanstack/start-server-core': 1.169.28(crossws@0.4.5(srvx@0.11.15))
       pathe: 2.0.3
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
-      vite: 8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
+      - '@farmfe/core'
       - '@rspack/core'
+      - bun-types-no-globals
       - crossws
+      - esbuild
       - react-server-dom-rspack
+      - rolldown
+      - rollup
       - supports-color
+      - unloader
       - vite-plugin-solid
       - webpack
 
@@ -5582,16 +5697,16 @@ snapshots:
       seroval: 1.5.2
       seroval-plugins: 1.5.2(seroval@1.5.2)
 
-  '@tanstack/router-core@1.171.13':
+  '@tanstack/router-core@1.171.24':
     dependencies:
-      '@tanstack/history': 1.162.0
+      '@tanstack/history': 1.162.1
       cookie-es: 3.1.1
-      seroval: 1.5.4
-      seroval-plugins: 1.5.4(seroval@1.5.4)
+      seroval: 1.6.2
+      seroval-plugins: 1.6.2(seroval@1.6.2)
 
-  '@tanstack/router-devtools-core@1.167.3(@tanstack/router-core@1.171.13)(csstype@3.2.3)':
+  '@tanstack/router-devtools-core@1.167.3(@tanstack/router-core@1.171.24)(csstype@3.2.3)':
     dependencies:
-      '@tanstack/router-core': 1.171.13
+      '@tanstack/router-core': 1.171.24
       clsx: 2.1.1
       goober: 2.1.18(csstype@3.2.3)
     optionalDependencies:
@@ -5610,10 +5725,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-generator@1.167.17':
+  '@tanstack/router-generator@1.167.30':
     dependencies:
-      '@babel/types': 7.29.7
-      '@tanstack/router-core': 1.171.13
+      '@babel/types': 7.29.0
+      '@tanstack/router-core': 1.171.24
       '@tanstack/router-utils': 1.162.2
       '@tanstack/virtual-file-routes': 1.162.0
       jiti: 2.7.0
@@ -5623,7 +5738,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.167.22(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tanstack/router-plugin@1.167.22(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.7)
@@ -5640,31 +5755,38 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       '@tanstack/react-router': 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      vite: 8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.18(@tanstack/react-router@1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tanstack/router-plugin@1.168.32(@tanstack/react-router@1.170.29(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.60.2)(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
-      '@tanstack/router-core': 1.171.13
-      '@tanstack/router-generator': 1.167.17
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      '@tanstack/router-core': 1.171.24
+      '@tanstack/router-generator': 1.167.30
       '@tanstack/router-utils': 1.162.2
       chokidar: 5.0.0
-      unplugin: 3.0.0
+      unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.60.2)(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       zod: 4.4.3
     optionalDependencies:
-      '@tanstack/react-router': 1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      vite: 8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      '@tanstack/react-router': 1.170.29(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      vite: 8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
       - supports-color
+      - unloader
 
-  '@tanstack/router-ssr-query-core@1.167.1(@tanstack/query-core@5.99.0)(@tanstack/router-core@1.171.13)':
+  '@tanstack/router-ssr-query-core@1.167.1(@tanstack/query-core@5.99.0)(@tanstack/router-core@1.171.24)':
     dependencies:
       '@tanstack/query-core': 5.99.0
-      '@tanstack/router-core': 1.171.13
+      '@tanstack/router-core': 1.171.24
 
   '@tanstack/router-utils@1.161.6':
     dependencies:
@@ -5682,72 +5804,79 @@ snapshots:
 
   '@tanstack/router-utils@1.162.2':
     dependencies:
-      '@babel/generator': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       ansis: 4.2.0
       babel-dead-code-elimination: 1.0.12
       diff: 8.0.4
       pathe: 2.0.3
-      tinyglobby: 0.2.17
+      tinyglobby: 0.2.16
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/start-client-core@1.170.12':
+  '@tanstack/start-client-core@1.170.24':
     dependencies:
-      '@tanstack/router-core': 1.171.13
+      '@tanstack/router-core': 1.171.24
       '@tanstack/start-fn-stubs': 1.162.0
-      '@tanstack/start-storage-context': 1.167.15
-      seroval: 1.5.4
+      '@tanstack/start-storage-context': 1.167.26
+      seroval: 1.6.2
 
   '@tanstack/start-fn-stubs@1.162.0': {}
 
-  '@tanstack/start-plugin-core@1.171.18(@tanstack/react-router@1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.15))(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tanstack/start-plugin-core@1.171.36(@tanstack/react-router@1.170.29(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.15))(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.60.2)(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.7
-      '@babel/types': 7.29.7
-      '@tanstack/router-core': 1.171.13
-      '@tanstack/router-generator': 1.167.17
-      '@tanstack/router-plugin': 1.168.18(@tanstack/react-router@1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@babel/types': 7.29.0
+      '@tanstack/router-core': 1.171.24
+      '@tanstack/router-generator': 1.167.30
+      '@tanstack/router-plugin': 1.168.32(@tanstack/react-router@1.170.29(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.60.2)(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/router-utils': 1.162.2
-      '@tanstack/start-server-core': 1.169.15(crossws@0.4.5(srvx@0.11.15))
+      '@tanstack/start-server-core': 1.169.28(crossws@0.4.5(srvx@0.11.15))
       exsolve: 1.0.8
       lightningcss: 1.32.0
       pathe: 2.0.3
       picomatch: 4.0.4
-      seroval: 1.5.4
+      seroval: 1.6.2
       source-map: 0.7.6
       srvx: 0.11.15
-      tinyglobby: 0.2.17
+      tinyglobby: 0.2.16
       ufo: 1.6.3
-      vitefu: 1.1.3(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitefu: 1.1.3(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       xmlbuilder2: 4.0.3
       zod: 4.4.3
     optionalDependencies:
-      vite: 8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
       - '@tanstack/react-router'
+      - bun-types-no-globals
       - crossws
+      - esbuild
+      - rolldown
+      - rollup
       - supports-color
+      - unloader
       - vite-plugin-solid
       - webpack
 
-  '@tanstack/start-server-core@1.169.15(crossws@0.4.5(srvx@0.11.15))':
+  '@tanstack/start-server-core@1.169.28(crossws@0.4.5(srvx@0.11.15))':
     dependencies:
-      '@tanstack/history': 1.162.0
-      '@tanstack/router-core': 1.171.13
-      '@tanstack/start-client-core': 1.170.12
-      '@tanstack/start-storage-context': 1.167.15
+      '@tanstack/history': 1.162.1
+      '@tanstack/router-core': 1.171.24
+      '@tanstack/start-client-core': 1.170.24
+      '@tanstack/start-storage-context': 1.167.26
       fetchdts: 0.1.7
       h3-v2: h3@2.0.1-rc.20(crossws@0.4.5(srvx@0.11.15))
-      seroval: 1.5.4
+      seroval: 1.6.2
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/start-storage-context@1.167.15':
+  '@tanstack/start-storage-context@1.167.26':
     dependencies:
-      '@tanstack/router-core': 1.171.13
+      '@tanstack/router-core': 1.171.24
 
   '@tanstack/store@0.9.3': {}
 
@@ -5992,60 +6121,60 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.1(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/expect@3.2.6':
+  '@vitest/expect@3.2.7':
     dependencies:
       '@types/chai': 5.2.3
-      '@vitest/spy': 3.2.6
-      '@vitest/utils': 3.2.6
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.6(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(vite@7.3.5(@types/node@20.19.39)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.7(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(vite@7.3.6(@types/node@20.19.39)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@vitest/spy': 3.2.6
+      '@vitest/spy': 3.2.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.13.4(@types/node@20.19.39)(typescript@5.9.3)
-      vite: 7.3.5(@types/node@20.19.39)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.6(@types/node@20.19.39)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/mocker@3.2.6(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(vite@7.3.5(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.7(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(vite@7.3.6(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@vitest/spy': 3.2.6
+      '@vitest/spy': 3.2.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.13.4(@types/node@22.19.17)(typescript@5.9.3)
-      vite: 7.3.5(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.6(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/pretty-format@3.2.6':
+  '@vitest/pretty-format@3.2.7':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/runner@3.2.6':
+  '@vitest/runner@3.2.7':
     dependencies:
-      '@vitest/utils': 3.2.6
+      '@vitest/utils': 3.2.7
       pathe: 2.0.3
       strip-literal: 3.1.0
 
-  '@vitest/snapshot@3.2.6':
+  '@vitest/snapshot@3.2.7':
     dependencies:
-      '@vitest/pretty-format': 3.2.6
+      '@vitest/pretty-format': 3.2.7
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@3.2.6':
+  '@vitest/spy@3.2.7':
     dependencies:
       tinyspy: 4.0.4
 
-  '@vitest/utils@3.2.6':
+  '@vitest/utils@3.2.7':
     dependencies:
-      '@vitest/pretty-format': 3.2.6
+      '@vitest/pretty-format': 3.2.7
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
@@ -6076,7 +6205,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6148,13 +6277,13 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.2
+      qs: 6.15.3
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6218,7 +6347,7 @@ snapshots:
 
   chokidar@5.0.0:
     dependencies:
-      readdirp: 5.0.0
+      readdirp: 5.1.1
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -6286,7 +6415,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -6321,10 +6450,10 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
-  data-urls@7.0.0(@noble/hashes@1.8.0):
+  data-urls@7.0.0(@noble/hashes@2.2.0):
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -6426,34 +6555,34 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
-  esbuild@0.28.1:
+  esbuild@0.28.2:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.28.1
-      '@esbuild/android-arm': 0.28.1
-      '@esbuild/android-arm64': 0.28.1
-      '@esbuild/android-x64': 0.28.1
-      '@esbuild/darwin-arm64': 0.28.1
-      '@esbuild/darwin-x64': 0.28.1
-      '@esbuild/freebsd-arm64': 0.28.1
-      '@esbuild/freebsd-x64': 0.28.1
-      '@esbuild/linux-arm': 0.28.1
-      '@esbuild/linux-arm64': 0.28.1
-      '@esbuild/linux-ia32': 0.28.1
-      '@esbuild/linux-loong64': 0.28.1
-      '@esbuild/linux-mips64el': 0.28.1
-      '@esbuild/linux-ppc64': 0.28.1
-      '@esbuild/linux-riscv64': 0.28.1
-      '@esbuild/linux-s390x': 0.28.1
-      '@esbuild/linux-x64': 0.28.1
-      '@esbuild/netbsd-arm64': 0.28.1
-      '@esbuild/netbsd-x64': 0.28.1
-      '@esbuild/openbsd-arm64': 0.28.1
-      '@esbuild/openbsd-x64': 0.28.1
-      '@esbuild/openharmony-arm64': 0.28.1
-      '@esbuild/sunos-x64': 0.28.1
-      '@esbuild/win32-arm64': 0.28.1
-      '@esbuild/win32-ia32': 0.28.1
-      '@esbuild/win32-x64': 0.28.1
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
 
   escalade@3.2.0: {}
 
@@ -6604,7 +6733,7 @@ snapshots:
   express-rate-limit@8.3.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.2.0
+      ip-address: 10.5.0
 
   express@5.2.1:
     dependencies:
@@ -6628,7 +6757,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.2
+      qs: 6.15.3
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -6661,7 +6790,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -6674,6 +6803,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
 
   fetch-blob@3.2.0:
     dependencies:
@@ -6811,13 +6944,13 @@ snapshots:
       '@types/set-cookie-parser': 2.4.10
       set-cookie-parser: 3.1.0
 
-  hono@4.12.26: {}
+  hono@4.13.2: {}
 
   hookable@6.1.1: {}
 
-  html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
     dependencies:
-      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -6868,7 +7001,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip-address@10.2.0: {}
+  ip-address@10.5.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -6942,20 +7075,20 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@28.1.0(@noble/hashes@1.8.0):
+  jsdom@28.1.0(@noble/hashes@2.2.0):
     dependencies:
       '@acemir/cssom': 0.9.31
       '@asamuzakjp/dom-selector': 6.8.1
       '@bramus/specificity': 2.4.2
-      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
       cssstyle: 6.2.0
-      data-urls: 7.0.0(@noble/hashes@1.8.0)
+      data-urls: 7.0.0(@noble/hashes@2.2.0)
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
@@ -6963,11 +7096,11 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.28.0
+      undici: 7.25.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -7006,7 +7139,7 @@ snapshots:
   launch-editor@2.14.1:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.4
+      shell-quote: 1.10.0
 
   levn@0.4.1:
     dependencies:
@@ -7016,34 +7149,67 @@ snapshots:
   lightningcss-android-arm64@1.32.0:
     optional: true
 
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
     optional: true
 
   lightningcss-darwin-x64@1.32.0:
     optional: true
 
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.32.0:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.32.0:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.32.0:
     optional: true
 
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.32.0:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
     optional: true
 
   lightningcss@1.32.0:
@@ -7061,6 +7227,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
 
   lines-and-columns@1.2.4: {}
 
@@ -7146,7 +7328,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -7207,7 +7389,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -7217,7 +7399,7 @@ snapshots:
 
   nf3@0.3.16: {}
 
-  nitro@3.0.260415-beta(chokidar@5.0.0)(dotenv@17.4.2)(jiti@2.7.0)(lru-cache@11.3.5)(rollup@4.60.2)(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)):
+  nitro@3.0.260415-beta(chokidar@5.0.0)(dotenv@17.4.2)(jiti@2.7.0)(lru-cache@11.3.5)(rollup@4.60.2)(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.5(srvx@0.11.15)
@@ -7237,7 +7419,7 @@ snapshots:
       dotenv: 17.4.2
       jiti: 2.7.0
       rollup: 4.60.2
-      vite: 8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -7350,6 +7532,10 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
+  otpauth@9.5.1:
+    dependencies:
+      '@noble/hashes': 2.2.0
+
   outvariant@1.4.3: {}
 
   p-limit@3.1.0:
@@ -7401,6 +7587,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  picomatch@4.0.5: {}
+
   pkce-challenge@5.0.1: {}
 
   postcss-selector-parser@6.0.10:
@@ -7419,9 +7607,9 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.15:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -7467,9 +7655,10 @@ snapshots:
 
   pvutils@1.1.5: {}
 
-  qs@6.15.2:
+  qs@6.15.3:
     dependencies:
-      side-channel: 1.1.0
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   queue-microtask@1.2.3: {}
 
@@ -7495,7 +7684,7 @@ snapshots:
     dependencies:
       picomatch: 2.3.2
 
-  readdirp@5.0.0: {}
+  readdirp@5.1.1: {}
 
   recast@0.23.11:
     dependencies:
@@ -7551,26 +7740,25 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.16
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.16
 
-  rolldown@1.0.3:
+  rolldown@1.2.4:
     dependencies:
-      '@oxc-project/types': 0.133.0
+      '@oxc-project/types': 0.144.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.3
-      '@rolldown/binding-darwin-arm64': 1.0.3
-      '@rolldown/binding-darwin-x64': 1.0.3
-      '@rolldown/binding-freebsd-x64': 1.0.3
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
-      '@rolldown/binding-linux-arm64-gnu': 1.0.3
-      '@rolldown/binding-linux-arm64-musl': 1.0.3
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
-      '@rolldown/binding-linux-s390x-gnu': 1.0.3
-      '@rolldown/binding-linux-x64-gnu': 1.0.3
-      '@rolldown/binding-linux-x64-musl': 1.0.3
-      '@rolldown/binding-openharmony-arm64': 1.0.3
-      '@rolldown/binding-wasm32-wasi': 1.0.3
-      '@rolldown/binding-win32-arm64-msvc': 1.0.3
-      '@rolldown/binding-win32-x64-msvc': 1.0.3
+      '@rolldown/binding-android-arm64': 1.2.4
+      '@rolldown/binding-darwin-arm64': 1.2.4
+      '@rolldown/binding-darwin-x64': 1.2.4
+      '@rolldown/binding-freebsd-x64': 1.2.4
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.4
+      '@rolldown/binding-linux-arm64-gnu': 1.2.4
+      '@rolldown/binding-linux-arm64-musl': 1.2.4
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.4
+      '@rolldown/binding-linux-s390x-gnu': 1.2.4
+      '@rolldown/binding-linux-x64-gnu': 1.2.4
+      '@rolldown/binding-linux-x64-musl': 1.2.4
+      '@rolldown/binding-openharmony-arm64': 1.2.4
+      '@rolldown/binding-win32-arm64-msvc': 1.2.4
+      '@rolldown/binding-win32-x64-msvc': 1.2.4
 
   rollup@4.60.2:
     dependencies:
@@ -7653,13 +7841,13 @@ snapshots:
     dependencies:
       seroval: 1.5.2
 
-  seroval-plugins@1.5.4(seroval@1.5.4):
+  seroval-plugins@1.6.2(seroval@1.6.2):
     dependencies:
-      seroval: 1.5.4
+      seroval: 1.6.2
 
   seroval@1.5.2: {}
 
-  seroval@1.5.4: {}
+  seroval@1.6.2: {}
 
   serve-static@2.2.1:
     dependencies:
@@ -7723,7 +7911,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.4: {}
+  shell-quote@1.10.0: {}
 
   side-channel-list@1.0.1:
     dependencies:
@@ -7745,7 +7933,7 @@ snapshots:
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
 
-  side-channel@1.1.0:
+  side-channel@1.1.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -7774,8 +7962,8 @@ snapshots:
   solid-js@1.9.12:
     dependencies:
       csstype: 3.2.3
-      seroval: 1.5.4
-      seroval-plugins: 1.5.4(seroval@1.5.4)
+      seroval: 1.5.2
+      seroval-plugins: 1.5.2(seroval@1.5.2)
 
   source-map-js@1.2.1: {}
 
@@ -7865,8 +8053,8 @@ snapshots:
 
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinypool@1.1.1: {}
 
@@ -7915,7 +8103,7 @@ snapshots:
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.28.1
+      esbuild: 0.28.2
       get-tsconfig: 4.14.0
     optionalDependencies:
       fsevents: 2.3.3
@@ -7957,7 +8145,9 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.28.0: {}
+  undici@7.25.0: {}
+
+  undici@7.29.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
@@ -7976,11 +8166,16 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  unplugin@3.0.0:
+  unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.60.2)(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      esbuild: 0.28.2
+      rolldown: 1.2.4
+      rollup: 4.60.2
+      vite: 8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
 
   unrs-resolver@1.11.1:
     dependencies:
@@ -8035,13 +8230,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@3.2.4(@types/node@20.19.39)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
+  vite-node@3.2.4(@types/node@20.19.39)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.5(@types/node@20.19.39)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.6(@types/node@20.19.39)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -8056,13 +8251,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
+  vite-node@3.2.4(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.5(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.6(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -8077,9 +8272,9 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.5(@types/node@20.19.39)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
+  vite@7.3.6(@types/node@20.19.39)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
-      esbuild: 0.28.1
+      esbuild: 0.28.2
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.10
@@ -8089,13 +8284,13 @@ snapshots:
       '@types/node': 20.19.39
       fsevents: 2.3.3
       jiti: 2.7.0
-      lightningcss: 1.32.0
+      lightningcss: 1.33.0
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vite@7.3.5(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
+  vite@7.3.6(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
-      esbuild: 0.28.1
+      esbuild: 0.28.2
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.10
@@ -8105,39 +8300,39 @@ snapshots:
       '@types/node': 22.19.17
       fsevents: 2.3.3
       jiti: 2.7.0
-      lightningcss: 1.32.0
+      lightningcss: 1.33.0
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3):
+  vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.0.3
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.2.4
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.19.17
-      esbuild: 0.28.1
+      esbuild: 0.28.2
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitefu@1.1.3(vite@8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vitefu@1.1.3(vite@8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
-      vite: 8.0.16(@types/node@22.19.17)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@22.19.17)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  vitest@3.2.6(@types/node@20.19.39)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3):
+  vitest@3.2.7(@types/node@20.19.39)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.33.0)(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.6
-      '@vitest/mocker': 3.2.6(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(vite@7.3.5(@types/node@20.19.39)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 3.2.6
-      '@vitest/runner': 3.2.6
-      '@vitest/snapshot': 3.2.6
-      '@vitest/spy': 3.2.6
-      '@vitest/utils': 3.2.6
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(msw@2.13.4(@types/node@20.19.39)(typescript@5.9.3))(vite@7.3.6(@types/node@20.19.39)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
       chai: 5.3.3
       debug: 4.4.3
       expect-type: 1.3.0
@@ -8150,12 +8345,12 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.5(@types/node@20.19.39)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@20.19.39)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.6(@types/node@20.19.39)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@20.19.39)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.39
-      jsdom: 28.1.0(@noble/hashes@1.8.0)
+      jsdom: 28.1.0(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -8170,16 +8365,16 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.6(@types/node@22.19.17)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3):
+  vitest@3.2.7(@types/node@22.19.17)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.33.0)(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.6
-      '@vitest/mocker': 3.2.6(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(vite@7.3.5(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 3.2.6
-      '@vitest/runner': 3.2.6
-      '@vitest/snapshot': 3.2.6
-      '@vitest/spy': 3.2.6
-      '@vitest/utils': 3.2.6
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(vite@7.3.6(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
       chai: 5.3.3
       debug: 4.4.3
       expect-type: 1.3.0
@@ -8192,12 +8387,12 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.5(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.6(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
-      jsdom: 28.1.0(@noble/hashes@1.8.0)
+      jsdom: 28.1.0(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -8224,9 +8419,9 @@ snapshots:
 
   whatwg-mimetype@5.0.0: {}
 
-  whatwg-url@16.0.1(@noble/hashes@1.8.0):
+  whatwg-url@16.0.1(@noble/hashes@2.2.0):
     dependencies:
-      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
@@ -8261,7 +8456,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.21.0: {}
+  ws@8.21.3: {}
 
   wsl-utils@0.3.1:
     dependencies:
@@ -8275,7 +8470,7 @@ snapshots:
       '@oozcitak/dom': 2.0.2
       '@oozcitak/infra': 2.0.2
       '@oozcitak/util': 10.0.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
 
   xmlchars@2.2.0: {}
 


### PR DESCRIPTION
## Summary

Adds a new `sig idp` command family and a Node-side TOTP autofill mechanism that types the 6-digit code into IdP 2FA pages during the browser login flow. Solves the annoyance of "sig launches the browser, walks the login, then stops at the 2FA prompt waiting for me to type six digits".

Secrets stay encrypted at rest (AES-256-GCM) and never enter the page context — only the computed 6-digit code is injected via CDP `Runtime.evaluate`.

## Usage

```bash
sig idp add <hostname> --totp-secret <base32> [--no-auto-submit] [--label <name>]
sig idp list
sig idp show <hostname>       # secret always redacted
sig idp remove <hostname>
```

Config shape (`~/.sig/config.yaml`; secret stored separately, encrypted, at `~/.sig/idps/<host>.json`):

```yaml
idps:
  idp.example.com:
    label: example
    totp: { autoSubmit: true }
```

## Design

- **IdP is a first-class concept**, indexed by hostname. A single IdP fronts many providers, so the secret is stored once per IdP, not per provider.
- **Strict suffix match** in `hostnameMatches`: `evil-github.com` does NOT match `github.com`. Longest-suffix wins in `IdpRegistry.resolve` (e.g. `idp.example.com` beats `example.com`).
- **Secret containment**: computed on the Node side via `otpauth`, injected as a literal string constant into the page-side IIFE. Secret never enters the browser.
- **Encryption at rest**: reuses the existing AES-256-GCM key at `~/.sig/encryption.key`. `~/.sig/config.yaml` holds metadata only; validator rejects any `secret`/`totpSecret`/`totp.secret` field (case-insensitive) so secrets cannot be smuggled into YAML.
- **Page-side script** uses the React-safe native `value` setter (`Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set`), then dispatches `input` and `change` events. `autoSubmit: true` (default) calls `form.requestSubmit()`. Selector list covers the common OTP input shapes (`#j_otpcode`, `input[name=otp|code|passcode]`, `input[autocomplete=one-time-code]`, `input[type=tel][maxlength=6]`, `input[inputmode=numeric]`).
- **Hook placement** in `BrowserStrategy.pollUntilValid`: intentionally placed BEFORE the `isOffDomain` check. IdP pages on a different hostname than the entry URL would otherwise be `continue`-d over. Found in real-world testing — a fix hidden until a live 2FA challenge triggered.

## Non-goals (deliberately)

- No `Page.addScriptToEvaluateOnNewDocument`. `Runtime.evaluate` per poll is sufficient and keeps the secret in Node.
- No exposure of TOTP `digits` / `period` / `algorithm` at the CLI. Every real IdP is SHA1/6/30.
- No dedupe of "already filled" — 3s poll + idempotent fill is fine.
- No sync of IdP secrets to remotes (future work).

## Backwards compatibility

- `config.yaml` without an `idps:` section → validator ignores it, `AuthManager` builds an empty registry, `BrowserStrategy` sees `this.idps?.resolve(...) === null` and behaves exactly as before. Existing tests that construct `BrowserStrategy` with 3 args continue to work (new `idps?` param is optional).
- No changes to on-disk `~/.sig/credentials/` layout or the `~/.sig/browser-data/` profile.

## Testing

**562 tests total (11 new tests + all existing).** New coverage:

- **`utils/totp.test.ts`** — RFC 6238 Appendix B known-answer vectors at 5 timestamps (via `vi.useFakeTimers`).
- **`idps/hostname-match.test.ts`** — including the security case `evil-example.com` vs `example.com` → false; case-insensitivity; label-boundary enforcement.
- **`idps/idp-registry.test.ts`** — longest-suffix win (`idp.example.com` beats `example.com`).
- **`idps/idp-store.test.ts`** — encrypted-at-rest round-trip; path-traversal defense against hostnames like `../etc/passwd`.
- **`idps/idp-config.test.ts`** — YAML comment preservation; validator rejects `secret` / `totpSecret` / `totp.secret` at three levels including case-insensitive misspellings (`Secret`, `TOTPSECRET`).
- **`strategies/totp-injector.test.ts`** — `buildFillScript` output evaluated in a hand-rolled DOM shim (no jsdom dep): React-safe setter, selector fallback, `autoSubmit` on/off, no-input, hidden-input, no-form, safe scalar injection under a malicious-looking `code`.
- **`commands/idp.test.ts`** — `sig idp add/list/show/remove` command flow; secret never appears in `list` or `show` output.
- **`auth-manager.test.ts`** — empty-idps wiring (`config.idps` undefined → empty registry, `resolve` returns null).
- **`strategies/browser-idp-totp-order.test.ts`** — regression test that `injectTotpFill` fires on off-domain IdP URLs (this test would have caught the ordering bug had we written it before hitting it in the field).

Manual end-to-end verification: full `sig login` flow through a real IdP redirect chain, with the TOTP hook confirmed to fire on the (off-domain) IdP hostname.

## Dependency

- Added `otpauth@^9.5.1` (RFC 6238, zero-dep, ESM, MIT).

## Follow-ups (out of scope for this PR)

- `sig idp show` currently emits `"secret": "<redacted>"` — could drop the key entirely.
- `AuthManager.create` eagerly decrypts all IdP secrets on startup; a lazy-load pass would help users with many IdPs.
- `sig login --fresh` / `--force-reauth` — clear target-domain browser cookies before login, to reliably reach 2FA challenges when the IdP session is still trusted.