### PR TITLE
feat(idp): add import subcommand for bulk-importing from otpauth URI file

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,15 @@ sig idp show idp.example.com
 sig idp remove idp.example.com
 ```
 
+If you have many accounts, export them from your authenticator app and bulk-import:
+
+```bash
+sig idp import ~/Downloads/authenticator.txt        # one otpauth://totp/ URI per line
+sig idp import ~/Downloads/authenticator.txt --force # overwrite existing entries
+```
+
+The file format is one `otpauth://totp/` URI per line (the standard export format from Google Authenticator and most other TOTP apps). The hostname is derived from the `issuer` parameter, falling back to the label prefix before `:`. Blank lines and lines not starting with `otpauth://totp/` are skipped.
+
 ### Custom selectors (when defaults don't fit)
 
 sig's built-in list covers common OTP inputs (`#otp`, `input[name=code|passcode|otp]`, `input[autocomplete=one-time-code]`, `input[type=tel][maxlength=6]`, `input[inputmode=numeric]`). If your IdP page uses different markup — or the defaults match the wrong element (e.g. a phone-number field on the same host) — override on a per-IdP basis by hand-editing `~/.sig/config.yaml`:

--- a/cli/src/cli-router.ts
+++ b/cli/src/cli-router.ts
@@ -147,6 +147,8 @@ Identity providers (2FA/MFA auto-fill during login):
     --format json|table          Output format
   idp show <hostname>          Show a single IdP entry (secret redacted)
   idp remove <hostname>        Remove an IdP entry (metadata + secret)
+  idp import <file>            Bulk-import from otpauth URI file (one per line)
+    --force                      Overwrite existing entries
   Custom OTP form selectors: edit idps.<host>.totp.selectors in ~/.sig/config.yaml
 
 Setup:

--- a/cli/src/commands/idp.ts
+++ b/cli/src/commands/idp.ts
@@ -12,6 +12,7 @@
  */
 
 import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -34,6 +35,8 @@ Subcommands:
   list [--format json|table]       List configured IdPs (secrets redacted)
   show <hostname>                  Show a single IdP entry (secret redacted)
   remove <hostname>                Remove an IdP entry (metadata + secret)
+  import <file>                    Bulk-import from otpauth URI file (one per line)
+    --force                          Overwrite existing entries
 
 Custom OTP form selectors are configured by hand-editing ~/.sig/config.yaml
 under idps.<hostname>.totp.selectors.{input,submit}.
@@ -79,6 +82,8 @@ export async function runIdp(
             return runShow(positionals);
         case IdpSubcommand.REMOVE:
             return runRemove(positionals);
+        case IdpSubcommand.IMPORT:
+            return runImport(positionals, flags);
         default:
             process.stderr.write(USAGE);
             process.exitCode = ExitCode.GENERAL_ERROR;
@@ -229,4 +234,104 @@ async function runRemove(positionals: string[]): Promise<void> {
     } else {
         process.stderr.write(`IdP "${hostname}" not found in config\n`);
     }
+}
+
+async function runImport(
+    positionals: string[],
+    flags: Record<string, string | boolean | string[]>,
+): Promise<void> {
+    const filePath = positionals[1];
+    if (!filePath) {
+        process.stderr.write('Usage: sig idp import <file> [--force]\n');
+        process.exitCode = ExitCode.GENERAL_ERROR;
+        return;
+    }
+    if (!requireConfig()) return;
+
+    const force = flags['force'] === true;
+
+    let raw: string;
+    try {
+        raw = await fsPromises.readFile(filePath, 'utf-8');
+    } catch (e) {
+        process.stderr.write(`Error reading file: ${(e as Error).message}\n`);
+        process.exitCode = ExitCode.GENERAL_ERROR;
+        return;
+    }
+
+    const store = await asyncIdpStore();
+    const lines = raw
+        .split('\n')
+        .map((l) => l.trim())
+        .filter((l) => l.startsWith('otpauth://totp/'));
+
+    if (lines.length === 0) {
+        process.stderr.write('No otpauth://totp/ URIs found in file.\n');
+        return;
+    }
+
+    let added = 0;
+    let skipped = 0;
+    let failed = 0;
+
+    for (const line of lines) {
+        let url: URL;
+        try {
+            url = new URL(line);
+        } catch {
+            process.stderr.write(`  SKIP (invalid URI): ${line}\n`);
+            failed++;
+            continue;
+        }
+
+        const secret = url.searchParams.get('secret');
+        if (!secret) {
+            process.stderr.write(`  SKIP (no secret): ${line}\n`);
+            failed++;
+            continue;
+        }
+
+        const normalized = secret.replace(/\s+/g, '').toUpperCase();
+        if (!isValidBase32(normalized)) {
+            process.stderr.write(`  SKIP (invalid base32 secret): ${line}\n`);
+            failed++;
+            continue;
+        }
+
+        // Derive hostname: prefer issuer param, fall back to label prefix before ':'
+        const issuer = url.searchParams.get('issuer') ?? '';
+        const label = decodeURIComponent(url.pathname.slice(1)); // strip leading '/'
+        const hostname = (issuer || label.split(':')[0] || label)
+            .trim()
+            .toLowerCase()
+            .replace(/\s+/g, '-');
+
+        if (!hostname) {
+            process.stderr.write(`  SKIP (cannot derive hostname): ${line}\n`);
+            failed++;
+            continue;
+        }
+
+        const existingMeta = (await getIdpMetaEntries())[hostname];
+        if (existingMeta && !force) {
+            process.stderr.write(`  SKIP (exists): ${hostname}\n`);
+            skipped++;
+            continue;
+        }
+
+        const labelText = label || issuer || undefined;
+        const meta: IdpMetaEntry = {
+            ...(labelText !== undefined ? { label: labelText } : {}),
+            totp: {},
+        };
+
+        await setIdpMetaEntry(hostname, meta);
+        await store.setSecret(hostname, normalized);
+        process.stderr.write(`  ADDED: ${hostname}${labelText ? ` (${labelText})` : ''}\n`);
+        added++;
+    }
+
+    process.stderr.write(
+        `\nImport complete: ${added} added, ${skipped} skipped, ${failed} failed\n`,
+    );
 }

--- a/cli/src/types/constants.ts
+++ b/cli/src/types/constants.ts
@@ -76,6 +76,7 @@ export const IdpSubcommand = {
     LIST: 'list',
     SHOW: 'show',
     REMOVE: 'remove',
+    IMPORT: 'import',
 } as const;
 
 /**

--- a/cli/tests/unit/commands/idp.test.ts
+++ b/cli/tests/unit/commands/idp.test.ts
@@ -323,7 +323,7 @@ describe('sig idp', () => {
                 importFile,
                 [
                     'otpauth://totp/GitHub:alice?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&issuer=GitHub',
-                    'otpauth://totp/accounts.sap.com:user?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&issuer=accounts.sap.com',
+                    'otpauth://totp/corp-idp.example.com:user?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&issuer=corp-idp.example.com',
                 ].join('\n'),
                 'utf-8',
             );
@@ -332,7 +332,7 @@ describe('sig idp', () => {
 
             const stderr = stderrChunks.join('');
             expect(stderr).toContain('ADDED: github');
-            expect(stderr).toContain('ADDED: accounts.sap.com');
+            expect(stderr).toContain('ADDED: corp-idp.example.com');
             expect(stderr).toContain('2 added');
             expect(stderr).toContain('0 skipped');
 

--- a/cli/tests/unit/commands/idp.test.ts
+++ b/cli/tests/unit/commands/idp.test.ts
@@ -306,4 +306,124 @@ describe('sig idp', () => {
             expect(stderr).toContain('not found in config');
         });
     });
+
+    // -----------------------------------------------------------------------
+    // import
+    // -----------------------------------------------------------------------
+
+    describe('import', () => {
+        let importFile: string;
+
+        beforeEach(async () => {
+            importFile = path.join(tmpHome, 'authenticator.txt');
+        });
+
+        it('imports valid otpauth URIs from a file', async () => {
+            await fs.writeFile(
+                importFile,
+                [
+                    'otpauth://totp/GitHub:alice?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&issuer=GitHub',
+                    'otpauth://totp/accounts.sap.com:user?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&issuer=accounts.sap.com',
+                ].join('\n'),
+                'utf-8',
+            );
+
+            await runIdp(['import', importFile], {});
+
+            const stderr = stderrChunks.join('');
+            expect(stderr).toContain('ADDED: github');
+            expect(stderr).toContain('ADDED: accounts.sap.com');
+            expect(stderr).toContain('2 added');
+            expect(stderr).toContain('0 skipped');
+
+            // Secrets must not appear in YAML
+            expect(currentYaml.includes('GEZDGNBVGY3TQOJQ')).toBe(false);
+
+            // Encrypted files must exist
+            const gitHubFile = path.join(tmpHome, '.sig', 'idps', 'github.json');
+            await expect(fs.access(gitHubFile)).resolves.toBeUndefined();
+        });
+
+        it('skips duplicate entries without --force', async () => {
+            await fs.writeFile(
+                importFile,
+                'otpauth://totp/GitHub:alice?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&issuer=GitHub',
+                'utf-8',
+            );
+
+            await runIdp(['import', importFile], {});
+            stderrChunks.length = 0;
+            await runIdp(['import', importFile], {});
+
+            const stderr = stderrChunks.join('');
+            expect(stderr).toContain('SKIP (exists): github');
+            expect(stderr).toContain('0 added');
+            expect(stderr).toContain('1 skipped');
+        });
+
+        it('overwrites duplicates with --force', async () => {
+            await fs.writeFile(
+                importFile,
+                'otpauth://totp/GitHub:alice?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&issuer=GitHub',
+                'utf-8',
+            );
+
+            await runIdp(['import', importFile], {});
+            stderrChunks.length = 0;
+            await runIdp(['import', importFile], { force: true });
+
+            const stderr = stderrChunks.join('');
+            expect(stderr).toContain('ADDED: github');
+            expect(stderr).toContain('1 added');
+            expect(stderr).toContain('0 skipped');
+        });
+
+        it('skips blank lines and non-otpauth lines', async () => {
+            await fs.writeFile(
+                importFile,
+                [
+                    '',
+                    '# this is a comment',
+                    'not-a-uri',
+                    'otpauth://totp/GitHub:alice?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&issuer=GitHub',
+                ].join('\n'),
+                'utf-8',
+            );
+
+            await runIdp(['import', importFile], {});
+
+            const stderr = stderrChunks.join('');
+            expect(stderr).toContain('1 added');
+        });
+
+        it('counts invalid URIs as failed', async () => {
+            await fs.writeFile(
+                importFile,
+                'otpauth://totp/GitHub:alice?secret=TOOSHORT&issuer=GitHub',
+                'utf-8',
+            );
+
+            await runIdp(['import', importFile], {});
+
+            const stderr = stderrChunks.join('');
+            expect(stderr).toContain('0 added');
+            expect(stderr).toContain('1 failed');
+        });
+
+        it('errors when file path is missing', async () => {
+            await runIdp(['import'], {});
+            expect(process.exitCode).not.toBe(undefined);
+            expect(process.exitCode).not.toBe(0);
+            const stderr = stderrChunks.join('');
+            expect(stderr).toContain('sig idp import');
+        });
+
+        it('errors when file does not exist', async () => {
+            await runIdp(['import', '/nonexistent/path/file.txt'], {});
+            expect(process.exitCode).not.toBe(undefined);
+            expect(process.exitCode).not.toBe(0);
+            const stderr = stderrChunks.join('');
+            expect(stderr).toContain('Error reading file');
+        });
+    });
 });


### PR DESCRIPTION
## Summary

- Adds `sig idp import <file>` subcommand to bulk-import TOTP secrets from a file of `otpauth://totp/` URIs (standard Google Authenticator export format)
- Hostname is derived from the `issuer` param, falling back to the label prefix before `:`
- Secrets are validated (base32, ≥16 chars) and stored encrypted at `~/.sig/idps/`
- Existing entries are silently skipped unless `--force` is passed
- Reports added/skipped/failed counts on completion

## Test plan

- [x] `sig idp import <file>` imports all valid URIs from the file
- [x] Duplicate entries are skipped without `--force`
- [x] Duplicate entries are overwritten with `--force`
- [x] Invalid/short secrets are reported as failed, not imported
- [x] Blank lines and non-otpauth lines are silently skipped
- [x] Missing file path or unreadable file exits with a clear error
- [x] 21 unit tests pass (`vitest run tests/unit/commands/idp.test.ts`)